### PR TITLE
finalize installation section

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -169,7 +169,7 @@ please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
       - During installation, you will be prompted to "Choose Install Location".
         **Install it into the miniconda Library directory**, e.g.
-        ``C:\Users\mih\Miniconda3\Library``.
+        ``C:\Users\me\Miniconda3\Library``.
 
    - **Step 4**: Install DataLad via pip
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -44,7 +44,7 @@ DataLad and all of its software dependencies (including the Git-annex-standalone
 
    .. container:: header
 
-      **Linux-machines with no root access**
+      **Linux-machines with no root access (e.g. HPC systems)**
 
    If you want to install DataLad on a machine you do not have root access to, DataLad
    can be installed with `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
@@ -103,60 +103,97 @@ a user's home directory:
 In addition, it is necessary to have a current version of :term:`Git-annex` installed which is
 not set up automatically by using the ``pip`` method.
 You can find detailed installation instructions on how to do this
-`here <https://git-annex.branchable.com/install/>`_.
+`here <https://git-annex.branchable.com/install/>`__.
 
-.. todo::
-
-   how to install Git-annex without sudo permissions. Currently the docs say:
-   "Git-annex can be deployed by extracting pre-built binaries from a tarball
-   (that also includes an up-to-date Git installation). Obtain the tarball,
-   extract it, and set the PATH environment variable to include the root of the
-   extracted tarball. Fingers crossed and good luck!" This could be turned into
-   a less intimidating step-by-step guide.
-
-   It is actually sufficient to just extract the provided EXE installer into an
-   existing Git installation directory (`example of how this is done in
-   DataLad's own test environment on Windows
-   <https://github.com/datalad/datalad/blob/master/appveyor.yml#L59>`__). If done
-   this way, no PATH variable manipulation is necessary, and things just start to
-   work.
-
+For Windows, extract the provided EXE installer into an existing Git
+installation directory (e.g. ``C:\\Program Files\Git``). If done
+this way, no ``PATH`` variable manipulation is necessary.
 
 Windows 10
 """"""""""
 
 There are two ways to get DataLad on Windows 10: one is within Windows itself,
-the other is using WSL, the Windows Subsystem for Linux. **We** *strongly*
-**recommend the latter.**
+the other is using WSL, the Windows Subsystem for Linux.
 
-Note: Using Windows comes with some downsides.
+Note: Using Windows itself comes with some downsides.
 In general, DataLad can feel a bit sluggish on Windows systems. This is because of
 a range of filesystem issues that also affect the version control system :term:`Git` itself,
-which DataLad relies on. The core functionality of DataLad should work, and you should
+which DataLad relies on. The core functionality of DataLad works, and you should
 be able to follow the contents covered in this book.
-You will notice, however, that some
-Unix commands displayed in examples may not work given the installation that you
-chose, and that terminal output can look different from what is displayed here.
+You will notice, however, that some Unix commands displayed in examples may not
+work, and that terminal output can look different from what is displayed in the
+code examples of the book.
 If you are a Windows user and want to help improve the handbook for Windows users,
 please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
+.. container:: toggle
+
+   .. container:: header
+
+      **1) Install within Windows [RECOMMENDED]**
+
+   Note: This installation method will get you a working version of
+   DataLad, but be aware that many Unix commands shown in the book
+   examples will not work for you, and DataLad-related output might
+   look different from what we can show in this book. Please
+   `get in touch <https://github.com/datalad-handbook/book/issues/new>`__
+   touch if you want to help.
+
+   - **Step 1**: Install Conda
+
+      - Go to https://docs.conda.io/en/latest/miniconda.html and pick the
+        latest Python 3 installer. Miniconda is a free, minimal installer for
+        conda and will install `conda <https://docs.conda.io/en/latest/>`_,
+        Python, depending packages, and a number of useful packages such as
+        `pip <https://pip.pypa.io/en/stable/>`_.
+
+      - During installation, keep everything on default. In particular, do
+        not add anything to ``PATH``.
+
+      - From now on, any further action must take place in the ``Anaconda prompt``,
+        a preconfigured terminal shell. Find it by searching for "Anaconda prompt"
+        in your search bar.
+
+   - **Step 2**: Install Git
+
+      - In the ``Anaconda prompt``, run ``conda install -c conda-forge git``.
+        Note: Is has to be from ``conda-forge``, the anaconda version does not
+        provide the ``cp`` command.
+
+   - **Step 3**: Install Git-annex
+
+      - Obtain the current Git-annex versions installer
+        `from here <https://downloads.kitenet.net/git-annex/windows/current/>`_.
+        Save the file, and double click the downloaded
+        :command:`git-annex-installer.exe` in your Downloads.
+
+      - During installation, you will be prompted to "Choose Install Location".
+        **Install it into the miniconda Library directory**, e.g.
+        ``C:\Users\mih\Miniconda3\Library``.
+
+   - **Step 4**: Install DataLad via pip
+
+      - ``pip`` was installed by ``miniconda``. In the ``Anaconda prompt``, run
+        ``pip install datalad``.
 
 
 .. container:: toggle
 
    .. container:: header
 
-      **1) Install within WSL [recommended]**
+      **2) Install within WSL**
 
    The Windows Subsystem for Linux (WSL) allows Windows users to have full access
    to a Linux distribution within Windows.
-   The improves the DataLad experience on Windows *greatly*.
-
    If you have always used Windows be prepared for some user experience changes when
    using Linux compared to Windows. For one, there will be no graphical user interface
    (GUI). Instead, you will work inside a terminal window. This however
    mirrors the examples and code snippets provided in this handbook exactly.
-   Also, note that there will be incompatibilities between the Windows and Linux filesystems.
+   Using a proper Linux installation improves the DataLad handbook experience on Windows
+   *greatly*. However, it comes with
+   the downside of two filesystems that are somewhat separated. Data access to files
+   within Linux from within Windows is problematic:
+   Note that there will be incompatibilities between the Windows and Linux filesystems.
    Files that are created within the WSL for example can not be modified with
    Windows tools. A great resource to get started and understand the WSL is
    `this guide <https://github.com/michaeltreat/Windows-Subsystem-For-Linux-Setup-Guide/>`_.
@@ -248,71 +285,109 @@ please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
    .. container:: header
 
-      **2) Install within WSL2 [TODO; will be the recommendation soon]**
+      **3) Install within WSL2**
+
+   The Windows Subsystem for Linux (WSL) allows Windows users to have full access
+   to a Linux distribution within Windows. The Windows Subsystem for Linux 2 (WSL2)
+   is the (currently pre-released) update to the WSL.
+   If you have always used Windows be prepared for some user experience changes when
+   using Linux compared to Windows. For one, there will be no graphical user interface
+   (GUI). Instead, you will work inside a terminal window. This however
+   mirrors the examples and code snippets provided in this handbook exactly.
+   Using a proper Linux installation improves the DataLad handbook experience on Windows
+   *greatly*. However, it comes with
+   the downside of two filesystems that are somewhat separated. Data access to files
+   within Linux from within Windows is problematic:
+   Note that there will be incompatibilities between the Windows and Linux filesystems.
+   Files that are created within the WSL for example can not be modified with
+   Windows tools. A great resource to get started and understand the WSL is
+   `this guide <https://github.com/michaeltreat/Windows-Subsystem-For-Linux-Setup-Guide/>`_.
+
+   **Requirements**:
+
+   WSL can be enabled for **64-bit** versions of **Windows 10** systems running
+   Windows 10 Insider Preview Build 18917 or higher. You can find out how to enter
+   the Windows Insider Program to get access to the prebuilds
+   `here <https://insider.windows.com/en-us/>`_.
+   To check whether your computer fulfills these requirements,
+   open *Settings* (in the start menu) > *System* > *About*. Your version number should be
+   at least 1903.
+   Furthermore, your computer needs to support
+   `Hyper-V Virtualization <https://www.thomasmaurer.ch/2017/08/install-hyper-v-on-windows-10-using-powershell/>`_.
+
+   The instructions below show you how to set up the WSL and configure it to use
+   DataLad and its dependencies. They follow the
+   `Microsoft Documentation on the Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_.
+   If you run into troubles during the installation, please consult the
+   `WSL troubleshooting page <https://docs.microsoft.com/en-us/windows/wsl/troubleshooting>`_.
+
+
+
+   - **Step 1**: Enable the windows subsystem for Linux.
+
+      - Start the Power Shell as an administrator. Run both commands below,
+        only restart after the second one (despite being prompted after the first one already)::
+
+           Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform
+           Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
+
+   - **Step 2**: Install a Debian Linux distribution
+
+      - To do this, visit the Microsoft store, and search for the Debian distro.
+        We **strongly** recommend installing :term:`Debian`, even though other
+        distributions are available. "Get" the app, and "install" it.
+
+   - **Step 3**: Initialize the distribution
+
+      - Launch the Subsystem either from the Microsoft store or from the Start menu. This
+        will start a terminal. Don't worry -- there is a dedicated section (:ref:`howto`)
+        on how to work with the terminal if you haven't so far.
+
+      - Upon first start, you will be prompted to enter a new UNIX username and password.
+        Tip: chose a short name, and no spaces or special characters. The password will
+        become necessary when you elevate a process using ``sudo`` -- sudo let's you execute a
+        process with rights of another user, such as administrative rights, for examples when
+        you need to install software.
+
+
+   - **Step 4**: Configure the WLS
+
+      - Start the Power Shell as an administrator. To set the WSL version to WSL2, run
+        ``wsl --set-default-version 2``. Configure the distro to use WSL2 by running
+        ``wsl -l -v``. This should give an output like this::
+
+               NAME        STATE               VERSION
+           *   Debian       Running            2
+
+   - **Step 5**: Enable NeuroDebian
+
+      - In the terminal of your distribution, run
+
+      .. code-block:: bash
+
+         $ wget -O- http://neuro.debian.net/lists/stretch.de-md.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+
+      - Afterwards, run
+
+      .. code-block:: bash
+
+         $ curl -sL "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA5D32F012649A5A9" | sudo apt-key add
+
+      - lastly do another
+
+      .. code-block:: bash
+
+         $ sudo apt-update && sudo apt upgrade
+
+   - **Step 6**: Install datalad and everything it needs from Neurodebian
+
+      .. code-block:: bash
+
+         $ sudo apt install datalad
 
    .. todo::
 
-      - find out how to install/enable WSL2
-
-      - find out what changes about the above instructions
-
-
-.. container:: toggle
-
-   .. container:: header
-
-      **3) Install within Windows**
-
-   Note: This installation method will get you a working version of
-   DataLad, but be aware that many Unix commands shown in the book
-   examples will not work for you, and DataLad-related output might
-   look different from what we can show in this book.
-
-   - **Step 1**: If you haven't, install Python3
-
-      - Check the official
-        `Python docs on installing on Windows <https://docs.python.org/3/using/windows.html>`_
-        for instructions here. Please read the recommendation below,
-        though
-
-      - **Check the box "Add Python <version> to PATH** at the bottom
-        of the window, and select "Customize installation".
-
-      - Stay with the default options to install all optional features,
-        and additionally tick
-        "Add Python to environment variables" on the second page.
-        Optionally, tick the box
-        "Install for all users" to ensure that other users on the computer
-        are able to use Python.
-
-      - Finish the installation. After successful installation, instruct the installer
-        to bypass the 260 character file path limit (option available at the bottom
-        of the window).
-
-      - Check the installation by opening CMD (type ``cmd`` into the Windows
-        search bar and press ``Enter``) and typing python + ``Enter``. You should
-        see Python start up in the terminal. This means that Python is working
-        and the ``PATH`` is set correctly. Yay!
-
-   - **Step 2**: Install Git
-
-      - Go to https://git-scm.com/downloads, select Windows, and
-        **download the 32-bit Git for Windows Setup** (not the 64-bit version!)
-
-   - **Step 3**: Install Git-annex
-
-      - Obtain the current Git-annex versions installer
-        `from here <https://downloads.kitenet.net/git-annex/windows/current/>`_.
-        Save the file, and double click the downloaded
-        :command:`git-annex-installer.exe` in your Downloads.
-
-      - During installation, you will be prompted to "Choose Install Location".
-        **Specify the directory in which Git is installed**.
-
-   - **Step 4**: Install DataLad via pip
-
-      - ``pip`` should be installed together with recent Python versions on
-        Windows. Open ``cmd`` and type ``pip install --user datalad``.
+      - maybe update Step 6 to use ``pip3`` to install DataLad and Git-annex.
 
 
 Initial configuration


### PR DESCRIPTION
This should finally get the installation instructions into a complete-ish state:

- updates Windows native installation instructions with Miniconda (using notes from https://github.com/datalad-handbook/book/issues/132) and make it the default
- add WSL2 instructions from issue for completeness (based on notes in https://github.com/datalad-handbook/book/issues/114)
- removes todos
- add "eg HPC systems" to Linux machines with no root access

Question to @mih: 
- You briefly mentioned enabling SSH Server via powershell yesterday. Am I right in my assumption that this is not necessary for a user-installation (but rather to use ``bnbdatalad``, see https://github.com/psychoinformatics-de/org/issues/91)?
- You once mentioned https://tortoisegit.org/ as an alternative, what do you think about this atm?