### PR TITLE
add yet missing example files

### DIFF
--- a/docs/basics/_examples/DL-101-125-109
+++ b/docs/basics/_examples/DL-101-125-109
@@ -1,0 +1,1 @@
+$ git config --file=.gitmodules --replace-all submodule."recordings/longnow".url "git@github.com:datalad-datasets/longnow-podcasts.git"

--- a/docs/basics/_examples/DL-101-125-110
+++ b/docs/basics/_examples/DL-101-125-110
@@ -1,0 +1,2 @@
+$ datalad status
+ modified: .gitmodules (file)

--- a/docs/basics/_examples/DL-101-125-111
+++ b/docs/basics/_examples/DL-101-125-111
@@ -1,0 +1,11 @@
+$ git diff
+diff --git a/.gitmodules b/.gitmodules
+index 1b59b8c..599864e 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -1,4 +1,4 @@
+ [submodule "recordings/longnow"]
+ 	path = recordings/longnow
+-	url = https://github.com/datalad-datasets/longnow-podcasts.git
++	url = git@github.com:datalad-datasets/longnow-podcasts.git
+ 	datalad-id = b3ca2718-8901-11e8-99aa-a0369f7c647e

--- a/docs/basics/_examples/DL-101-125-112
+++ b/docs/basics/_examples/DL-101-125-112
@@ -1,0 +1,2 @@
+$ git checkout .gitmodules
+$ datalad status


### PR DESCRIPTION
#104 missed some example files. I don't know why the build didn't fail, to be honest. As far as I can see, there are no other example files with these names in this repository (``_examples/DL-101-125-109``  - ``_examples/DL-101-125-112``). The rendered version included really funky examples instead of failing. For example:

```
$ datalad status
bash: line 1: datalad: command not found
```

or a git diff displays the ``docs/conf.py`` contents:

```
$ git diff
diff --git a/docs/conf.py b/docs/conf.py
index 19b18d8..7890263 100644
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -310,3 +310,180 @@ plantuml_latex_output_format = 'pdf'
 
 def setup(app):
     app.add_stylesheet('custom.css')
+
+
+
+
+###########################################################################
+#          auto-created readthedocs.org specific configuration            #
+###########################################################################
+
+
+#
+# The following code was added during an automated build on readthedocs.org
+# It is auto created and injected for every build. The result is based on the
+# conf.py.tmpl file found in the readthedocs.org codebase:
+# https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+#
+
+
+import importlib
+import sys
+import os.path
[...]
```

I'm clueless where these snippets stem from, but adding the correct example files will hopefully fix the rendered version.