### PR TITLE
add front page info on alpha stage, fixes #57

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,4 +14,15 @@ The DataLad Handbook
       :alt: Virtual directory tree of a nested DataLad dataset
 
 
+.. important::
+
+   **Welcome to the DataLad handbook!**
+
+   We are happy about and greatly appreciate your interest in the handbook.
+   Currently, the handbook is under initial development. You are welcome
+   to check out the existing content, but please consider the handbook to be in alpha
+   stage -- expect thourough changes and developments in all aspects of the book until further notice.
+   If you would be willing to provide feedback on this, or a future beta version, please
+   `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
+
 .. include:: contents.rst.inc


### PR DESCRIPTION
simple ``important`` directive to inform accidental visitors about the state of things on the frontpage (see #57).