### PR TITLE
Also build the PDF version as part of the continuous integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-sudo: false
 language: python
 python:
   - "3.6"
-install: pip install -r requirements.txt
+install:
+  - sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk
+  - pip install -r requirements.txt
 script:
   - make doctest
   - make html
+  - make latexpdf


### PR DESCRIPTION
This causes the tests to run for much longer (big Latex toolchain download), but still <5min -- I think it is worth it.