### PR TITLE
Add frontpage link to github repoof handbook

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -39,7 +39,8 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://datalad.org/">The DataLad Website</a></li>
+  <li><a href="https://datalad.org/">DataLad Website</a></li>
   <li><a href="http://docs.datalad.org/en/latest/#">Developer Docs</a></li>
-  <li><a href="https://github.com/datalad/datalad">Datalad on Github</a></li>
+  <li><a href="https://github.com/datalad/datalad">Datalad@Github</a></li>
+  <li><a href="https://github.com/datalad-handbook/book">Handbook@Github</a></li>
 </ul>


### PR DESCRIPTION
Plus slight change of link text style