### PR TITLE
Page-wise progress bars

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -12,3 +12,18 @@
     });
 </script>
 {% endblock %}
+
+{% block header %}
+  <script type="text/javascript">
+
+  $(window).scroll(function () {
+    var s = $(window).scrollTop(),
+          d = $(document).height(),
+          c = $(window).height();
+          scrollPercent = (s / (d-c)) * 100;
+          var position = scrollPercent;
+
+     $("#progressbar").attr('value', position);
+  });
+  </script>
+{% endblock %}

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -20,3 +20,5 @@
   height: 100%;
 }
 </style>
+
+<progress id="progressbar" value="0" max="100"></progress>


### PR DESCRIPTION
After #193 I looked a bit into "scrolling progress bars". This isn't yet what @lisanmo suggests (it's only page-wise) and I'm not sure yet whether or how one could get a chapter-wise progress bar in the HTML version of the book, but I will continue exploring. This is how it currently looks like (The blue bar progresses the more you scroll):

![image](https://user-images.githubusercontent.com/29738718/66067480-f3606700-e54b-11e9-80a9-3e27c9ad78b2.png)
