### PR TITLE
Refine install instructions for OSX

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -158,6 +158,11 @@ Glossary
       Git concept: a submodule is a Git repository embedded inside another Git repository. A
       :term:`DataLad subdataset` is known as a submodule in the :term:`Git config file`.
 
+   tab completion
+      Also known as command-line completion. A common shell feature in which
+      the program automatically fills in partially types commands upon
+      pressing the ``TAB`` key.
+
    the DataLad superdataset ///
       TODO
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -73,8 +73,8 @@ This should install :term:`Git`, :term:`Git-annex`, and DataLad.
 The installer automatically configures the shell to make conda-installed
 tools accessible, so no further configuration is necessary.
 
-OS X
-""""
+macOS/OSX
+"""""""""
 
 A common way to install packages on OS X is via the
 `homebrew <https://brew.sh/>`_ package manager.
@@ -87,7 +87,13 @@ instructions on their webpage (linked above).
 Next, `install Git-annex <https://git-annex.branchable.com/install/OSX/>`_.
 
 Once Git-annex is available, DataLad can be installed via Pythons package
-manager ``pip`` as described below.
+manager ``pip`` as described below. ``pip`` should already be installed by
+default. Recent macOS versions may have ``pip3`` instead of ``pip`` -- use
+:term:`tab completion` to find out which is installed. If it is ``pip3``, run::
+
+   $ pip3 install datalad~=0.12.0rc6
+
+instead of the code snippets in the section below.
 
 Using Pythons package manager ``pip``
 """""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This fixes #236 -- while troubleshooting a failed datalad installation on OSX 10.14 (Mojave) via ``pip install datalad`` we found that the default preinstalled Python package manager was ``pip3``.