### PR TITLE
add general clean target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ clean-usecases:
 	@rm -vrf docs/usecases/_examples
 	# also wipe the workdirs, otherwise a rebuild will lead to chaos
 	@chmod +w -R /home/me/usecases; rm -vrf /home/me/usecases
+
+# wipe out everything
+clean:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs -name _examples -type d | xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done


### PR DESCRIPTION
Following #224, this adds a general ``make clean`` that gets rid of all examples and workdirs.