### PR TITLE
warn about invisible broken symlinks in certain viewers

### DIFF
--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -305,6 +305,17 @@ modification.
    $ datalad save -m "Add note on datalad install"
 
 
+.. note::
+
+  Listing files directly after an installation of a dataset will
+  work if done in a terminal with ``ls``.
+  However, certain file managers (such as OSX's Finder [#f3]_) may fail to
+  display files that are not yet present locally (i.e., before a
+  :command:`datalad get` was run). Therefore, be  mindful when exploring
+  a dataset hierarchy with a file manager -- it might not show you
+  the available but not yet retrieved files. More about why this is will be
+  explained in section :ref:`symlink`.
+
 .. rubric:: Footnotes
 
 .. [#f1] Additionally, a source  can also be a pointer to an open-data collection,
@@ -314,3 +325,8 @@ modification.
 .. [#f2] The longnow podcasts are lectures and conversations on long-term thinking produced by
          the LongNow foundation. Subscribe to the podcasts at http://longnow.org/seminars/podcast.
          Support the foundation by becoming a member: https://longnow.org/membership. http://longnow.org
+
+.. [#f3] You can also upgrade your file manager to display file types in a
+         DataLad datasets (e.g., with the
+         `git-annex-turtle extension <https://github.com/andrewringler/git-annex-turtle>`_
+         for Finder)

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -270,7 +270,36 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    about Git-annex, you can check out its
    `documentation <https://git-annex.branchable.com/git-annex/>`_.
 
-If you are still in the ``books/`` directory, go back into the root of the superdataset.
+Broken symlinks
+^^^^^^^^^^^^^^^
+
+Whenever a symlink points to a non-existent target, this symlink is called
+*broken*, and opening the symlink would not work as it does not resolve. The
+section :ref:`filesystem` will give a thorough demonstration of how symlinks can
+break, and how one can fix them again. Even though *broken* sounds
+troublesome, most types of broken symlinks you will encounter can be fixed,
+or are not problematic. At this point, you actually have already seen broken
+symlinks: Back in section :ref:`installds` we explored
+the file hierarchy in an installed subdataset that contained many annexed
+``mp3`` files. Upon installation, the annexed files were not present locally.
+Instead, their symlinks (stored in Git) existed and allowed to explore which
+file's contents could be retrieved. These symlinks point to nothing, though, as
+the content isn't yet present locally, and are thus *broken*. This state,
+however, is not problematic at all. Once the content is retrieved via
+:command:`datalad get`, the symlink is functional again.
+
+Nevertheless, it may be important to know that some file managers (e.g., OSX's
+Finder) may not display broken symlinks. In these cases, it will be
+impossible to browse and explore the file hierarchy of not-yet-retrieved
+files with the file manager. You can make sure to always be able to see the
+file hierarchy in two seperate ways: Upgrade your file manager to display
+file types in a DataLad datasets (e.g., the
+`git-annex-turtle extension <https://github.com/andrewringler/git-annex-turtle>`_
+for Finder). Alternatively, use the :command:`ls` command in a terminal instead
+of a file manager GUI.
+
+Finally, if you are still in the ``books/`` directory, go back into the root of
+the superdataset.
 
 .. runrecord:: _examples/DL-101-115-106
    :workdir: dl-101/DataLad-101/books


### PR DESCRIPTION
@loj and @bpoldrack discovered that OSX Finder was not able to
display broken symlinks, essentially hiding available files.
This should make readers aware in the section installing datasets,
and give some more information on this in the section on symlinks