### PR TITLE
add bottom page section links as well, fixes #61

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,8 @@ html_theme_options = {
     'note_bg': '#e2eacdff',
     # the real "DataLad dark gray"
     'note_border': '#333333ff',
-    'fixed_sidebar': True
+    'fixed_sidebar': True,
+    'show_relbar_bottom': True,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
With the updated feedback after #62 noted in #61, this also adds links to the previous and next section at the bottom of the page.