### PR TITLE
Revert "Readthedocs build crashes (due to missing section number?)"

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -23,7 +23,7 @@ concepts of DataLad datasets together by creating one.
 .. index:: ! datalad command; create
 
 Find a nice place on your computers file system to put a dataset for ``DataLad-101``,
-and create a fresh, empty dataset with the :command:`datalad create` command (:manpage:`datalad-create(1)` manual).
+and create a fresh, empty dataset with the :command:`datalad create` command (:manpage:`datalad-create` manual).
 In a bit of time, you will thank yourself for adding a description about the *location*
 of your dataset with the *optional* ``--description`` flag. (At the moment,
 we will not dive into the details of where that description ends up or


### PR DESCRIPTION
Failure might have been resolved with Sphinx>2 dependency change before.

This reverts commit 5030564327e048ce80fd5d5cbb009e5dedb72d67.