### PR TITLE
Slim makefile, fixes #218

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ build: html
 clean-examples:
 	# check if we have something like .xsession or a .bashrc
 	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
-	@find docs -name _examples -type d | xargs rm -vrf
+	@find docs -name _examples -type d | sed 's/docs\/usecases\/_examples//' |xargs rm -vrf
 	# also wipe the workdirs, otherwise a rebuild will lead to chaos
-	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq | cut -d '/' -f 1 | uniq); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
+	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq | sed 's/usecases//'); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
+
+# wipe out usecases
+clean-usecases:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@rm -vrf docs/usecases/_examples
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases; rm -vrf /home/me/usecases

--- a/docs/usecases/datasets.rst
+++ b/docs/usecases/datasets.rst
@@ -21,7 +21,7 @@ a hands-on experience.
 
    .. runrecord:: _examples/dataset
       :language: console
-      :workdir: studyforrest
+      :workdir: usecases/studyforrest
 
       $ datalad install https://github.com/psychoinformatics-de/studyforrest-data-phase2.git
 
@@ -29,7 +29,7 @@ Once installed, a DataLad dataset looks like any other directory on your filesys
 
 .. runrecord:: _examples/dataset2
    :language: console
-   :workdir: studyforrest
+   :workdir: usecases/studyforrest
    :lines: 1-2, 8-18
 
    $ cd studyforrest-data-phase2
@@ -51,7 +51,7 @@ all of these changes can be written to your DataLad datasets history.
       :language: console
       :lines: 1, 5-11, 15-25
       :emphasize-lines: 3, 5-6, 8
-      :workdir: studyforrest/studyforrest-data-phase2
+      :workdir: usecases/studyforrest/studyforrest-data-phase2
 
       $ ls -a # show also hidden files (excerpt)
 
@@ -69,7 +69,7 @@ from :command:`git log`.
 .. runrecord:: _examples/dataset4
    :language: console
    :lines: 1-10
-   :workdir: studyforrest/studyforrest-data-phase2
+   :workdir: usecases/studyforrest/studyforrest-data-phase2
 
    $ git log --oneline --graph --decorate
 
@@ -85,7 +85,7 @@ small in size:
 
 .. runrecord:: _examples/dataset5
    :language: console
-   :workdir: studyforrest/studyforrest-data-phase2
+   :workdir: usecases/studyforrest/studyforrest-data-phase2
 
    $ du -sh
 
@@ -100,7 +100,7 @@ explore which files exist without the potentially large download.
 .. runrecord:: _examples/dataset6
    :language: console
    :emphasize-lines: 3
-   :workdir: studyforrest/studyforrest-data-phase2
+   :workdir: usecases/studyforrest/studyforrest-data-phase2
 
    $ ls participants.tsv  sub-01/ses-movie/func/sub-01_ses-movie_task-movie_run-1_bold.nii.gz
 
@@ -110,7 +110,7 @@ of files. Let's get the nifti file:
 
 .. runrecord:: _examples/dataset7
    :language: console
-   :workdir: studyforrest/studyforrest-data-phase2
+   :workdir: usecases/studyforrest/studyforrest-data-phase2
 
    $ datalad get sub-01/ses-movie/func/sub-01_ses-movie_task-movie_run-1_bold.nii.gz
 


### PR DESCRIPTION
This separates removing examples and workdirs for usecases from removing examples and workdirs for the rest of the book. With a growing amount of use cases, it will take more and more time to compute them, while recomputing them is not relevant (they are standalone), especially not for the basics sections of the book.

Performance observation:

``Make`` with removed examples from intro, basics, and usecases
``73.52s user 17.27s system 56% cpu 2:40.54 total``

 ``Make`` with removed examples from intro, basics
``38.38s user 11.66s system 67% cpu 1:13.68 total``

