### PR TITLE
adjust latex fonts to resemble those of readthedocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 cache:
   - apt
 install:
-  - sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk librsvg2-bin plantuml
+  - sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra latexmk librsvg2-bin plantuml
   # plantuml is really outdated, smuggle in the latest upstream
   - sudo wget -O /usr/share/plantuml/plantuml.jar http://sourceforge.net/projects/plantuml/files/plantuml.jar/download
   - pip install -r requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,7 +273,10 @@ latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',
     'figure_align': 'tbp',
-    'preamble': """\
+    'preamble': r"""
+\usepackage{charter}
+\usepackage[defaultsans]{lato}
+\usepackage{inconsolata}
 \setcounter{tocdepth}{0}
 """,
 }


### PR DESCRIPTION
This lets the PDF use fonts that are closer to what readthedoc's theme uses. It's pure personal taste - I find those fonts more readable and more modern, but I'm also happy to stick to the defaults.