### PR TITLE
'findoutmore' RST directive, plus exemplary use

### DIFF
--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -37,6 +37,60 @@ class GitUserNote(BaseAdmonition):
     node_class = gitusernote
 
 
+class FindOutMore(BaseAdmonition):
+    """findoutmore RST directive
+
+    The idea here is to use an admonition to parse the RST,
+    but actually fully replace it afterwards with a custom
+    node structure. This is done to be able to replace a
+    rather verbose custom markup that was used before in the
+    book. Eventually, it may be replaced (in here) with
+    something completely different -- without having to change
+    content and markup in the book sources.
+    """
+    node_class = nodes.admonition
+    # empty is no allowed
+    has_content = True
+    # needs at least a one word titel
+    required_arguments = 1
+
+    def run(self):
+        # this uses the admonition code for RST parsion
+        docnodes = super(FindOutMore, self).run()
+        # but we throw away the title, because we want to mark
+        # it up as a 'header' further down
+        del docnodes[0][0]
+        # now put the entire admonition structure into a container
+        # that we assign the necessary class to make it 'toggle-able'
+        # in HTML
+        # outer container
+        toggle = nodes.container(
+            'toogle',
+            # header line with 'Find out more' prefix
+            nodes.container(
+                'label',
+                nodes.paragraph(
+                    'title', '',
+                    nodes.strong('strong', 'Find out more: '),
+                    # place actual admonition title we removed
+                    # above
+                    nodes.Text(self.arguments[0]),
+                ),
+                # add (CSS) class
+                classes=['header'],
+            ),
+            # place the rest of the admonition structure after the header,
+            # but still inside the container
+            *docnodes[0].children,
+            # properly identify as 'findoutmore' to enable easy custom
+            # styling, and also tag with 'toggle'. The later is actually
+            # not 100% necessary, as 'findoutmore' could get that
+            # functional assigned in CSS instead (maybe streamline later)
+            classes=['toggle', 'findoutmore'],
+        )
+        return [toggle]
+
+
 def setup(app):
     app.add_node(
         gitusernote,
@@ -44,5 +98,6 @@ def setup(app):
         latex=(visit_gitusernote_latex, depart_gitusernote_latex),
     )
     app.add_directive('gitusernote', GitUserNote)
+    app.add_directive('findoutmore', FindOutMore)
 
 # vim: set expandtab shiftwidth=4 softtabstop=4 :

--- a/docs/basics/101-125-config.rst
+++ b/docs/basics/101-125-config.rst
@@ -188,11 +188,7 @@ a value, one can configure Git, Git-annex, and DataLad.
 of Git, depending on the scope (local, global, system-wide)
 specified in the command.
 
-.. container:: toggle
-
-   .. container:: header
-
-       **Find out more:** If things go wrong
+.. findoutmore:: If things go wrong
 
    If something goes wrong during the :command:`git config` command,
    for example you end up having two keys of the same name because you
@@ -214,11 +210,7 @@ Nevertheless, it might be helpful to get an overview about the meaning of the
 remaining sections in that file, and the following hidden section can give
 you a glimpse of this.
 
-.. container:: toggle
-
-   .. container:: header
-
-      **Find out more:** More on this config file
+.. findoutmore:: More on this config file
 
    The second section of ``.git/config`` is a Git-annex configuration.
    As mentioned above, Git-annex will use the


### PR DESCRIPTION
Visual impression should be unchanged from status quo. But now we have it semantically marked-up and can distinguish it from other boxes and toggle containers.