### PR TITLE
More obvious bugs in the book

### DIFF
--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -154,7 +154,8 @@ into the same spot of our history, because it would get very nasty should we wan
 revert *some* of the changes without affecting others in this commit.
 
 Luckily, we can point :command:`datalad save` to exactly the changes we want it to record.
-Let's try this by adding yet another book, a good reference work about git:
+Let's try this by adding yet another book, a good reference work about git,
+`Pro Git <https://git-scm.com/book/en/v2>`_:
 
 .. runrecord:: _examples/DL-101-102-108
    :language: console

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -72,7 +72,6 @@ Interesting, the ``books/`` directory is "untracked". Remember how content
 *can* be tracked *if a user wants to*?
 Untracked means that DataLad does not know about this directory or its content,
 because we haven't ordered DataLad to actually track it. This means, DataLad
-
 does not keep the downloaded books in its history yet. Let's change this by
 saving the files to the dataset's history with the :command:`datalad save` command
 (:manpage:`datalad-save` manual).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -41,7 +41,7 @@ If you want to be able to build the book locally, though, please follow these in
    # navigate into the installed dataset
    cd book
    # install required software
-   pip install -r requirements
+   pip install -r requirements.txt
    pip install -e .
 
 - install ``librsvg2-bin`` (a tool to render ``.svgs``) with your package manager

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -102,7 +102,7 @@ is ongoing, and this handbook will incorporate all DataLad commands and extensio
 *once they are stable* (that is, once the command(-structure) is likely to not
 change in the future anymore). If you are looking for a feature but cannot find it in this
 handbook, please take a look at the `documentation <http://docs.datalad.org>`_,
-`write <LinkThisToContributing>`_ or
+`write <http://handbook.datalad.org/en/latest/contributing.html>`_ or
 `request <https://github.com/datalad-handbook/book/issues/new>`_
 an additional chapter if you believe it's a worthwhile addition, or
 `ask a question on Neurostars.org <https://neurostars.org/latest>`_


### PR DESCRIPTION
I gave the rendered book a quick read and fixed some problems:

- a left-over "linktocontributing"
- an accidental linebreak in the text
- I added a link to download the ProGit book just as for the other books, to give an alternative to running ``wget``
- a missing file extensions in ``pip install requirements`` on the contributing page