### PR TITLE
Add installation notes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ The DataLad Handbook
    check out the existing content, but please consider the handbook to be in
    alpha stage -- expect thourough changes and developments in all aspects of
    the book until further notice. Please also note that all examples are based
-   on a future release of DataLad version 0.12.
+   on **DataLad version 0.12**.
 
    If you would be willing to provide feedback on this, or a future beta version, please
    `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -68,7 +68,7 @@ DataLad and all of its software dependencies (including the Git-annex-standalone
 
       .. code-block:: bash
 
-         pip install datalad==0.12.0rc5
+         pip install datalad~=0.12.0rc5
 
 
 OS X

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -60,6 +60,16 @@ DataLad and all of its software dependencies (including the Git-annex-standalone
    The installer automatically configures the shell to make conda-installed
    tools accessible, so no further configuration is necessary.
 
+   .. note::
+
+      Currently, the latest DataLad version on conda is 0.11, but the handbook
+      is written for version 0.12. If you have installed DataLad 0.11 already, an upgrade
+      to the most recent 0.12 release candidate is possible with
+
+      .. code-block:: bash
+
+         pip install datalad==0.12.0rc5
+
 
 OS X
 """"


### PR DESCRIPTION
- Note that the Miniconda-based installation on DataLad only provides 0.11; add instructions how to upgrade (based on [this question](https://neurostars.org/t/datalad-install-datalad-containers-extension-in-conjunction-with-singularity-datalad-container/5246) mentioned in https://github.com/datalad-handbook/book/issues/177#issuecomment-542872693)
- Remove "future release" from note on landing page