### PR TITLE
shell-agnostic pipe

### DIFF
--- a/docs/basics/101-109-rerun.rst
+++ b/docs/basics/101-109-rerun.rst
@@ -34,7 +34,7 @@ with the following, fixed script:
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 2
 
-   $ cat << EOT > code/list_titles.sh
+   $ cat << EOT >| code/list_titles.sh
    for i in recordings/longnow/Long_Now*/*.mp3; do
       # get the filename
       base=\$(basename "\$i");

--- a/docs/basics/_examples/DL-101-108-110
+++ b/docs/basics/_examples/DL-101-108-110
@@ -1,4 +1,4 @@
-$ cat << EOT > code/list_titles.sh
+$ cat << EOT >| code/list_titles.sh
 for i in recordings/longnow/Long_Now*/*.mp3; do
    # get the filename
    base=\$(basename "\$i");


### PR DESCRIPTION
use ``>| `` instead of ``>`` to overwrite existing files.Thanks to Alex for this advice!