### PR TITLE
Do not render speakernotes as captions

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -37,7 +37,7 @@ Note the command structure of :command:`datalad create` (optional bits are enclo
    :language: console
    :workdir: dl-101
    :cast: 01_dataset_basics
-   :caption: Datasets are datalads core data type. We will explore the concepts of datasets by creating one with datalad create. optional configuration template and a description
+   :notes: Datasets are datalads core data type. We will explore the concepts of datasets by creating one with datalad create. optional configuration template and a description
 
    $ datalad create --description "course on DataLad-101 on my private Laptop" -c text2git DataLad-101
 
@@ -52,7 +52,7 @@ Currently, it seems empty.
    :language: console
    :workdir: dl-101
    :cast: 01_dataset_basics
-   :caption: Datalad informs about what it is doing during a command. At the end is a summary, in this case it is ok. What is inside of a newly created dataset? We list contents with ls.
+   :notes: Datalad informs about what it is doing during a command. At the end is a summary, in this case it is ok. What is inside of a newly created dataset? We list contents with ls.
 
    $ cd DataLad-101
    $ ls    # ls does not show any output, because the dataset is empty.
@@ -78,7 +78,7 @@ a built-in git command [#f1]_. Your git log *might* be opened in a `terminal pag
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 3-4, 6, 9-10, 12
    :cast: 01_dataset_basics
-   :caption: GIT LOG, SHASUM, MESSAGE: A dataset is version controlled. This means, edits done to a file are associated with information about the change, the author, and the time + ability to restore previous states of the dataset. Let's take a look into the history, even if it is small atm
+   :notes: GIT LOG, SHASUM, MESSAGE: A dataset is version controlled. This means, edits done to a file are associated with information about the change, the author, and the time + ability to restore previous states of the dataset. Let's take a look into the history, even if it is small atm
 
    $ git log
 
@@ -110,7 +110,7 @@ an informative commit message yourself.
       :workdir: dl-101/DataLad-101
       :emphasize-lines: 4-6
       :cast: 01_dataset_basics
-      :caption: Datalad, git-annex, and git create hidden files and directories in your dataset. Make sure to not delete them!
+      :notes: Datalad, git-annex, and git create hidden files and directories in your dataset. Make sure to not delete them!
 
       $ ls -a # show also hidden files
 

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -12,7 +12,7 @@ Let's first create a directory to save books for additional reading in.
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: The dataset is empty, lets put some PDFs inside. First, create a directory to store them in:
+   :notes: The dataset is empty, lets put some PDFs inside. First, create a directory to store them in:
 
    $ mkdir books
 
@@ -22,7 +22,7 @@ Let's take a look at the current directory structure with the tree command [#f1]
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: The tree command shows us the directory structure in the dataset. Apart from the directory, its empty.
+   :notes: The tree command shows us the directory structure in the dataset. Apart from the directory, its empty.
 
    $ tree
 
@@ -42,7 +42,7 @@ or run the following commands [#f2]_ to download the books right from the termin
    :workdir: dl-101/DataLad-101
    :realcommand: cd books && wget -nv https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download -O TLCL.pdf && wget -nv https://www.gitbook.com/download/pdf/book/swaroopch/byte-of-python -O byte-of-python.pdf && cd ../
    :cast: 01_dataset_basics
-   :caption: We use wget to download a few books from the web. CAVE: longish realcommand!
+   :notes: We use wget to download a few books from the web. CAVE: longish realcommand!
 
    $ cd books
    $ wget https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download -O TLCL.pdf
@@ -57,7 +57,7 @@ structure with tree:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: Here they are:
+   :notes: Here they are:
 
    $ tree
 
@@ -72,7 +72,7 @@ regular status reports should become a habit in the wake of ``DataLad-101``.
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: What has happened to our dataset now with this new content? We can use datalad status to find out:
+   :notes: What has happened to our dataset now with this new content? We can use datalad status to find out:
 
    $ datalad status
 
@@ -93,7 +93,7 @@ with the ``-m`` option:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: ATM the files are untracked and thus unknown to any version control system. In order to version control the PDFs we need to save them. We attach a meaningful summary of this with the -m option:
+   :notes: ATM the files are untracked and thus unknown to any version control system. In order to version control the PDFs we need to save them. We attach a meaningful summary of this with the -m option:
 
    $ datalad save -m "add books on Python and Unix to read later"
 
@@ -130,7 +130,7 @@ by typing ``q``, navigate with up and down arrow keys):
    :lines: 1-20
    :emphasize-lines: 3-4, 6, 8, 12, 16, 20
    :cast: 01_dataset_basics
-   :caption: Save command reports what has been added to the dataset. Now we can see how this action looks like in our dataset's history:
+   :notes: Save command reports what has been added to the dataset. Now we can see how this action looks like in our dataset's history:
 
    $ git log -p -n 1
 
@@ -189,7 +189,7 @@ Let's try this by adding yet another book, a good reference work about git,
    :workdir: dl-101/DataLad-101
    :realcommand: cd books && wget -nv https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf && cd ../
    :cast: 01_dataset_basics
-   :caption: Its inconvenient that we saved two books together - we should have saved them as independent modifications of the dataset. To see how single modifications can be saved, let's download another book
+   :notes: Its inconvenient that we saved two books together - we should have saved them as independent modifications of the dataset. To see how single modifications can be saved, let's download another book
 
    $ cd books
    $ wget https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf
@@ -201,7 +201,7 @@ Let's try this by adding yet another book, a good reference work about git,
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: Check the dataset state with the status command frequently
+   :notes: Check the dataset state with the status command frequently
 
    $ datalad status
 
@@ -211,7 +211,7 @@ Let's :command:`datalad save` precisely this file by specifying its path after t
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: To save a single modification, provide a path to it!
+   :notes: To save a single modification, provide a path to it!
 
    $ datalad save -m "add reference book about git" books/progit.pdf
 
@@ -235,7 +235,7 @@ A :command:`datalad status` should now be empty, and our dataset's history shoul
    :workdir: dl-101/DataLad-101
    :language: console
    :cast: 01_dataset_basics
-   :caption: Let's view the growing history (concise with the --oneline option):
+   :notes: Let's view the growing history (concise with the --oneline option):
 
    # lets make the output a bit more concise with the --oneline option
    $ git log --oneline

--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -61,7 +61,7 @@ root of your ``DataLad-101`` dataset:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: Let's find out how we can modify files in dataset. Lets create a text file with notes about the DataLad commands we learned. (maybe explain here docs)
+   :notes: Let's find out how we can modify files in dataset. Lets create a text file with notes about the DataLad commands we learned. (maybe explain here docs)
 
    $ cat << EOT > notes.txt
    One can create a new dataset with 'datalad create [--description] PATH'.
@@ -75,7 +75,7 @@ Run :command:`datalad status` to confirm that there is a new, untracked file:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: As expected, there is a new file in the dataset. At first the file is untracked. We can save without a path specification because it is the only existing modification
+   :notes: As expected, there is a new file in the dataset. At first the file is untracked. We can save without a path specification because it is the only existing modification
 
    $ datalad status
 
@@ -100,7 +100,7 @@ to accomplish this, but you can take any editor of your choice.
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: Now let's start to modify this text file by adding more notes to it. Think about this being a code file that you add functions to:
+   :notes: Now let's start to modify this text file by adding more notes to it. Think about this being a code file that you add functions to:
 
    $ cat << EOT >> notes.txt
    The command "datalad save [-m] PATH" saves the file
@@ -124,7 +124,7 @@ and save the file in DataLad:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: The modification can simply be saved as well
+   :notes: The modification can simply be saved as well
 
    $ datalad save -m "add note on datalad save"
 
@@ -140,7 +140,7 @@ You can get out of it by pressing ``q``.
    :lines: 1-28
    :emphasize-lines: 6, 25, 27
    :cast: 01_dataset_basics
-   :caption: An the history gives an accurate record of what happened to this file
+   :notes: An the history gives an accurate record of what happened to this file
 
    $ git log -p -n 2
 

--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -57,7 +57,7 @@ called recordings.
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: The next challenge is to install an existing dataset from the web as a subdataset. First, we create a location for this
+   :notes: The next challenge is to install an existing dataset from the web as a subdataset. First, we create a location for this
 
    # we are in the root of DataLad-101
    $ mkdir recordings
@@ -78,7 +78,7 @@ line.
    :workdir: dl-101/DataLad-101/
    :realcommand: datalad install -d . -s https://github.com/datalad-datasets/longnow-podcasts.git recordings/longnow
    :cast: 01_dataset_basics
-   :caption: We need to install the dataset as a subdataset. For this, we use the datalad install command with a --dataset option and --source option as well as a path. Else the dataset would not be registered as a subdataset!
+   :notes: We need to install the dataset as a subdataset. For this, we use the datalad install command with a --dataset option and --source option as well as a path. Else the dataset would not be registered as a subdataset!
 
    $ datalad install --dataset . \
    --source https://github.com/datalad-datasets/longnow-podcasts.git recordings/longnow
@@ -125,7 +125,7 @@ Here is the repository structure:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 01_dataset_basics
-   :caption: Let's take a look at the directory structure after the installation
+   :notes: Let's take a look at the directory structure after the installation
 
    $ tree -d   # we limit the output to directories
 
@@ -141,7 +141,7 @@ excerpt).
    :workdir: dl-101/DataLad-101/
    :lines: 1-15
    :cast: 01_dataset_basics
-   :caption: And now lets look into these seminar series folders: There are hundreds of mp3 files, yet the download only took a few seconds! How can that be?
+   :notes: And now lets look into these seminar series folders: There are hundreds of mp3 files, yet the download only took a few seconds! How can that be?
 
    $ cd recordings/longnow/Long_Now__Seminars_About_Long_term_Thinking
    $ ls
@@ -170,7 +170,7 @@ small in size:
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow/Long_Now__Seminars_About_Long_term_Thinking
    :cast: 01_dataset_basics
-   :caption: Upon installation of a DataLad dataset, DataLad retrieves only small files and metadata. Therefore the dataset is tiny in size. The files are non-functional now atm (Try opening one)
+   :notes: Upon installation of a DataLad dataset, DataLad retrieves only small files and metadata. Therefore the dataset is tiny in size. The files are non-functional now atm (Try opening one)
 
    $ cd ../      # in longnow/
    $ du -sh      # Unix command to show size of contents
@@ -201,7 +201,7 @@ For this, we supply an additional option to :command:`datalad status`. Make sure
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
    :cast: 01_dataset_basics
-   :caption: But how large would the dataset be if we had all the content?
+   :notes: But how large would the dataset be if we had all the content?
 
    $ datalad status --annex
 
@@ -229,7 +229,7 @@ First, we get one of the recordings in the dataset -- take any one of your choic
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
    :cast: 01_dataset_basics
-   :caption: Now let's finally get some content in this dataset. This is done with the datalad get command
+   :notes: Now let's finally get some content in this dataset. This is done with the datalad get command
 
    $ datalad get Long_Now__Seminars_About_Long_term_Thinking/2003_11_15__Brian_Eno__The_Long_Now.mp3
 
@@ -255,7 +255,7 @@ has a nice summary:
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
    :cast: 01_dataset_basics
-   :caption: Datalad status can also summarize how much of the content is already present locally:
+   :notes: Datalad status can also summarize how much of the content is already present locally:
 
    $ datalad status --annex all
 
@@ -269,7 +269,7 @@ DataLad's fancy progress bars.
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
    :cast: 01_dataset_basics
-   :caption: Let's get a few more files. Note how already obtained files are not downloaded again:
+   :notes: Let's get a few more files. Note how already obtained files are not downloaded again:
 
    $ datalad get Long_Now__Seminars_About_Long_term_Thinking/2003_11_15__Brian_Eno__The_Long_Now.mp3 \
    Long_Now__Seminars_About_Long_term_Thinking/2003_12_13__Peter_Schwartz__The_Art_Of_The_Really_Long_View.mp3 \
@@ -293,7 +293,7 @@ history from first to most recent commit):
    :emphasize-lines: 3
    :lines: 1-13
    :cast: 01_dataset_basics
-   :caption: On Dataset nesting: You have seen the history of DataLad-101. But the subdataset has a standalone history as well! We can find out who created it!
+   :notes: On Dataset nesting: You have seen the history of DataLad-101. But the subdataset has a standalone history as well! We can find out who created it!
 
 
    $ git log --reverse
@@ -313,7 +313,7 @@ modification.
    :language: console
    :workdir: dl-101/DataLad-101/recordings/longnow
    :cast: 01_dataset_basics
-   :caption: We can make a note about this:
+   :notes: We can make a note about this:
 
    # in the root of DataLad-101:
    $ cd ../../

--- a/docs/basics/101-106-nesting.rst
+++ b/docs/basics/101-106-nesting.rst
@@ -38,7 +38,7 @@ this excerpt).
    :emphasize-lines: 24
    :realcommand: git log -p
    :cast: 01_dataset_basics
-   :caption: The superdataset only stores the version of the subdataset.  Let's take a look into how the superdataset's history looks like
+   :notes: The superdataset only stores the version of the subdataset.  Let's take a look into how the superdataset's history looks like
 
    $ git log -p -n 2
 
@@ -66,7 +66,7 @@ subdataset's history:
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 3
    :cast: 01_dataset_basics
-   :caption: We can find this shasum in the subdatasets history: it's the most recent change
+   :notes: We can find this shasum in the subdatasets history: it's the most recent change
 
    $ cd recordings/longnow
    $ git log --oneline

--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -54,7 +54,7 @@ superdataset:
 .. runrecord:: _examples/DL-101-108-101
    :language: console
    :workdir: dl-101
-   :caption: its impossible to remember how a large data analysis produced which result for a human, but not for datalad. Start with yoda principles and structure.
+   :notes: its impossible to remember how a large data analysis produced which result for a human, but not for datalad. Start with yoda principles and structure.
    :cast: 02_reproducible_execution
    :realcommand: cd DataLad-101 && mkdir code && tree -d
 
@@ -71,7 +71,7 @@ will write it into the script.
 .. runrecord:: _examples/DL-101-108-102
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: First we will create a script to execute. Let's make one that summarizes the podcasts in the longnow dataset
+   :notes: First we will create a script to execute. Let's make one that summarizes the podcasts in the longnow dataset
    :cast: 02_reproducible_execution
 
    $ cat << EOT > code/list_titles.sh
@@ -92,7 +92,7 @@ Save this script to the dataset.
 .. runrecord:: _examples/DL-101-108-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: We have to save the script first: status and save
+   :notes: We have to save the script first: status and save
    :cast: 02_reproducible_execution
 
    $ datalad status
@@ -100,7 +100,7 @@ Save this script to the dataset.
 .. runrecord:: _examples/DL-101-108-104
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: ... preferably with a helpful commit message
+   :notes: ... preferably with a helpful commit message
    :cast: 02_reproducible_execution
 
    $ datalad save -m "Add simple script to write a list of podcast speakers and titles"
@@ -134,7 +134,7 @@ command from the root of ``DataLad-101``.
 .. runrecord:: _examples/DL-101-108-105
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: The datalad run command records a command's impact on a dataset. We try it in the most simple way:
+   :notes: The datalad run command records a command's impact on a dataset. We try it in the most simple way:
    :cast: 02_reproducible_execution
 
    $ datalad run -m "create a list of podcast titles" "bash code/list_titles.sh > recordings/podcasts.tsv"
@@ -157,7 +157,7 @@ Let's take a look into the history:
    :workdir: dl-101/DataLad-101
    :lines: 1-30
    :emphasize-lines: 6, 11, 25
-   :caption: Let's now check what has been written into the history. (runrecord)
+   :notes: Let's now check what has been written into the history. (runrecord)
    :cast: 02_reproducible_execution
 
    $ git log -p -1
@@ -196,7 +196,7 @@ command as before, and check whether anything in your log changes:
 .. runrecord:: _examples/DL-101-108-107
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: What happens if we do the same again?
+   :notes: What happens if we do the same again?
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Try again to create a list of podcast titles" "bash code/list_titles.sh > recordings/podcasts.tsv"
@@ -206,7 +206,7 @@ command as before, and check whether anything in your log changes:
    :workdir: dl-101/DataLad-101
    :lines: 1-5
    :emphasize-lines: 2
-   :caption: as the result is byte-identical, there is no new commit
+   :notes: as the result is byte-identical, there is no new commit
    :cast: 02_reproducible_execution
 
    $ git log --oneline

--- a/docs/basics/101-109-rerun.rst
+++ b/docs/basics/101-109-rerun.rst
@@ -13,7 +13,7 @@ Let's actually take a look into this file now:
    :language: console
    :workdir: dl-101/DataLad-101
    :lines: 1-30
-   :caption: let's take a look into our output file:
+   :notes: let's take a look into our output file:
    :cast: 02_reproducible_execution
 
    $ less recordings/podcasts.tsv
@@ -35,7 +35,7 @@ with the following, fixed script:
    :language: console
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 2
-   :caption: Dang, we made a mistake in our script: we only listed a part of the podcasts! Let's fix the script:
+   :notes: Dang, we made a mistake in our script: we only listed a part of the podcasts! Let's fix the script:
    :cast: 02_reproducible_execution
 
    $ cat << EOT >| code/list_titles.sh
@@ -96,7 +96,7 @@ So you go ahead and find the commit :term:`shasum` in your history:
    :workdir: dl-101/DataLad-101
    :lines: 1-12
    :emphasize-lines: 8
-   :caption: We could execute the same command as before. However, we can also let DataLad take care of it, and use the datalad rerun command.
+   :notes: We could execute the same command as before. However, we can also let DataLad take care of it, and use the datalad rerun command.
    :cast: 02_reproducible_execution
 
    $ git log -2
@@ -109,7 +109,7 @@ here we're using all of them).
    :language: console
    :workdir: dl-101/DataLad-101
    :realcommand: echo "$ datalad rerun $(git rev-parse HEAD~1)" && datalad rerun $(git rev-parse HEAD~1)
-   :caption: We'll find the shasum of the run commit and plug it into rerun
+   :notes: We'll find the shasum of the run commit and plug it into rerun
    :cast: 02_reproducible_execution
 
 Now DataLad has made use of the ``run record``, and
@@ -128,7 +128,7 @@ it will also not be recorded in the history.
    :language: console
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 4
-   :caption: how does a rerun look in the history?
+   :notes: how does a rerun look in the history?
    :cast: 02_reproducible_execution
 
    $ git log -1
@@ -156,7 +156,7 @@ of the dataset and the previous commit (called "``HEAD~1``" in Git terminology):
 .. runrecord:: _examples/DL-101-108-116
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: The datalad diff command can help us find out what changed between the last two commands:
+   :notes: The datalad diff command can help us find out what changed between the last two commands:
    :cast: 02_reproducible_execution
 
    $ datalad diff --to HEAD~1
@@ -168,7 +168,7 @@ diff view by pressing ``q``):
 .. runrecord:: _examples/DL-101-108-117
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: The git diff command has even more insights:
+   :notes: The git diff command has even more insights:
    :cast: 02_reproducible_execution
 
    $ git diff HEAD~1
@@ -183,7 +183,7 @@ Quickly create a note about these two helpful commands in ``notes.txt``:
 .. runrecord:: _examples/DL-101-108-118
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Let's make a note about this.
+   :notes: Let's make a note about this.
    :cast: 02_reproducible_execution
 
    $ cat << EOT >> notes.txt
@@ -225,7 +225,7 @@ give the file path to :command:`git log` (prefixed by ``--``):
 .. runrecord:: _examples/DL-101-108-120
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: An amazing thing is that DataLad captured all of the provenance of the output file, and we get use git tools to find out about it
+   :notes: An amazing thing is that DataLad captured all of the provenance of the output file, and we get use git tools to find out about it
    :cast: 02_reproducible_execution
 
    $ git log -- recordings/podcasts.tsv
@@ -243,7 +243,7 @@ But prior to that, make a note about :command:`datalad run` and :command:`datala
 .. runrecord:: _examples/DL-101-108-121
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Another final note on run and rerun
+   :notes: Another final note on run and rerun
    :cast: 02_reproducible_execution
 
    $ cat << EOT >> notes.txt
@@ -263,7 +263,7 @@ Finally, save this note.
 .. runrecord:: _examples/DL-101-108-122
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Another final note on run and rerun
+   :notes: Another final note on run and rerun
    :cast: 02_reproducible_execution
 
    $ datalad save -m "add note on basic datalad run and datalad rerun"

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -39,7 +39,7 @@ in the hidden paths
 .. runrecord:: _examples/DL-101-110-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: We saw a very simple datalad run. Now we're going to extend it with useful options. For this, we'll try to resize a logo in the meta data of the subdataset
+   :notes: We saw a very simple datalad run. Now we're going to extend it with useful options. For this, we'll try to resize a logo in the meta data of the subdataset
    :cast: 02_reproducible_execution
 
    $ ls recordings/longnow/.datalad/feed_metadata/*jpg
@@ -68,7 +68,7 @@ when you copy them formatted like this.
    :language: console
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 4
-   :caption: This command resizes the logo to 400 by 400 px.
+   :notes: This command resizes the logo to 400 by 400 px.
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -113,7 +113,7 @@ prior to running the command.
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 8, 11, 16
    :realcommand: datalad run --input "recordings/longnow/.datalad/feed_metadata/logo_salt.jpg" "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-   :caption: The --input option makes sure that all content is retrieved prior to command execution.
+   :notes: The --input option makes sure that all content is retrieved prior to command execution.
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -163,7 +163,7 @@ To establish best-practices, let's specify the input even though it is already p
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 10
    :realcommand: datalad run --input "recordings/longnow/.datalad/feed_metadata/logo_salt.jpg" "convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-   :caption: Maybe 400x400 is too small. We should try 450x450. Can we use a datalad rerun for this? (no)
+   :notes: Maybe 400x400 is too small. We should try 450x450. Can we use a datalad rerun for this? (no)
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -218,7 +218,7 @@ Let us check out what it does:
 .. runrecord:: _examples/DL-101-111-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: The created output is protected from accidental modifications, we have to unlock it first
+   :notes: The created output is protected from accidental modifications, we have to unlock it first
    :cast: 02_reproducible_execution
 
    $ datalad unlock recordings/salt_logo_small.jpg
@@ -229,7 +229,7 @@ feel the urge to run a :command:`datalad status` on this:
 .. runrecord:: _examples/DL-101-111-102
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: How does the file look like after an unlock?
+   :notes: How does the file look like after an unlock?
    :cast: 02_reproducible_execution
 
    $ datalad status
@@ -242,7 +242,7 @@ on. Hastily, you run the command right from the terminal:
 .. runrecord:: _examples/DL-101-111-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: In principle, you could rerun the command now, outside of any datalad run. The unlocked output can be overwritten
+   :notes: In principle, you could rerun the command now, outside of any datalad run. The unlocked output can be overwritten
    :cast: 02_reproducible_execution
 
    $ convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg
@@ -257,7 +257,7 @@ run a :command:`datalad save`."
 .. runrecord:: _examples/DL-101-111-104
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Afterwards you'd need to save, to lock everything again
+   :notes: Afterwards you'd need to save, to lock everything again
    :cast: 02_reproducible_execution
 
    $ datalad save -m "resized picture by hand"
@@ -294,7 +294,7 @@ flag and see their magic, let's crop the second logo, ``logo_interval.jpg``:
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 14, 19
    :realcommand: datalad run --input "recordings/longnow/.datalad/feed_metadata/logo_interval.jpg" --output "recordings/interval_logo_small.jpg" "convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_interval.jpg recordings/interval_logo_small.jpg"
-   :caption: but it is way easier to just use the --output option of datalad run: it takes care of unlocking if necessary
+   :notes: but it is way easier to just use the --output option of datalad run: it takes care of unlocking if necessary
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -331,7 +331,7 @@ Make a note of this behavior in your ``notes.txt`` file.
 .. runrecord:: _examples/DL-101-111-106
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Finally, lets add a note on this
+   :notes: Finally, lets add a note on this
    :cast: 02_reproducible_execution
 
    $ cat << EOT >> notes.txt

--- a/docs/basics/101-112-run4.rst
+++ b/docs/basics/101-112-run4.rst
@@ -15,7 +15,7 @@ you think.
    :language: console
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 5
-   :caption: mhh, 450x450px seems a bit large, we have to go back to 400. Lets make yet another, complete run command
+   :notes: mhh, 450x450px seems a bit large, we have to go back to 400. Lets make yet another, complete run command
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -34,7 +34,7 @@ Run a :command:`datalad status` to see what is meant by this:
 .. runrecord:: _examples/DL-101-112-102
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: What happened? The dataset is not "clean"
+   :notes: What happened? The dataset is not "clean"
    :cast: 02_reproducible_execution
 
    $ datalad status
@@ -63,7 +63,7 @@ First, save the changes,
 .. runrecord:: _examples/DL-101-112-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: One way to prevent this is to have a clean dataset state
+   :notes: One way to prevent this is to have a clean dataset state
    :cast: 02_reproducible_execution
 
    $ datalad save -m "add additional notes on run options"
@@ -73,7 +73,7 @@ and then try again:
 .. runrecord:: _examples/DL-101-112-104
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: let's try again with a clean dataset
+   :notes: let's try again with a clean dataset
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -90,7 +90,7 @@ to a :command:`datalad run`:
 .. runrecord:: _examples/DL-101-112-105
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: we'll put this into a note (which we won't save)
+   :notes: we'll put this into a note (which we won't save)
    :cast: 02_reproducible_execution
 
    $ cat << EOT >> notes.txt
@@ -110,7 +110,7 @@ addition to the note.
 .. runrecord:: _examples/DL-101-112-106
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: alternatively, the --explicit flag allows run despite an unclean dataset. However, this will only save changes to --output
+   :notes: alternatively, the --explicit flag allows run despite an unclean dataset. However, this will only save changes to --output
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \
@@ -130,7 +130,7 @@ is still modified:
 .. runrecord:: _examples/DL-101-112-110
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: the previously modified ``notes.txt`` is still modified:
+   :notes: the previously modified ``notes.txt`` is still modified:
    :cast: 02_reproducible_execution
 
    $ datalad status
@@ -140,7 +140,7 @@ Add an additional note on the ``--explicit`` flag, and finally save your changes
 .. runrecord:: _examples/DL-101-112-107
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: we note this down
+   :notes: we note this down
    :cast: 02_reproducible_execution
 
    $ cat << EOT >> notes.txt
@@ -153,7 +153,7 @@ Add an additional note on the ``--explicit`` flag, and finally save your changes
 .. runrecord:: _examples/DL-101-112-108
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: and save it
+   :notes: and save it
    :cast: 02_reproducible_execution
 
    $ datalad save -m "add note on clean datasets"
@@ -166,7 +166,7 @@ commit to see a :term:`run record` with more content:
    :workdir: dl-101/DataLad-101
    :lines: 1, 24-50
    :emphasize-lines: 11, 15-17, 18-20
-   :caption: finally, lets see a more complex runrecord
+   :notes: finally, lets see a more complex runrecord
    :cast: 02_reproducible_execution
 
    $ git log -p -2

--- a/docs/basics/101-114-txt2git.rst
+++ b/docs/basics/101-114-txt2git.rst
@@ -33,7 +33,7 @@ The second commit message in our datasets history summarizes this:
    :workdir: dl-101
    :emphasize-lines: 3
    :realcommand: cd DataLad-101 && git log --reverse --oneline
-   :caption: Confusing: Why could we modify the tsv file without unlocking? The reason is in the dataset configuration with text2git
+   :notes: Confusing: Why could we modify the tsv file without unlocking? The reason is in the dataset configuration with text2git
    :cast: 03_git_annex_basics
 
    $ git log --reverse --oneline

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -30,7 +30,7 @@ them. We'll take a look together, using the ``books/`` directory as an example:
 .. runrecord:: _examples/DL-101-115-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: We have to talk about symlinks now.
+   :notes: We have to talk about symlinks now.
    :cast: 03_git_annex_basics
 
    # in the root of DataLad-101
@@ -95,7 +95,7 @@ your standard PDF reader).
    :language: console
    :workdir: dl-101/DataLad-101/books
    :realcommand: echo "evince $(readlink TLCL.pdf)"
-   :caption: we can just open the cryptic file path and it works just as any pdf!
+   :notes: we can just open the cryptic file path and it works just as any pdf!
    :cast: 03_git_annex_basics
 
 
@@ -114,7 +114,7 @@ small size of ~130 Bytes:
 .. runrecord:: _examples/DL-101-115-103
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: Symlinks are super small in size, just the amount of characters in the symlink!
+   :notes: Symlinks are super small in size, just the amount of characters in the symlink!
    :cast: 03_git_annex_basics
 
    $ ls -lah
@@ -233,7 +233,7 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    .. runrecord:: _examples/DL-101-115-104
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: how does the symlink relate to the shasum of the file?
+      :notes: how does the symlink relate to the shasum of the file?
       :cast: 03_git_annex_basics
 
       # take a look at the last part of the target path:
@@ -242,7 +242,7 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    .. runrecord:: _examples/DL-101-115-105
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: let's look at how the shasum would look like
+      :notes: let's look at how the shasum would look like
       :cast: 03_git_annex_basics
 
       # compare it to the checksum (here of type md5sum) of the PDF file and the subdirectory name
@@ -314,7 +314,7 @@ the superdataset.
 .. runrecord:: _examples/DL-101-115-106
    :workdir: dl-101/DataLad-101/books
    :language: console
-   :caption: understanding how symlinks work will help you with everyday file management operations.
+   :notes: understanding how symlinks work will help you with everyday file management operations.
    :cast: 03_git_annex_basics
 
    $ cd ../

--- a/docs/basics/101-116-sharelocal.rst
+++ b/docs/basics/101-116-sharelocal.rst
@@ -63,7 +63,7 @@ simplicity -- create a new directory, ``mock_user``, right next to it:
    :language: console
    :workdir: dl-101
    :realcommand: mkdir mock_user
-   :caption: (hope this works)
+   :notes: (hope this works)
    :cast: 04_collaboration
 
    $ cd ../
@@ -81,7 +81,7 @@ the dataset ``DataLad-101`` by specifying its path as a ``--source``
 .. runrecord:: _examples/DL-101-116-102
    :language: console
    :workdir: dl-101
-   :caption: We pretend to install the DataLad-101 dataset into a different users home directory. To do this, we use datalad install with a path
+   :notes: We pretend to install the DataLad-101 dataset into a different users home directory. To do this, we use datalad install with a path
    :cast: 04_collaboration
 
 
@@ -100,7 +100,7 @@ like. Before running the command, try to predict what you will see.
 .. runrecord:: _examples/DL-101-116-103
    :language: console
    :workdir: dl-101/mock_user
-   :caption: How do you think does the dataset look like
+   :notes: How do you think does the dataset look like
    :cast: 04_collaboration
 
    $ cd DataLad-101
@@ -145,7 +145,7 @@ To demonstrate this, you decide to examine the PDFs further.
 .. runrecord:: _examples/DL-101-116-104
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: how does it feel to get a file?
+   :notes: how does it feel to get a file?
    :cast: 04_collaboration
 
    $ datalad get books/progit.pdf
@@ -162,7 +162,7 @@ let's query Git-annex where its content is stored:
 .. runrecord:: _examples/DL-101-116-105
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: git-annex whereis to find out where content is stored
+   :notes: git-annex whereis to find out where content is stored
    :cast: 04_collaboration
 
    $ git annex whereis books/TLCL.pdf
@@ -219,7 +219,7 @@ you have to run a somewhat unexpected command:
 .. runrecord:: _examples/DL-101-116-106
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: how do we get the subdataset? currently it looks empty. --> a plain datalad install
+   :notes: how do we get the subdataset? currently it looks empty. --> a plain datalad install
    :cast: 04_collaboration
 
    $ datalad install recordings/longnow
@@ -230,7 +230,7 @@ Let's what has changed (excerpt):
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
    :lines: 1-30
-   :caption: what has changed? --> file metadata information!
+   :notes: what has changed? --> file metadata information!
    :cast: 04_collaboration
 
    $ tree
@@ -280,7 +280,7 @@ Write this note in "your own" (the original) ``DataLad-101`` dataset, though!
 .. runrecord:: _examples/DL-101-116-108
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: note in original DataLad-101 dataset
+   :notes: note in original DataLad-101 dataset
    :cast: 04_collaboration
 
    # navigate back into the original dataset

--- a/docs/basics/101-117-sharelocal2.rst
+++ b/docs/basics/101-117-sharelocal2.rst
@@ -34,7 +34,7 @@ Here is the output for the retrieved file:
 .. runrecord:: _examples/DL-101-117-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: More on how git-annex whereis behaves
+   :notes: More on how git-annex whereis behaves
    :cast: 04_collaboration
 
    # navigate back into the installed copy of DataLad-101
@@ -65,7 +65,7 @@ Let's see how this affects a :command:`datalad get`:
 .. runrecord:: _examples/DL-101-117-103
    :language: console
    :workdir: dl-101/mock_user/DataLad-101/recordings/longnow
-   :caption: Get a file thats present in original and one that is not
+   :notes: Get a file thats present in original and one that is not
    :cast: 04_collaboration
 
    # get the first file
@@ -104,7 +104,7 @@ this in the original ``DataLad-101`` directory, and don't forget to save it.
 .. runrecord:: _examples/DL-101-117-105
    :language: console
    :workdir: dl-101/mock_user/DataLad-101/recordings/longnow
-   :caption: a note in original dataset
+   :notes: a note in original dataset
    :cast: 04_collaboration
 
    # navigate back:

--- a/docs/basics/101-118-sharelocal3.rst
+++ b/docs/basics/101-118-sharelocal3.rst
@@ -42,7 +42,7 @@ want to run by taking a look into the history of the dataset
 .. runrecord:: _examples/DL-101-118-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: More cool things on shared datasets: rerunning run commands
+   :notes: More cool things on shared datasets: rerunning run commands
    :cast: 04_collaboration
 
    # navigate into the shared copy
@@ -52,7 +52,7 @@ want to run by taking a look into the history of the dataset
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
    :emphasize-lines: 4
-   :caption: find the shasum
+   :notes: find the shasum
    :cast: 04_collaboration
 
    # lets view the history
@@ -67,7 +67,7 @@ command:
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
    :realcommand: echo "$ datalad rerun $(git rev-parse HEAD~1)" && datalad rerun $(git rev-parse HEAD~1)
-   :caption: plug the shasum into a rerun command
+   :notes: plug the shasum into a rerun command
    :cast: 04_collaboration
 
 "This was so easy!" you exclaim. DataLad retrieved the missing

--- a/docs/basics/101-119-sharelocal4.rst
+++ b/docs/basics/101-119-sharelocal4.rst
@@ -32,7 +32,7 @@ installation in ``../mock_user/DataLad-101``:
 
 .. runrecord:: _examples/DL-101-119-101
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: On updating dataset. How do we get the updated notes from the original dataset?
+   :notes: On updating dataset. How do we get the updated notes from the original dataset?
    :cast: 04_collaboration
 
    # we are inside the installed copy
@@ -57,7 +57,7 @@ command (:manpage:`datalad-update` manual).
 .. runrecord:: _examples/DL-101-119-102
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: retrieve and integrate changes from origin with datalad update --merge
+   :notes: retrieve and integrate changes from origin with datalad update --merge
    :cast: 04_collaboration
 
    $ datalad update --merge
@@ -76,7 +76,7 @@ the previously missing changes are now present:
 .. runrecord:: _examples/DL-101-119-103
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: let's check whether the updates are there
+   :notes: let's check whether the updates are there
    :cast: 04_collaboration
 
    $ cat notes.txt
@@ -94,7 +94,7 @@ dataset to your own ``DataLad-101`` dataset:
 .. runrecord:: _examples/DL-101-119-104
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: note in original ds
+   :notes: note in original ds
    :cast: 04_collaboration
 
    # navigate back:
@@ -111,7 +111,7 @@ dataset to your own ``DataLad-101`` dataset:
 .. runrecord:: _examples/DL-101-119-105
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption:
+   :notes:
    :cast: 04_collaboration
 
    # save the changes

--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -44,7 +44,7 @@ and run the following command
 .. runrecord:: _examples/DL-101-121-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Let's make changes in the copy of the original ds
+   :notes: Let's make changes in the copy of the original ds
    :cast: 04_collaboration
 
    # navigate into the installed copy
@@ -61,7 +61,7 @@ Run a quick datalad status:
 .. runrecord:: _examples/DL-101-121-102
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: the download url command takes care of saving contents for you
+   :notes: the download url command takes care of saving contents for you
    :cast: 04_collaboration
 
    $ datalad status
@@ -75,7 +75,7 @@ here:
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
    :lines: 1-30
-   :caption: the ds copy has a change the original ds does not have:
+   :notes: the ds copy has a change the original ds does not have:
    :cast: 04_collaboration
 
    $ git log -1 -p
@@ -118,7 +118,7 @@ This registers your room mate's ``DataLad-101`` as a "sibling" (we will call it
 .. runrecord:: _examples/DL-101-121-104
    :language: console
    :workdir: dl-101/mock_user/DataLad-101
-   :caption: To allow updates from copy to original we have to configure the copy as a sibling of the original
+   :notes: To allow updates from copy to original we have to configure the copy as a sibling of the original
    :cast: 04_collaboration
 
    $ cd ../../DataLad-101
@@ -144,7 +144,7 @@ is now known to your own dataset as "roommate"
 .. runrecord:: _examples/DL-101-121-105
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: we can check which siblings the dataset has
+   :notes: we can check which siblings the dataset has
    :cast: 04_collaboration
 
    $ datalad siblings
@@ -185,7 +185,7 @@ the ``--merge`` option.
 .. runrecord:: _examples/DL-101-121-106
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: now we can update. Problem: how do we know whether we want the changes? --> plain datalad update
+   :notes: now we can update. Problem: how do we know whether we want the changes? --> plain datalad update
    :cast: 04_collaboration
 
    $ datalad update -s roommate
@@ -203,7 +203,7 @@ he added is not yet in your ``code/`` directory:
 .. runrecord:: _examples/DL-101-121-107
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: no file changes there yet, but where are they?
+   :notes: no file changes there yet, but where are they?
    :cast: 04_collaboration
 
    $ ls code/
@@ -235,7 +235,7 @@ the former for a different lecture:
 .. runrecord:: _examples/DL-101-121-108
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: on a different branch: remotes/roommate/master. Do a git remote -v here
+   :notes: on a different branch: remotes/roommate/master. Do a git remote -v here
    :cast: 04_collaboration
 
    $ datalad diff --to remotes/roommate/master
@@ -247,7 +247,7 @@ that there is a difference in ``notes.txt``! Let's ask
 .. runrecord:: _examples/DL-101-121-109
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: also git diff
+   :notes: also git diff
    :cast: 04_collaboration
 
    $ git diff remotes/roommate/master
@@ -277,7 +277,7 @@ of your room mate's dataset, but you incorporate all changes he made
 .. runrecord:: _examples/DL-101-121-110
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: no we can safely merge
+   :notes: no we can safely merge
    :cast: 04_collaboration
 
    $ datalad update --merge -s roommate
@@ -289,7 +289,7 @@ directory and also peek into the history:
 .. runrecord:: _examples/DL-101-121-111
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: check for the updated files... they are there!
+   :notes: check for the updated files... they are there!
    :cast: 04_collaboration
 
    $ ls code/
@@ -299,7 +299,7 @@ directory and also peek into the history:
    :lines: 1-6
    :emphasize-lines: 2, 4
    :workdir: dl-101/DataLad-101
-   :caption: and here is the summary in the log
+   :notes: and here is the summary in the log
    :cast: 04_collaboration
 
    $ git log --oneline
@@ -324,7 +324,7 @@ Create a note about this, and save it.
 .. runrecord:: _examples/DL-101-121-113
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: write a note
+   :notes: write a note
    :cast: 04_collaboration
 
    $ cat << EOT >> notes.txt

--- a/docs/basics/101-140-filesystem.rst
+++ b/docs/basics/101-140-filesystem.rst
@@ -41,7 +41,7 @@ moving a file, and uses the :command:`mv` command.
 .. runrecord:: _examples/DL-101-140-101
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: Let's look into file system operations. What does renaming does to a file that is symlinked?
+   :notes: Let's look into file system operations. What does renaming does to a file that is symlinked?
    :cast: 03_git_annex_basics
 
    $ cd books/
@@ -57,7 +57,7 @@ But let's see what changed in the dataset with this operation:
 .. runrecord:: _examples/DL-101-140-102
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: how does datalad see this? (deleted and untracked -- weird!!)
+   :notes: how does datalad see this? (deleted and untracked -- weird!!)
    :cast: 03_git_annex_basics
 
    $ datalad status
@@ -75,7 +75,7 @@ under the hood.
 .. runrecord:: _examples/DL-101-140-103
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: datalad save rectifies the weird status
+   :notes: datalad save rectifies the weird status
    :cast: 03_git_annex_basics
 
    $ datalad save -m "rename the book"
@@ -87,7 +87,7 @@ renamed, and will summarize this nicely in the resulting commit:
    :language: console
    :workdir: dl-101/DataLad-101/books
    :emphasize-lines: 8-11
-   :caption: and this is how it looks like in the history
+   :notes: and this is how it looks like in the history
    :cast: 03_git_annex_basics
 
    $ git log -1 -p
@@ -122,7 +122,7 @@ section. If you are a Git user, you will be very familiar with it.
    .. runrecord:: _examples/DL-101-140-105
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: We can also rename with git tools. first: reset history
+      :notes: We can also rename with git tools. first: reset history
       :cast: 03_git_annex_basics
 
       $ git reset --hard HEAD~1
@@ -135,7 +135,7 @@ section. If you are a Git user, you will be very familiar with it.
    .. runrecord:: _examples/DL-101-140-106
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: we use "git mv" instead of "mv" to rename
+      :notes: we use "git mv" instead of "mv" to rename
       :cast: 03_git_annex_basics
 
       $ git mv TLCL.pdf The_Linux_Command_Line.pdf
@@ -143,7 +143,7 @@ section. If you are a Git user, you will be very familiar with it.
    .. runrecord:: _examples/DL-101-140-107
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: how does the modification appear to datalad now?
+      :notes: how does the modification appear to datalad now?
       :cast: 03_git_annex_basics
 
       $ datalad status
@@ -155,7 +155,7 @@ section. If you are a Git user, you will be very familiar with it.
    .. runrecord:: _examples/DL-101-140-108
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: how does the modification appear to git?
+      :notes: how does the modification appear to git?
       :cast: 03_git_annex_basics
 
       $ git status
@@ -169,7 +169,7 @@ section. If you are a Git user, you will be very familiar with it.
    .. runrecord:: _examples/DL-101-140-109
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: git mv put the modification to the staging area, we need to commit
+      :notes: git mv put the modification to the staging area, we need to commit
       :cast: 03_git_annex_basics
 
       $ git commit -m "rename book"
@@ -186,7 +186,7 @@ Let's revert this now, to have a clean history.
 .. runrecord:: _examples/DL-101-140-110
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: (reverting again for clean history)
+   :notes: (reverting again for clean history)
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -202,7 +202,7 @@ of the superdataset:
 .. runrecord:: _examples/DL-101-140-120
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: Renaming was easy. How does moving files into different directories look like?
+   :notes: Renaming was easy. How does moving files into different directories look like?
    :cast: 03_git_annex_basics
 
    $ mv TLCL.pdf ../TLCL.pdf
@@ -218,7 +218,7 @@ at the symlink:
 .. runrecord:: _examples/DL-101-140-121
    :language: console
    :workdir: dl-101/DataLad-101/books
-   :caption: currently the symlink is broken! it points into nowhere
+   :notes: currently the symlink is broken! it points into nowhere
    :cast: 03_git_annex_basics
 
    $ cd ../
@@ -237,7 +237,7 @@ rectify this as well:
 .. runrecord:: _examples/DL-101-140-122
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: but a save rectifies it
+   :notes: but a save rectifies it
    :cast: 03_git_annex_basics
 
    $ datalad save -m "moved book into root"
@@ -259,7 +259,7 @@ the best option to turn to.
    .. runrecord:: _examples/DL-101-140-123
       :language: console
       :workdir: dl-101/DataLad-101/books
-      :caption: moving files across directory levels is a content change because the symlink changes!
+      :notes: moving files across directory levels is a content change because the symlink changes!
       :cast: 03_git_annex_basics
 
       $ git log -1 -p
@@ -288,7 +288,7 @@ Finally, let's clean up:
 .. runrecord:: _examples/DL-101-140-124
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: (reset history)
+   :notes: (reset history)
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -303,7 +303,7 @@ command ``cp`` to copy.
 .. runrecord:: _examples/DL-101-140-130
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: renaming and moving was fine, how about copying?
+   :notes: renaming and moving was fine, how about copying?
    :cast: 03_git_annex_basics
 
    $ cp books/TLCL.pdf copyofTLCL.pdf
@@ -315,7 +315,7 @@ file. Let's save it:
 .. runrecord:: _examples/DL-101-140-131
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: status says there's an untracked file, let's save it
+   :notes: status says there's an untracked file, let's save it
    :cast: 03_git_annex_basics
 
 
@@ -324,7 +324,7 @@ file. Let's save it:
 .. runrecord:: _examples/DL-101-140-132
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: That's it!
+   :notes: That's it!
    :cast: 03_git_annex_basics
 
    $ git log -1 -p
@@ -347,7 +347,7 @@ That's it.
    .. runrecord:: _examples/DL-101-140-133
       :language: console
       :workdir: dl-101/DataLad-101
-      :caption: A cool thing is that the two identical files link to the same place in the object tree
+      :notes: A cool thing is that the two identical files link to the same place in the object tree
       :cast: 03_git_annex_basics
 
       $ ls -l copyofTLCL.pdf
@@ -369,7 +369,7 @@ Finally, let's clean up:
 .. runrecord:: _examples/DL-101-140-134
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: (reset history)
+   :notes: (reset history)
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -388,7 +388,7 @@ Let's for example rename the ``books`` directory:
 .. runrecord:: _examples/DL-101-140-150
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: renaming and moving subdirectories and subdatasets can be a minefield, but is usually okay: let's change the name of books to readings
+   :notes: renaming and moving subdirectories and subdatasets can be a minefield, but is usually okay: let's change the name of books to readings
    :cast: 03_git_annex_basics
 
    $ mv books/ readings
@@ -397,7 +397,7 @@ Let's for example rename the ``books`` directory:
 .. runrecord:: _examples/DL-101-140-151
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: a save rectifies everything
+   :notes: a save rectifies everything
    :cast: 03_git_annex_basics
 
    $ datalad save -m "renamed directory"
@@ -410,7 +410,7 @@ Let's quickly clean this up:
 .. runrecord:: _examples/DL-101-140-152
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: (quickly clean up)
+   :notes: (quickly clean up)
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -421,7 +421,7 @@ superdataset:
 .. runrecord:: _examples/DL-101-140-153
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: But what about renaming or moving a subdataset? Let's move longnow into the root of the dataset
+   :notes: But what about renaming or moving a subdataset? Let's move longnow into the root of the dataset
    :cast: 03_git_annex_basics
 
    $ mv recordings/longnow .
@@ -430,7 +430,7 @@ superdataset:
 .. runrecord:: _examples/DL-101-140-154
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: a save will work and rectify things ...
+   :notes: a save will work and rectify things ...
    :cast: 03_git_annex_basics
 
    $ datalad save -m "moved subdataset"
@@ -453,7 +453,7 @@ to take care of the unwanted changes the commit reversal introduced.
 .. runrecord:: _examples/DL-101-140-156
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: BUT reverting such a commit in the history can be tricky atm:
+   :notes: BUT reverting such a commit in the history can be tricky atm:
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -461,7 +461,7 @@ to take care of the unwanted changes the commit reversal introduced.
 .. runrecord:: _examples/DL-101-140-157
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: we have to move the remaining subdataset contents back to the original place
+   :notes: we have to move the remaining subdataset contents back to the original place
    :cast: 03_git_annex_basics
 
    $ mv -f longnow recordings
@@ -625,7 +625,7 @@ by going back into the history of the dataset or reverting the removal commit:
 
 .. runrecord:: _examples/DL-101-140-170
    :workdir: dl-101/DataLad-101
-   :caption: 2 ways to remove a file from dataset: remove the file from the current state of the repository (the *worktree*) but keeping the content in the history, or remove content entirely from a dataset and its history.
+   :notes: 2 ways to remove a file from dataset: remove the file from the current state of the repository (the *worktree*) but keeping the content in the history, or remove content entirely from a dataset and its history.
    :cast: 03_git_annex_basics
 
    # download a file
@@ -648,7 +648,7 @@ This will lead to a dirty dataset status:
 .. runrecord:: _examples/DL-101-140-172
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: the deletion looks like this for datalad
+   :notes: the deletion looks like this for datalad
    :cast: 03_git_annex_basics
 
    $ datalad status
@@ -660,7 +660,7 @@ state, :command:`datalad save` will suffice:
 .. runrecord:: _examples/DL-101-140-173
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: a save will write the deletion of the file to history, but keep the content.
+   :notes: a save will write the deletion of the file to history, but keep the content.
    :cast: 03_git_annex_basics
 
    $ datalad save -m "removed file again"
@@ -672,7 +672,7 @@ If this commit is reverted, the file comes back to existence:
    :language: console
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 6
-   :caption: reverting the last action will bring back the file content:
+   :notes: reverting the last action will bring back the file content:
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~1
@@ -709,7 +709,7 @@ It is possible to drop the downloaded image, because thanks to
 .. runrecord:: _examples/DL-101-140-175
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: to drop content entirely we use datalad drop
+   :notes: to drop content entirely we use datalad drop
    :cast: 03_git_annex_basics
 
    $ datalad drop flowers.jpg
@@ -721,7 +721,7 @@ remaining symlink will fail, but the content can be obtained easily again with
 .. runrecord:: _examples/DL-101-140-176
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: this will keep the symlink, but drop the content, making the dataset lean
+   :notes: this will keep the symlink, but drop the content, making the dataset lean
    :cast: 03_git_annex_basics
 
    $ datalad get flowers.jpg
@@ -733,7 +733,7 @@ this by generating a random PDF file:
 .. runrecord:: _examples/DL-101-140-177
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: the content could be dropped bc the file was obtained with datalad, and dl knows where to retrieve the file again. If this isn't the case, datalad will complain. Let's try:
+   :notes: the content could be dropped bc the file was obtained with datalad, and dl knows where to retrieve the file again. If this isn't the case, datalad will complain. Let's try:
    :cast: 03_git_annex_basics
 
    $ convert xc:none -page Letter a.pdf
@@ -744,7 +744,7 @@ DataLad will safeguard dropping content that it can't retrieve again:
 .. runrecord:: _examples/DL-101-140-178
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: datalad does not know how to reobtain the file, so it complains
+   :notes: datalad does not know how to reobtain the file, so it complains
    :cast: 03_git_annex_basics
 
    $ datalad drop a.pdf
@@ -754,7 +754,7 @@ But with the ``--nocheck`` flag it will work:
 .. runrecord:: _examples/DL-101-140-179
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: the --nocheck flag lets us drop content anyway. This content is gone forever now, though!
+   :notes: the --nocheck flag lets us drop content anyway. This content is gone forever now, though!
    :cast: 03_git_annex_basics
 
    $ datalad drop --nocheck a.pdf
@@ -768,7 +768,7 @@ Finally, let's clean up:
 .. runrecord:: _examples/DL-101-140-180
    :workdir: dl-101/DataLad-101
    :language: console
-   :caption: let's clean up
+   :notes: let's clean up
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~2
@@ -789,7 +789,7 @@ will error if given a sub-*directory*, a file, or a top-level dataset.
 .. runrecord:: _examples/DL-101-140-160
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: To get rid of subdatasets one can either uninstall or remove them. let's install one to see:
+   :notes: To get rid of subdatasets one can either uninstall or remove them. let's install one to see:
    :cast: 03_git_annex_basics
 
    # Install a subdataset - the content is irrelevant, so why not a cloud :)
@@ -802,7 +802,7 @@ To uninstall the dataset, use
 .. runrecord:: _examples/DL-101-140-161
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: uninstall uninstalls the dataset, but it is still registered in the superdataset. a dl install will get the dataset again!
+   :notes: uninstall uninstalls the dataset, but it is still registered in the superdataset. a dl install will get the dataset again!
    :cast: 03_git_annex_basics
 
    $ datalad uninstall cloud
@@ -825,7 +825,7 @@ subsequently remove it with the :command:`datalad remove` command:
 .. runrecord:: _examples/DL-101-140-163
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: to completely remove the dataset, use datalad remove
+   :notes: to completely remove the dataset, use datalad remove
    :cast: 03_git_annex_basics
 
    $ datalad install cloud
@@ -842,7 +842,7 @@ Finally, after this last piece of information, let's clean up:
 .. runrecord:: _examples/DL-101-140-164
    :language: console
    :workdir: dl-101/DataLad-101
-   :caption: (clean up)
+   :notes: (clean up)
    :cast: 03_git_annex_basics
 
    $ git reset --hard HEAD~2

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -148,7 +148,7 @@ following prerequisites exist:
 - If ``:realcommand:`` options are specified, they will become the executable
   part of the cast. If note, the code snippet in the code-block of the
   ``runrecord`` will become the executable part of the cast.
-- An optional ``:caption:`` lets you add "speakernotes" for the cast.
+- An optional ``:notes:`` lets you add "speakernotes" for the cast.
 - Casts are produced upon ``make``, but only if the environment variable
   ``CAST_DIR`` is set.
   This should be a path that points to any directory in which casts should be
@@ -164,7 +164,7 @@ This is a fully specified ``runrecord``:
       :language: console
       :workdir: dl-101/DataLad-101
       :cast: dataset_basics   # name of the cast file (will be created/extended in CAST_DIR)
-      :caption: This is an optional speaker note only visible to presenter during the cast
+      :notes: This is an optional speaker note only visible to presenter during the cast
 
       # this is a comment and will be written to the cast
       $ this line will be executed and written to the cast

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ sphinxcontrib-websupport
 urllib3
 sphinxcontrib-svg2pdfconverter
 sphinxcontrib-plantuml
--e git://github.com/mih/autorunrecord.git@81afbbbb86909cd7e916ff912884377300ebd75f#egg=autorunrecord
+-e git://github.com/mih/autorunrecord.git@cf6a545152f49f0f9e59d3d66d8ffe1bdb46c823#egg=autorunrecord


### PR DESCRIPTION
This fixes #246, but it relies on https://github.com/mih/autorunrecord/pull/3 being merged first, and a subsequent update of ``requirements.txt`` to the latest version of ``autorunrecord``.

- [x] replace ``:caption:`` with ``:notes:``
- [x] update ``requirements.txt``