### PR TITLE
handpolish more contributor names, fixes #200

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
   "contributors": [
     {
       "login": "adswa",
-      "name": "Adina Wagner",
+      "name": "Adina S. Wagner",
       "avatar_url": "https://avatars1.githubusercontent.com/u/29738718?v=4",
       "profile": "https://www.researchgate.net/profile/Adina_Wagner",
       "contributions": [
@@ -137,7 +137,7 @@
     },
     {
       "login": "lisanmo",
-      "name": "lisanmo",
+      "name": "Lisa N. Mochalski",
       "avatar_url": "https://avatars0.githubusercontent.com/u/52251433?v=4",
       "profile": "https://github.com/lisanmo",
       "contributions": [


### PR DESCRIPTION
This fixes #200 by giving @lisanmo her full name. While I was at it I also included my second name's initial.