### PR TITLE
Simplified overview on content lock with git-annex

### DIFF
--- a/docs/basics/101-114-txt2git.rst
+++ b/docs/basics/101-114-txt2git.rst
@@ -46,6 +46,12 @@ Well, procedurally it means that everything that is stored in Git-annex is
 content-locked, and everything that is stored in Git is not. You can modify
 content stored in Git straight away, without unlocking it first.
 
+.. figure:: ../artwork/src/git_vs_gitannex.svg
+   :alt: A simplified illustration of content lock in files managed by Git-annex.
+   :figwidth: 100%
+
+   A simplified overview of the tools that manage data in your dataset.
+
 That's easy enough.
 
 "So, first of all: If we hadn't provided the ``-c text2git`` argument, text files

--- a/docs/basics/101-114-txt2git.rst
+++ b/docs/basics/101-114-txt2git.rst
@@ -58,7 +58,7 @@ That's easy enough.
 would get content-locked, too?". "Yes, indeed. However, there are also ways to
 later change how file content is handled based on its type or size. It can be specified
 in the ``.gitattributes`` file, using ``annex.largefile`` options.
-But there will be a lecture on that."
+But there will be a lecture on that [#f1]_."
 
 "Okay, well, second: Isn't it much easier to just not bother with locking and
 unlocking, and have everything 'stored in Git'? Even if :command:`datalad run` takes care
@@ -87,3 +87,10 @@ use-case dependent comparison of the pros and cons. BUT: it is possible,
 and in many cases useful, and in later sections we will see how to use this
 feature. The next lecture, in any way, will guide us deeper into Git-annex,
 and improve our understanding a slight bit further.
+
+
+.. rubric:: Footnotes
+
+.. [#f1] If you can't wait to read about ``.gitattributes`` and other
+         configuration files, jump ahead to chapter "Tuning datasets to your needs",
+         starting with section :ref:`config`.


### PR DESCRIPTION
This adds a simplified graphic how git versus git-annex with regard to content-locked files.