### PR TITLE
Improve sidebar experience, fixes #170

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -42,3 +42,8 @@ div.gitusernote {
     background-color: #c3ebffff;
     border: 1px solid #7fd4ffff;
 }
+
+div.sphinxsidebar {
+    max-height: 100%;
+    overflow-y: auto;
+}

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -26,7 +26,7 @@
 </p>
 
 <div style="display:block;position:relative;margin: 1em 0 1em 0;">
-  <div style="display:block;width:100%;padding-top:100%;"></div>
+  <div style="display:block;width:50%;padding-top:50%;"></div>
   <div class="rpad" data-unit="1x1" style="position:absolute;left:0;top:0;right:0;bottom:0;overflow:hidden;"></div>
 </div>
 


### PR DESCRIPTION
As noted by @effigies in #170 (thanks!), content in the sidebar can be invisible, for example when zooming in too much. This is both because a larg-ish empty box makes it taller than the page, and because the side bar is fixed.

In principle, I like the space in the sidebar because it creates a nice visual offset between the intro in the sidebar and the Contributors section, making both parts more striking/visible. I'd also like to have the sidebar fixed in the sense that scrolling the main content does not scroll the sidebar away, because it keeps the navigation links to the landing page, pre-/succeeding sections, Github, and the quicksearch close by in very long sections. 
In this PR I therefore try to mitigate the problem by

- decreasing the amount of white space between intro and contributors in the sidebar
- giving the side bar its own vertical scroll bar as soon as it does not fit on a single page anymore

@mih, do you have thoughts on this?

