### PR TITLE
dl st --annex basic -> dl st --annex, fixes #74

### DIFF
--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -183,7 +183,7 @@ For this, we supply an additional option to ``datalad status``. Make sure to be
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
 
-   $ datalad status --annex basic
+   $ datalad status --annex
 
 Woah! More than 200 files, totalling more than 15 GB?
 You begin to appreciate that DataLad did not

--- a/docs/basics/101-107-summary.rst
+++ b/docs/basics/101-107-summary.rst
@@ -24,7 +24,7 @@ and experienced the concept of modularly nesting datasets.
   To retrieve actual file content of larger files, ``datalad get PATH`` downloads large file
   content on demand.
 
-* ``datalad status --annex basic`` or ``datalad status --annex all`` are helpful to determine
+* ``datalad status --annex`` or ``datalad status --annex all`` are helpful to determine
   total repository size and the amount of data that is present locally.
 
 * Remember: Super- and subdatasets have standalone histories. A superdataset only stores

--- a/docs/basics/_examples/DL-101-105-106
+++ b/docs/basics/_examples/DL-101-105-106
@@ -1,2 +1,2 @@
-$ datalad status --annex basic
+$ datalad status --annex
 236 annex'd files (15.4 GB recorded total size)


### PR DESCRIPTION
Getting rid of all ``datalad status --annex basic`` in response to #74.