### PR TITLE
Various minor fixes primarily to gain consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear and concise description of what the bug is.
 **Background information**
 Please provide us with everything relevant to make sense of the issue such as:
 1. Your operating system
-2. Your version of DataLad and Git-annex. Consider providing the output of a ``datalad wtf``.
+2. Your version of DataLad and git-annex. Consider providing the output of a ``datalad wtf``.
 3. Your browser [e.g., chrome, safari] and its version [e.g., 22]
 4. ...
 

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -41,6 +41,6 @@
 <ul>
   <li><a href="https://datalad.org/">DataLad Website</a></li>
   <li><a href="http://docs.datalad.org/en/latest/#">Developer Docs</a></li>
-  <li><a href="https://github.com/datalad/datalad">Datalad@Github</a></li>
-  <li><a href="https://github.com/datalad-handbook/book">Handbook@Github</a></li>
+  <li><a href="https://github.com/datalad/datalad">Datalad@GitHub</a></li>
+  <li><a href="https://github.com/datalad-handbook/book">Handbook@GitHub</a></li>
 </ul>

--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -102,7 +102,7 @@ an informative commit message yourself.
    :command:`datalad create` uses :command:`git init` and :command:`git-annex init`. Therefore,
    the DataLad dataset is a Git repository.
    Large file content in the
-   dataset in the annex is tracked with Git-annex. An ``ls -a``
+   dataset in the annex is tracked with git-annex. An ``ls -a``
    reveals that Git has secretly done its work:
 
    .. runrecord:: _examples/DL-101-101-104

--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -67,8 +67,8 @@ Because we are installing a dataset (the podcasts) within an existing dataset (t
 dataset), we supply the ``-d`` (``--dataset``) flag.
 This specifies the dataset to perform the operation on. Because we are in the root
 of the ``DataLad-101`` dataset, the pointer to the dataset is a ``.`` (which is Unix'
-way for saying "current directory"). The dataset to be installed lives on Github, and
-we can give its Github URL as a source (``-s``, ``--source``). Note that we line
+way for saying "current directory"). The dataset to be installed lives on GitHub, and
+we can give its GitHub URL as a source (``-s``, ``--source``). Note that we line
 break these examples with a ``\``. You can copy them as they are presented here into
 your terminal, but in your own work you can write commands like this into a single
 line.
@@ -299,7 +299,7 @@ history from first to most recent commit):
    $ git log --reverse
 
 But that's not all. The seminar series is ongoing, and more recordings can get added
-to the original repository shared on Github.
+to the original repository shared on GitHub.
 Because an installed dataset knows the dataset it was installed from,
 the locally installed dataset can simply be updated, and thus get the new recordings,
 should there be some. But we will see examples of this later in this handbook.

--- a/docs/basics/101-107-summary.rst
+++ b/docs/basics/101-107-summary.rst
@@ -54,7 +54,7 @@ and experienced the concept of modular nesting datasets.
 * If a dataset is installed inside of a dataset as a subdataset, the
   ``--dataset``/``-d`` option needs to specify the root of the superdataset.
 
-* The source can be a URL (for example of a Github repository, as in section :ref:`installds`), but also
+* The source can be a URL (for example of a GitHub repository, as in section :ref:`installds`), but also
   paths, or open data collections.
 
 * After installation, only small files and metadata about file availability are present locally.

--- a/docs/basics/101-107-summary.rst
+++ b/docs/basics/101-107-summary.rst
@@ -12,7 +12,7 @@ and making simple modifications *locally*.
 
     datalad create --description "here is a description" -c text2git PATH
 
-* Thanks to :term:`Git` and :term:`Git-annex`, the dataset has a history to track files and their
+* Thanks to :term:`Git` and :term:`git-annex`, the dataset has a history to track files and their
   modifications. Built-in Git tools (:command:`git log`) or external tools (such as ``tig``) allow to explore
   the history.
 

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -395,7 +395,7 @@ the ``--input`` and ``--output`` specification done before.
       $ datalad run -m "move a few files around" \
       --input "file1" --input "file2" --input "file3" \
       --output "directory_a/" \
-      "mv file1 file2 file3 directory_a}"
+      "mv file1 file2 file3 directory_a/"
 
 
    The order of the values will match that order from the command line.
@@ -416,7 +416,7 @@ the ``--input`` and ``--output`` specification done before.
       $ datalad run -m "move a few files around" \
       --input "file1" --input "file2" --input "file3" \
       --output "directory_a/" \
-      "mv file1 file2 file3 directory_a}"
+      "mv file1 file2 file3 directory_a/"
 
    If the command only needs a subset of the inputs or outputs, individual values
    can be accessed with an integer index, e.g., ``{inputs[0]}`` for the very first

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -186,17 +186,17 @@ done wrong, we raise our hand to ask the instructor for help.
 Knowingly, she smiles, and tells you about how DataLad protects content given
 to it:
 
-"Content in your DataLad dataset is protected by :term:`Git-annex` from
+"Content in your DataLad dataset is protected by :term:`git-annex` from
 accidental changes" our instructor begins.
 
 "Wait!" we interrupt. "First of, that wasn't accidental. And second, I was told this
-course does not have ``Git-annex-101`` as a prerequisite?"
+course does not have ``git-annex-101`` as a prerequisite?"
 
 "Yes, hear me out" she says. "I promise you two different solutions at
 the end of this explanation, and the concept behind this is quite relevant".
 
-DataLad usually gives content to :term:`Git-annex` to store and track.
-Git-annex, let's just say, takes this task *really* seriously. One of its
+DataLad usually gives content to :term:`git-annex` to store and track.
+git-annex, let's just say, takes this task *really* seriously. One of its
 features that you have just experienced is that it *locks* content.
 
 If files are *locked down*, their content can not be modified. In principle,
@@ -206,7 +206,7 @@ Therefore, a file needs to be consciously *unlocked* to apply modifications.
 
 In the attempt to resize the image to 450x450 you tried to overwrite
 ``recordings/salt_logo_small.jpg``, a file that was given to DataLad
-and thus protected by Git-annex.
+and thus protected by git-annex.
 
 .. index:: ! datalad command; unlock
 

--- a/docs/basics/101-113-summary.rst
+++ b/docs/basics/101-113-summary.rst
@@ -54,8 +54,8 @@ Furthermore, by experiencing many common error messages in the context of :comma
 commands, you have gotten some clues on where to look for problems, should you encounter
 those errors in your own work.
 
-Lastly, we've started to unveil some principles of :term:`Git-annex` that are relevant to
+Lastly, we've started to unveil some principles of :term:`git-annex` that are relevant to
 understanding how certain commands work and why certain commands may fail. We have seen that
-Git-annex locks large files' content to prevent accidental modifications, and how the ``--output``
+git-annex locks large files' content to prevent accidental modifications, and how the ``--output``
 flag in :command:`datalad run` can save us an intermediate :command:`datalad unlock` to unlock this content.
 The next section will elaborate on this a bit more.

--- a/docs/basics/101-114-txt2git.rst
+++ b/docs/basics/101-114-txt2git.rst
@@ -7,7 +7,7 @@ Later in the day, after seeing and solving so many DataLad error messages,
 you fall tired into your
 bed. Just as you are about to fall asleep, a thought crosses your mind:
 
-"I now know that tracked content in a dataset is protected by :term:`Git-annex`.
+"I now know that tracked content in a dataset is protected by :term:`git-annex`.
 Whenever tracked contents are ``saved``, they get locked and should not be
 modifiable. But... what about the notes that I have been taking since the first day?
 Should I not need to unlock them before I can modify them? And also the script!
@@ -39,15 +39,15 @@ The second commit message in our datasets history summarizes this:
    $ git log --reverse --oneline
 
 Instead of giving text files such as your notes or your script
-to Git-annex, the dataset stores it in :term:`Git`.
-But what does it mean if files are in Git instead of Git-annex?
+to git-annex, the dataset stores it in :term:`Git`.
+But what does it mean if files are in Git instead of git-annex?
 
-Well, procedurally it means that everything that is stored in Git-annex is
+Well, procedurally it means that everything that is stored in git-annex is
 content-locked, and everything that is stored in Git is not. You can modify
 content stored in Git straight away, without unlocking it first.
 
 .. figure:: ../artwork/src/git_vs_gitannex.svg
-   :alt: A simplified illustration of content lock in files managed by Git-annex.
+   :alt: A simplified illustration of content lock in files managed by git-annex.
    :figwidth: 100%
 
    A simplified overview of the tools that manage data in your dataset.
@@ -62,7 +62,7 @@ But there will be a lecture on that [#f1]_."
 
 "Okay, well, second: Isn't it much easier to just not bother with locking and
 unlocking, and have everything 'stored in Git'? Even if :command:`datalad run` takes care
-of unlocking content, I do not see the point of Git-annex", you continue.
+of unlocking content, I do not see the point of git-annex", you continue.
 
 Here it gets tricky. To begin with the most important, and most straight-forward fact:
 It is not possible to store
@@ -73,19 +73,19 @@ for example does not allow files larger than 100MB of size.
 For now, we have solved the mystery of why text files can be modified
 without unlocking, and this is a small
 improvement in the vast amount of questions that have piled up in our curious
-minds. Essentially, Git-annex protects your data from accidental modifications
+minds. Essentially, git-annex protects your data from accidental modifications
 and thus keeps it safe. :command:`datalad run` commands mitigate any technical
 complexity of this completely if ``-o/--output`` is specified properly, and
 :command:`datalad unlock` commands can be used to unlock content "by hand" if
 modifications are performed outside of a :command:`datalad run`.
 
 But there comes the second, tricky part: There are ways to get rid of locking and
-unlocking within Git-annex, using so-called :term:`adjusted branch`\es.
-This functionality is dependent on the Git-annex
-version one has installed, the Git-annex version of the repository, and a
+unlocking within git-annex, using so-called :term:`adjusted branch`\es.
+This functionality is dependent on the git-annex
+version one has installed, the git-annex version of the repository, and a
 use-case dependent comparison of the pros and cons. BUT: it is possible,
 and in many cases useful, and in later sections we will see how to use this
-feature. The next lecture, in any way, will guide us deeper into Git-annex,
+feature. The next lecture, in any way, will guide us deeper into git-annex,
 and improve our understanding a slight bit further.
 
 

--- a/docs/basics/101-114-txt2git.rst
+++ b/docs/basics/101-114-txt2git.rst
@@ -67,7 +67,7 @@ of unlocking content, I do not see the point of git-annex", you continue.
 Here it gets tricky. To begin with the most important, and most straight-forward fact:
 It is not possible to store
 large files in Git. This is because Git would very quickly run into severe performance
-issues. For this reason, :term:`Github`, a well-known hosting site for projects using Git,
+issues. For this reason, :term:`GitHub`, a well-known hosting site for projects using Git,
 for example does not allow files larger than 100MB of size.
 
 For now, we have solved the mystery of why text files can be modified

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -11,7 +11,7 @@ We further took note that when we modified content in ``notes.txt`` or ``list_fi
 the modified content was in a *text file*. We learned that
 this precise type of file, in conjunction with the initial configuration template
 ``text2git`` we gave to :command:`datalad create`, is meaningful: As the textfile is
-stored in Git and not Git-annex, no content unlocking is necessary.
+stored in Git and not git-annex, no content unlocking is necessary.
 As we saw within the demonstrations of :command:`datalad run`,
 modifying content of non-text files, such as ``.jpg``\s, requires
 -- spoiler: at least in our current type of dataset --
@@ -65,11 +65,11 @@ repository in the root of any dataset. One reason
 why you should not do this is because *this* ``.git`` directory is where all of your file content
 is actually stored.
 
-But why is that? We have to talk a bit Git-annex now in order to understand it [#f1]_.
+But why is that? We have to talk a bit git-annex now in order to understand it [#f1]_.
 
 When a file is saved into a dataset to be tracked,
 by default -- that is in a dataset created without any configuration template --
-DataLad gives this file to Git-annex. Exceptions to this behavior can be
+DataLad gives this file to git-annex. Exceptions to this behavior can be
 defined based on
 
 #. file size
@@ -78,7 +78,7 @@ defined based on
    or names, or file types (e.g., text files, as with the
    ``text2git`` configuration template).
 
-Git-annex, in order to version control the data, takes the file content
+git-annex, in order to version control the data, takes the file content
 and moves it under ``.git/annex/objects`` -- the so called :term:`object-tree`.
 It further renames the file into the sequence of characters you can see
 in the path, and in its place
@@ -124,7 +124,7 @@ Here you can see the reason why content is symlinked: Small file size means that
 Therefore, instead of large file content, only the symlinks are committed into
 Git, and the Git repository thus stays lean. Simultaneously, still, all
 files stored in Git as symlinks can point to arbitrarily large files in the
-object tree. Within the object tree, Git-annex handles file content tracking,
+object tree. Within the object tree, git-annex handles file content tracking,
 and is busy creating and maintaining appropriate symlinks so that your data
 can be version controlled just as any text file.
 
@@ -156,7 +156,7 @@ out the hidden section below.
 
 The second is that it should now be clear to you why the ``.git`` directory
 should not be deleted or in any way modified by hand. This place is where
-your data is stored, and you can trust Git-annex to be better able to
+your data is stored, and you can trust git-annex to be better able to
 work with the paths in the object tree than you or any other human are.
 
 Lastly, understanding that annexed files in your dataset are symlinked
@@ -173,7 +173,7 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    maximal confusion with this naming? Can't it be ... more *readable*?
 
    Its not malicious intent that leads to these paths and file names. Its
-   checksums. And they are quite readable -- just not for humans, but Git-annex.
+   checksums. And they are quite readable -- just not for humans, but git-annex.
    Understanding the next section is completely irrelevant for the
    subsequent sections of the book. But it can help to establish trust in that
    your data is safely stored and tracked, and it can get certainly helpful
@@ -184,12 +184,12 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    you need to take appropriate actions to get the dataset back into a clean
    state.
    Understanding more about the object tree can help to understand such
-   problems, and knowing bits of the Git-annex basics can make you more
+   problems, and knowing bits of the git-annex basics can make you more
    confident in working with your datasets.
 
    So how do these paths and names come into existence?
 
-   When a file is annexed, Git-annex generates a *key* from the **file content**.
+   When a file is annexed, git-annex generates a *key* from the **file content**.
    It uses this key (in part) as a name for the file and as the path
    in the object tree.
    Thus, the key is associated with the content of the file (the *value*),
@@ -212,7 +212,7 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    tree will contain only one instance of that content, and all copies will
    symlink to it, thus saving disk space. But furthermore,
    the file name also becomes a way of ensuring data integrity. File content
-   can not be changed without Git-annex noticing, because the symlink to the
+   can not be changed without git-annex noticing, because the symlink to the
    file content will change. If you want to read more about the
    computer science basics about about hashes check out the Wikipedia
    page `here <https://en.wikipedia.org/wiki/Hash_function>`_.
@@ -274,10 +274,10 @@ to manage the file system in a datalad dataset (:ref:`filesystem`).
    of the key, and their sole purpose to exist is to avoid issues with too many files
    in one directory (which is a situation that certain file systems have problems with).
 
-   In summary, you now know a great deal about Git-annex and the object tree. Maybe you
+   In summary, you now know a great deal about git-annex and the object tree. Maybe you
    are as amazed as we are about some of the ingenuity used behind the scenes. In any
    case, this section was hopefully insightful, and not confusing. If you are still curious
-   about Git-annex, you can check out its
+   about git-annex, you can check out its
    `documentation <https://git-annex.branchable.com/git-annex/>`_.
 
 Broken symlinks
@@ -322,7 +322,7 @@ the superdataset.
 .. rubric:: Footnotes
 
 .. [#f1] Note, though, that the information below applies to everything that is not an
-         *adjusted branch* in a Git-annex *v7 repository* -- this information does not make
+         *adjusted branch* in a git-annex *v7 repository* -- this information does not make
          sense yet, but it will be an important reference point later on.
          Just for the record: Currently, we do not yet have a v7 repository
          in ``DataLad-101``, and the explanation below applies to our current dataset.

--- a/docs/basics/101-116-sharelocal.rst
+++ b/docs/basics/101-116-sharelocal.rst
@@ -123,7 +123,7 @@ Indeed, the PDFs and pictures appear just as they did in the original dataset
 on first sight: They are symlinks pointing to some location in the
 object tree. To reassure your room mate that everything is fine you
 quickly explain to him the concept of a symlink and the :term:`object-tree`
-of :term:`Git-annex`.
+of :term:`git-annex`.
 
 "But why does the PDF not open when I try to open it?" he repeats.
 True, these files cannot be opened. This mimics our experience when
@@ -156,8 +156,8 @@ thought it would. Your room mate is excited by this magical
 command. You however begin to wonder: how does DataLad know where to look for
 that original content?
 
-This information comes from Git-annex. Before getting the next PDF,
-let's query Git-annex where its content is stored:
+This information comes from git-annex. Before getting the next PDF,
+let's query git-annex where its content is stored:
 
 .. runrecord:: _examples/DL-101-116-105
    :language: console
@@ -191,21 +191,21 @@ is only your own, original ``DataLad-101`` dataset in which
 this book is saved.
 
 To retrieve file content of an annexed file such as one of
-these PDFs, Git-annex will try
+these PDFs, git-annex will try
 to obtain it from the locations it knows to contain this content.
 It uses the checksums to identify these locations. Every copy
 of a dataset will get a unique ID with such a checksum.
-Note however that just because Git-annex knows a certain location
+Note however that just because git-annex knows a certain location
 where content was once it does not guarantee that retrieval will
 work. If one location is a USB-Stick that is in your bag pack instead
 of your USB port,
 a second location is a hard drive that you deleted all of its
 previous contents (including dataset content) from,
 and another location is a web server, but you are not connected
-to the internet, Git-annex will not succeed in retrieving
+to the internet, git-annex will not succeed in retrieving
 contents from these locations.
 As long as there is at least one location that contains
-the file and is accessible, though, Git-annex will get the content.
+the file and is accessible, though, git-annex will get the content.
 
 Let's now turn to the fact that the subdataset ``longnow`` does
 not contain not only no file content, but also no file metadata

--- a/docs/basics/101-117-sharelocal2.rst
+++ b/docs/basics/101-117-sharelocal2.rst
@@ -16,11 +16,11 @@ from the start. Alternatively, a subsequent :command:`datalad install`
 in the subdataset or with a path to the subdataset takes care
 of the missing installation.
 
-And you have mesmerized your room mate by showing him how :term:`Git-annex`
+And you have mesmerized your room mate by showing him how :term:`git-annex`
 retrieved large file contents from the original dataset.
 
 Let's now see the :command:`git annex whereis` command in more detail,
-and find out how Git-annex knows *where* file content can be obtained from.
+and find out how git-annex knows *where* file content can be obtained from.
 Within the original ``DataLad-101`` dataset, you retrieved some of the ``.mp3``
 files via :command:`datalad get`, but not others. How will this influence the
 output of :command:`git annex whereis`, you wonder?
@@ -84,7 +84,7 @@ Let's see how this affects a :command:`datalad get`:
 The most important thing to note is: It worked in both cases, regardless of whether the original
 ``DataLad-101`` dataset contained the file content or not.
 
-We can see that Git-annex used two different sources to retrieve the content from,
+We can see that git-annex used two different sources to retrieve the content from,
 though, if we look at the very end of the ``get`` summary.
 The first file was retrieved "``from origin...``". ``Origin`` is Git terminology
 for "from where the dataset was copied from" -- ``origin`` therefore is the

--- a/docs/basics/101-120-summary.rst
+++ b/docs/basics/101-120-summary.rst
@@ -35,7 +35,7 @@ sharing a dataset with a simple example.
   file content sources.
 
 * :command:`git annex whereis PATH` will list all locations known to contain file
-  content for a particular file. This location is where :term:`Git-annex`
+  content for a particular file. This location is where :term:`git-annex`
   will attempt to retrieve file content from, and it is described with the
   ``--description`` provided during a :command:`datalad create`. It is a very
   helpful command to find out where file content resides, and how many

--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -27,7 +27,7 @@ as the ascii-cast on `dataset nesting <https://www.datalad.org/for/git-users>`_.
 Because he found this very helpful in understanding dataset
 nesting concepts, he decided to download the ``shell`` script
 that was `used to generate this example <https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1f08d0a54ab521586f27ee918b4441d69/content/asciicast/seamless_nested_repos.sh>`_
-from Github, and saves it in the ``code/`` directory.
+from GitHub, and saves it in the ``code/`` directory.
 
 .. index:: ! datalad command; download-url
 

--- a/docs/basics/101-122-config.rst
+++ b/docs/basics/101-122-config.rst
@@ -7,9 +7,9 @@ Back in section :ref:`text2git`, you already learned that there
 are dataset configurations, and that these configurations can
 be modified, for example with the ``-c text2git`` option.
 This option applies a configuration template to store text
-files in :term:`Git` instead of :term:`Git-annex`, and thereby
+files in :term:`Git` instead of :term:`git-annex`, and thereby
 modifies the DataLad dataset's default configuration to store
-every file in Git-annex.
+every file in git-annex.
 
 The lecture today focuses entirely on the topic of configurations,
 and aims to equip everyone with the basics to configure
@@ -23,7 +23,7 @@ computers, or datasets.
 to differentiate between different scopes of configuration,
 and different tools the configuration belongs or applies to",
 our lecturer starts. "In DataLad datasets, different tools can
-have a configuration: :term:`Git`, :term:`Git-annex`, and
+have a configuration: :term:`Git`, :term:`git-annex`, and
 obviously DataLad itself. Because these tools are all
 combined by DataLad to help you manage your data,
 it is important to understand how the configuration of one
@@ -34,7 +34,7 @@ dataset performance."
 student from the row behind you. Personally, you'd also
 be much more excited
 about any hands-on lecture filled with commands. But the
-recent lecture about :term:`Git-annex` and the :term:`object-tree`
+recent lecture about :term:`git-annex` and the :term:`object-tree`
 was surprisingly captivating, so you're actually looking forward to today.
 "Shht! I want to hear this!", you shush him with a wink.
 
@@ -63,7 +63,7 @@ to understand how a configuration file in principle works and also
 how to use it. The only piece of information you will need
 are the necessary files, or the command that writes to them, and
 the available options for configuration, that's it. And what's
-really cool is that all tools we'll be looking at -- Git, Git-annex,
+really cool is that all tools we'll be looking at -- Git, git-annex,
 and DataLad -- can be configured using the :command:`git config`
 command [#f1]_. Therefore, once you understand the syntax of this
 command, you already know half of what's relevant. The other half
@@ -80,7 +80,7 @@ Git config files
 The user name and email configuration
 is a *user-specific* configuration (called *global*
 configuration by Git), and therefore applies to your user account.
-Where ever on your computer *you* run a Git, Git-annex, or DataLad
+Where ever on your computer *you* run a Git, git-annex, or DataLad
 command, this global configuration will
 associate the name and email address you supplied in
 the :command:`git config` commands above with this action.
@@ -112,7 +112,7 @@ Thus, there are three different scopes of Git configuration, and each is defined
 in a ``config`` file in a different location. The configurations will determine
 how Git behaves. In principle, all of these files can configure
 the same variables differently, but more specific scopes take precedence over broader
-scopes. Conveniently, not only can DataLad and Git-annex be configured with
+scopes. Conveniently, not only can DataLad and git-annex be configured with
 the same command as Git, but in many cases they will also use exactly the same
 files as Git for their own configurations.
 
@@ -183,7 +183,7 @@ configure repository-specific editors)
 This example demonstrated the structure of a :command:`git config`
 command. By specifying the ``name`` option with ``section.variable``
 (or ``section.subsection.variable`` if there is a subsection), and
-a value, one can configure Git, Git-annex, and DataLad.
+a value, one can configure Git, git-annex, and DataLad.
 *Most* of these configurations will be written to a ``config`` file
 of Git, depending on the scope (local, global, system-wide)
 specified in the command.
@@ -246,11 +246,11 @@ you a glimpse of this.
 
 .. findoutmore:: More on this config file
 
-   The second section of ``.git/config`` is a Git-annex configuration.
-   As mentioned above, Git-annex will use the
+   The second section of ``.git/config`` is a git-annex configuration.
+   As mentioned above, git-annex will use the
    :term:`Git config file` for some of its configurations.
    For example, it lists the repository as a
-   "version 5 repository", and gives the dataset its own Git-annex
+   "version 5 repository", and gives the dataset its own git-annex
    UUID. While the "annex-uuid" [#f4]_ looks like yet another cryptic
    random string of characters, you have seen a UUID like this before:
    A :command:`git annex whereis` displays information about where the
@@ -295,7 +295,7 @@ you a glimpse of this.
    path, and a demonstration of this is in section :ref:`filesystem`.
    `fetch` contains a specification which parts of the repository are
    updated -- in this case everything (all of the branches).
-   Lastly, the ``annex-ignore = false`` configuration allows Git-annex
+   Lastly, the ``annex-ignore = false`` configuration allows git-annex
    to query the remote when it tries to retrieve data from annexed content.
 
 ``.git/config`` versus other (configuration) files

--- a/docs/basics/101-123-config2.rst
+++ b/docs/basics/101-123-config2.rst
@@ -202,7 +202,7 @@ Let's try this:
 
 This command will replace the submodule's https URL with an SSH URL.
 The later is often used if someone has an *SSH key pair* and added the
-public key to their Github account (you can read more about this
+public key to their GitHub account (you can read more about this
 `here <https://help.github.com/en/articles/which-remote-url-should-i-use>`_).
 We will revert this change shortly, but use it to show the difference between
 a :command:`git config` on a ``.git/config`` file and on a version controlled file:

--- a/docs/basics/101-123-config2.rst
+++ b/docs/basics/101-123-config2.rst
@@ -13,7 +13,7 @@ They are version controlled, and upon sharing a dataset these configurations
 will be shared as well. An example for a shared configuration
 is the one that the ``text2git`` configuration template applied:
 In the shared copy of your dataset, text files are also saved with Git,
-and not Git-annex (see section :ref:`sibling`). The configuration responsible
+and not git-annex (see section :ref:`sibling`). The configuration responsible
 for this behavior is in a ``.gitattributes`` file, and we'll start this
 section by looking into it.
 
@@ -30,11 +30,11 @@ This file lies right in the root of your superdataset:
 
 This looks neither spectacular nor pretty. Also, it does not follow the ``section-option-value``
 organization of the ``.git/config`` file anymore. Instead, there are three lines,
-and all of these seem to have something to do with the configuration of Git-annex.
+and all of these seem to have something to do with the configuration of git-annex.
 There even is one key word that you recognize: MD5E.
 If you have read the hidden section in :ref:`symlink`
 you will recognize it as a reference to the type of
-key used by Git-annex to identify and store file content in the object-tree.
+key used by git-annex to identify and store file content in the object-tree.
 The first row, ``* annex.backend=MD5E``, therefore translates to "Everything in this
 directory should be hashed with a MD5E hash function".
 But what is the rest? We'll start with the last row::
@@ -43,7 +43,7 @@ But what is the rest? We'll start with the last row::
 
 Uhhh, cryptic. The lecturer explains:
 
-"Git-annex will *annex*, that is, *store in the object-tree*,
+"git-annex will *annex*, that is, *store in the object-tree*,
 anything it considers to be a "large file". By default, anything
 in your dataset would be a "large file", that means anything would be annexed.
 However, in section :ref:`symlink` I already mentioned that exceptions to this
@@ -56,11 +56,11 @@ behavior can be defined based on
    ``text2git`` configuration template).
 
 "In ``.gitattributes``, you can define what a large file and what is not
-by simply telling Git-annex by writing such rules."
+by simply telling git-annex by writing such rules."
 
 What you can see in this ``.gitattribute`` file is a rule based on **file types**:
 With ``(not(mimetype=text/*))`` [#f1]_, the ``text2git`` configuration template
-configured Git-annex to regard all files of type text **not** as a large file.
+configured git-annex to regard all files of type text **not** as a large file.
 Thanks to this little line, your text files are not annexed, but stored
 directly in Git.
 
@@ -68,10 +68,10 @@ The patterns ``*`` and ``**`` are so-called "wildcards" used in :term:`globbing`
 ``*`` matches any file or directory in the current directory, and ``**`` matches
 all files and directories in the current directory *and subdirectories*. In technical
 terms, ``**`` matches *recursively*. The third row therefore
-translates to "Do not annex anything that is a text file in this directory" for Git-annex.
+translates to "Do not annex anything that is a text file in this directory" for git-annex.
 
 However, rules can be even simpler. The second row simply takes a complete directory
-(``.git``) and instructs Git-annex to regard nothing in it as a "large file".
+(``.git``) and instructs git-annex to regard nothing in it as a "large file".
 The second row, ``**/.git* annex.largefiles=nothing`` therefore means that no
 ``.git`` repository in this directory or a subdirectory should be considered
 a "large file". This way, the ``.git`` repositories are protected from being annexed.
@@ -89,13 +89,13 @@ and view this dataset's ``.gitattributes`` file:
    $ cat recordings/longnow/.gitattributes
 
 The relevant part is ``README.md annex.largefiles=nothing``.
-This instructs Git-annex to specifically not annex ``README.md``.
+This instructs git-annex to specifically not annex ``README.md``.
 
 Lastly, if you wanted to configure a rule based on **size**, you could add a row such as::
 
    ** annex.largefiles(largerthan=20kb)
 
-to store only files exceeding 20KB in size in Git-annex [#f2]_.
+to store only files exceeding 20KB in size in git-annex [#f2]_.
 
 As you may have noticed, unlike ``.git/config`` files,
 there can be multiple ``.gitattributes`` files within a dataset. So far, you have seen one
@@ -121,9 +121,9 @@ This can be very handy, and allows you to tune your dataset to your custom needs
 For example, files you will often edit by hand could be stored in Git if they are
 not too large to ease modifying them [#f3]_.
 Once you know the basics of this type of configuration syntax, writing
-your own rules is easy. For more tips on how configure Git-annex's content
+your own rules is easy. For more tips on how configure git-annex's content
 management in ``.gitattributes``, take a look at `this <https://git-annex.branchable.com/tips/largefiles/>`_
-page of the Git-annex documentation.
+page of the git-annex documentation.
 Later however you will see preconfigured DataLad *procedures* such as ``text2git`` that
 can apply useful configurations for you, just as ``text2git`` added the last line
 in the root ``.gitattributes`` file.
@@ -243,7 +243,7 @@ Environment variables
 An :term:`environment variable` is a variable set up in your shell
 that affects the way the shell or certain software works -- for example
 the environment variables ``HOME``, ``PWD``, or ``PATH`` [#f4]_.
-Configuration options that determine the behavior of Git, Git-annex, and
+Configuration options that determine the behavior of Git, git-annex, and
 DataLad that could be defined in a configuration file can also be set (or overridden)
 by the associated environment variables of these configuration options.
 Many configuration items have associated environment variables.
@@ -254,7 +254,7 @@ configuration of Git can be overridden by its associated environment variable,
 ``GIT_AUTHOR_NAME``. Likewise, one can define the environment variable instead
 of setting the ``user.name`` configuration in a configuration file.
 
-Git, Git-annex, and DataLad have more environment variables than anyone would want to
+Git, git-annex, and DataLad have more environment variables than anyone would want to
 remember. `Here <https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables>`__
 is a good overview on Git's most useful available environment variables for a start.
 All of DataLad's configuration options can be easily translated to their
@@ -279,7 +279,7 @@ want to work with and change them. You can use the :command:`git config` command
 for Git configuration files on different scopes, and even the ``.gitmodules`` or ``datalad/config``
 files. Of course you do not yet know all of the available configuration options. However,
 you already know some core Git configurations such as name, email, and editor. Even more
-important, you know how to configure Git-annex's content management based on ``largefile``
+important, you know how to configure git-annex's content management based on ``largefile``
 rules, and you understand the majority of variables within ``.gitmodules`` or the sections
 in ``.git/config``. Slowly, you realize with pride,
 you're more and more becoming a DataLad power-user.
@@ -310,7 +310,7 @@ Write a note about configurations in datasets into ``notes.txt``.
    The git config --list --show-origin command is a useful tool
    to give an overview over existing configurations. Particularly
    important may be the .gitattributes file, in which one can set
-   rules for Git-annex about which files should be version-controlled
+   rules for git-annex about which files should be version-controlled
    with Git instead of being annexed.
 
    EOT
@@ -346,7 +346,7 @@ Write a note about configurations in datasets into ``notes.txt``.
          The above command annexes files larger than 100KB, and will never annex files with a
          ``.c`` or ``.h`` extension.
 
-.. [#f3] Should you ever need to, this file is also where one would change the Git-annex
+.. [#f3] Should you ever need to, this file is also where one would change the git-annex
          backend in order to store new files with a new backend. Switching the backend of
          *all* files (new as well as existing ones) requires the :command:`git annex migrate`
          (see `the documentation <https://git-annex.branchable.com/git-annex-migrate/>`_ for

--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -5,7 +5,7 @@ Configurations to go
 
 The past two sections should have given you a comprehensive
 overview on the different configuration options the tools
-Git, Git-annex, and DataLad provide. They not only
+Git, git-annex, and DataLad provide. They not only
 showed you a way to configure everything you may need to
 configure, but also gave explanations about what the
 configuration options actually mean.
@@ -50,7 +50,7 @@ are highlighted:
     annex_largefiles = '(not(mimetype=text/*))'
     # check existing configurations:
     attrs = ds.repo.get_gitattributes('*')
-    # if not already an existing configuration, configure Git-annex with the above rule
+    # if not already an existing configuration, configure git-annex with the above rule
     if not attrs.get('*', {}).get(
             'annex.largefiles', None) == annex_largefiles:
         ds.repo.set_gitattributes([
@@ -68,7 +68,7 @@ executables (such as a script, or compiled code).
 In principle, they can be written in any language, and perform
 any task inside of a dataset.
 The ``text2git`` configuration for example applies a configuration for how
-Git-annex treats different file types. Other procedures do not
+git-annex treats different file types. Other procedures do not
 only modify ``.gitattributes``, but can also populate a dataset
 with particular content, or automate routine tasks such as
 synchronizing dataset content with certain siblings.

--- a/docs/basics/101-125-summary.rst
+++ b/docs/basics/101-125-summary.rst
@@ -45,4 +45,4 @@ Now what can I do with it?
 Configurations are not a closed book for you anymore. What will probably be
 especially helpful is your new knowledge about ``.gitattributes`` and
 DataLads ``run-procedure`` command that allow you to configure the behaviour
-of Git-annex in your dataset.
+of git-annex in your dataset.

--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -397,7 +397,7 @@ Summarizing these two glimpses into the dataset, this configuration has
 
 #. included a code directory in your dataset
 #. included three files for human consumption (``README.md``, ``CHANGELOG.md``)
-#. configured everything in the ``code/`` directory to be tracked by Git, not Git-annex [#f5]_
+#. configured everything in the ``code/`` directory to be tracked by Git, not git-annex [#f5]_
 #. and configured ``README.md`` and ``CHANGELOG.md`` in the root of the dataset to be
    tracked by Git.
 

--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -247,7 +247,7 @@ be included in an analysis superdataset as subdatasets. Thanks to
 :command:`datalad install`, information on the source of these subdatasets
 is stored in the history of the analysis superdataset, and they can even be
 updated from those sources if the original data dataset gets extended or changed.
-If you are including a file, for example code from Github,
+If you are including a file, for example code from GitHub,
 the :command:`datalad download-url` command (introduced in section :ref:`sibling`)
 will record the source of it safely in the dataset's history. And if you add anything to your dataset,
 from simple incremental coding progress in your analysis scripts up to

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -482,7 +482,7 @@ dataset that you can use for this [#f4]_.
 
 Note that one feature of the YODA procedure was that it configured certain files
 (for example everything inside of ``code/``, and the ``README.md`` file in the
-root of the dataset) to be saved in Git instead of Git-annex. This was the
+root of the dataset) to be saved in Git instead of git-annex. This was the
 reason why the ``README.md`` in the root of the dataset was easily modifiable [#f4]_.
 
 .. findoutmore:: Saving contents with Git regardless of configuration with --to-git
@@ -495,7 +495,7 @@ reason why the ``README.md`` in the root of the dataset was easily modifiable [#
    This is not true in ``midterm_project``: Only the existing ``README.md`` files and
    anything within ``code/`` are stored -- everything else will be annexed.
    That means that if you create any other file, even text files, inside of
-   ``midterm_project`` (but not in ``code/``), it will be managed by :term:`Git-annex`
+   ``midterm_project`` (but not in ``code/``), it will be managed by :term:`git-annex`
    and content-locked after a :command:`datalad save` -- an inconvenience if it
    would be a file that is small enough to be handled by Git.
 
@@ -623,7 +623,7 @@ state of the dataset to this sibling with the :command:`datalad publish`
 
    The :command:`datalad publish` uses ``git push``, and ``git annex copy`` under
    the hood. Publication targets need to either be configured remote Git repositories,
-   or Git-annex special remotes (if they support data upload).
+   or git-annex special remotes (if they support data upload).
 
 Here is one important detail, though: By default, your tags will not be published.
 The reason for this is that tags are viral -- they can be removed locally, and old
@@ -676,7 +676,7 @@ reproduce your data science project easily from scratch!
 
       $ datalad get prediction_report.csv pairwise_relationships.png
 
-   Why is that? The file content of these files is managed by Git-annex, and
+   Why is that? The file content of these files is managed by git-annex, and
    thus only information about the file name and location is known to Git.
    Because GitHub does not host large data for free, annexed file content always
    needs to be deposited somewhere else (e.g., a webserver) to make it
@@ -747,7 +747,7 @@ reproduce your data science project easily from scratch!
             pip install seaborn, pandas, sklearn
 
 .. [#f4] Note that all ``README.md`` files the YODA procedure created are
-         version controlled by Git, not Git-annex, thanks to the
+         version controlled by Git, not git-annex, thanks to the
          configurations that YODA supplied. This makes it easy to change the
          ``README.md`` file. Let previous section detailed how the YODA procedure
          configured your dataset. If you want to re-read the full chapter on

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -172,7 +172,7 @@ independent dataset from scratch in the hidden section below.
        $ datalad download-url https://gist.githubusercontent.com/netj/8836201/raw/6f9306ad21398ea43cba4f7d537619d0e07d5ae3/iris.csv
 
    Finally, we *published* (more on this later in this section) the dataset
-   to :term:`Github`.
+   to :term:`GitHub`.
 
    With this setup, the iris dataset (a single comma-separated (``.csv``)
    file) is downloaded, and, importantly, the dataset recorded *where* it
@@ -531,7 +531,7 @@ syllabus, this should be done via :term:`GitHub`.
    repositories, which lets you navigate through nested datasets in the web-interface.
 
    .. figure:: ../artwork/src/screenshot_midtermproject.png
-      :alt: The midterm project repository, published to Github
+      :alt: The midterm project repository, published to GitHub
 
    The above screenshot shows the linkage between the analysis project you will create
    and its subdataset. Clicking on the subdataset (highlighted) will take you to the iris dataset

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -65,7 +65,7 @@ The output below shows an excerpt.
    $ datalad wtf
 
 This lengthy output will report all information that might
-be relevant -- from DataLad to :term:`Git-annex` or Python
+be relevant -- from DataLad to :term:`git-annex` or Python
 up to your operating system.
 
 The second step, finding and reading the help page of the command
@@ -114,7 +114,7 @@ Include
   steps necessary to reproduce it.
 
 - *technical details* -- what version of DataLad are you using, what version
-  of Git-annex, and which Git-annex repository type, what is your operating
+  of git-annex, and which git-annex repository type, what is your operating
   system and -- if applicable -- Python version? :command:`datalad wtf` is your friend
   to find all of this information.
 
@@ -123,12 +123,12 @@ page prefills a neurostars form with a template for a question for a good
 starting point if you want to have more guidance or encounter writer's block.
 
 
-Common Git-annex warnings and errors
+Common git-annex warnings and errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A lot of output you will see while working with DataLad originates from
-Git-annex. It's outputs can be wordy and not trivial to comprehend even if
-everything works. This following section will list some common Git-annex
+git-annex. It's outputs can be wordy and not trivial to comprehend even if
+everything works. This following section will list some common git-annex
 warnings and errors and attempts to explain them.
 
 Upon installation of a dataset, you may see::
@@ -136,7 +136,7 @@ Upon installation of a dataset, you may see::
    [INFO    ]     Remote origin not usable by git-annex; setting annex-ignore
    [INFO    ]     This could be a problem with the git-annex installation on the remote. Please make sure that git-annex-shell is available in PATH when you ssh into the remote. Once you have fixed the git-annex installation, run: git annex enableremote origin
 
-This warning lets you know that Git-annex will not attempt to download
+This warning lets you know that git-annex will not attempt to download
 content from the remote "origin", because it is not usable. This can have
 many reasons, but as long as there are other remotes you can access the
 data from, you are fine.

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -118,7 +118,7 @@ Include
   system and -- if applicable -- Python version? :command:`datalad wtf` is your friend
   to find all of this information.
 
-The "submit a question link" on `DataLad's Github page <https://github.com/datalad/datalad#support>`_
+The "submit a question link" on `DataLad's GitHub page <https://github.com/datalad/datalad#support>`_
 page prefills a neurostars form with a template for a question for a good
 starting point if you want to have more guidance or encounter writer's block.
 

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -274,9 +274,9 @@ the best option to turn to.
    An additional piece of background information: A :command:`datalad save` command
    internally uses a :command:`git commit` to save changes to a dataset.
    :command:`git commit` in turn triggers a :command:`git annex fix`
-   command. This Git-annex command fixes up links that have become broken
+   command. This git-annex command fixes up links that have become broken
    to again point to annexed content, and is responsible for cleaning up
-   what needs to be cleaned up. Thanks, Git-annex!
+   what needs to be cleaned up. Thanks, git-annex!
 
 
 Therefore, while it might be startling
@@ -862,8 +862,8 @@ have seen permission denied errors such as
 
 This error indicates that there is write-protected content within ``.git`` that
 cannot not be deleted. What is this write-protected content? It's the file content
-stored in the object tree of Git-annex. If you want, you can re-read the section on
-:ref:`symlink` to find out how Git-annex revokes write permission for the user
+stored in the object tree of git-annex. If you want, you can re-read the section on
+:ref:`symlink` to find out how git-annex revokes write permission for the user
 to protect the file content given to it. To remove a dataset with annexed content
 one has to regain write permissions to everything in the dataset. This is done
 with the `chmod <https://en.wikipedia.org/wiki/Chmod>`_ command::

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -137,7 +137,7 @@ DataLad in the editor)!
       Be aware that an interactive rebase lets you *rewrite* history.
       This can lead to confusion or worse if the history you are rewriting
       is shared with others, e.g., in a collaborative project. Be also aware
-      that rewriting history that is *pushed*/*published* (e.g., to Github)
+      that rewriting history that is *pushed*/*published* (e.g., to GitHub)
       will require a force-push!
 
    Running this command gives you a list of the N most recent commits
@@ -757,7 +757,7 @@ to remove the ``Gitjoke2.txt`` file.
 
 .. [#f4] Note though that rewriting history can be dangerous, and you should
          be aware of what you are doing. For example, rewriting parts of the
-         dataset's history that have been published (e.g., to a Github repository)
+         dataset's history that have been published (e.g., to a GitHub repository)
          already or that other people have copies of, is not advised.
 
 .. [#f5] When in need to interactively rebase, please consult further documentation

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -287,13 +287,13 @@ Finally, lets check how the history looks afterwards:
 
 Wow! You have rewritten history [#f4]_ !
 
-Untracking accidentally saved contents (stored in Git-annex)
+Untracking accidentally saved contents (stored in git-annex)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The previous :command:`git reset` undid the tracking of *text* files.
 However, those files are stored in Git, and thus their content
 is also stored in Git. Files that are annexed, however, have
-their content stored in Git-annex, and not the file itself is stored
+their content stored in git-annex, and not the file itself is stored
 in the history, but a symlink pointing to the location of the file
 content in the dataset's annex. This has consequences for
 a :command:`git reset` command: Reverting a save of a file that is

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -19,7 +19,7 @@ has an external Git-expert as a guest lecturer.
 "I do not have enough time to go through all the details in only
 one lecture. But I'll give you the basics, and an idea of what is possible.
 Always remember: Just google what you need. You will find thousands of helpful tutorials
-or questions on `Stackoverflow <https.stackoverflow.com>`_ right away.
+or questions on `Stack Overflow <https://stackoverflow.com>`_ right away.
 Even experts will *constantly* seek help to find out which Git command to
 use, and how to use it.", he reassures with a wink.
 

--- a/docs/basics/101-180-FAQ.rst
+++ b/docs/basics/101-180-FAQ.rst
@@ -24,7 +24,7 @@ distributed nature.
 DataLad uses Git underneath the hood. Every DataLad dataset is a Git
 repository, and you can use any Git command within a DataLad dataset. Based
 on the configurations in ``.gitattributes``, file content can be version
-controlled by Git or managed by Git-annex, based on path pattern, file types,
+controlled by Git or managed by git-annex, based on path pattern, file types,
 or file size. The section :ref:`config2` details how these configurations work.
 `This chapter <https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F>`_
 gives a comprehensive overview on what Git is.
@@ -36,39 +36,39 @@ As mentioned in :ref:`populate`, a local version control workflow with
 DataLad "skips" the staging area (that is typical for Git workflows) from the
 user's point of view.
 
-What is Git-annex?
+What is git-annex?
 ^^^^^^^^^^^^^^^^^^
 
-Git-annex (`https://git-annex.branchable.com/ <https://git-annex.branchable.com/>`_)
+git-annex (`https://git-annex.branchable.com/ <https://git-annex.branchable.com/>`_)
 is a distributed file synchronization system written by Joey Hess. It can
 share and synchronize large files independent from a commercial service or a
 central server. It does so by managing all file *content* in a separate
 directory (the *annex*, *object tree*, or *key-value-store* in ``.git/annex/objects/``),
 and placing only file names and
-metadata into version control by Git. Among many other features, Git-annex
+metadata into version control by Git. Among many other features, git-annex
 can ensure sufficient amounts of file copies to prevent accidental data loss and
 enables a variety of data transfer mechanisms.
-DataLad uses Git-annex underneath the hood for file content tracking and
-transport logistics. Git-annex offers an astonishing range of functionality
+DataLad uses git-annex underneath the hood for file content tracking and
+transport logistics. git-annex offers an astonishing range of functionality
 that DataLad tries to expose in full. That being said, any DataLad dataset
 (with the exception of datasets configured to be pure Git repositories) is
-fully compatible with Git-annex -- you can use any Git-annex command inside a
+fully compatible with git-annex -- you can use any git-annex command inside a
 DataLad dataset.
 
-The chapter :ref:`symlink` can give you more insights into how Git-annex
-takes care of your data. Git-annex's `website <https://git-annex.branchable.com/>`_
+The chapter :ref:`symlink` can give you more insights into how git-annex
+takes care of your data. git-annex's `website <https://git-annex.branchable.com/>`_
 can give you a complete walk-through and detailed technical background
 information.
 
-What does DataLad add to Git and Git-annex?
+What does DataLad add to Git and git-annex?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-DataLad sits on top of Git and Git-annex and tries to integrate and expose
+DataLad sits on top of Git and git-annex and tries to integrate and expose
 their functionality fully. While DataLad thus is a "thin layer" on top of
 these tools and tries to minimize the use of unique/idiosyncratic functionality,
 it also adds a range of useful concepts and functions:
 
-- Both Git and Git-annex are made to work with a single repository at a time.
+- Both Git and git-annex are made to work with a single repository at a time.
   For example, while nesting pure Git repositories is possible via Git
   submodules (that DataLad also uses internally), *cleaning up* after
   placing a random file somewhere into this repository hierarchy can be very
@@ -130,10 +130,10 @@ superdataset is whether it is *registered* in another dataset (by means of an en
 install -d`` or ``datalad create -d`` command) or contains registered datasets.
 
 
-How can I convert/import/transform an existing Git or Git-annex repository into a DataLad dataset?
+How can I convert/import/transform an existing Git or git-annex repository into a DataLad dataset?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can transform any existing Git or Git-annex repository of yours into a
+You can transform any existing Git or git-annex repository of yours into a
 DataLad dataset by running::
 
    $ datalad create -f
@@ -157,7 +157,7 @@ research and collaboration.
 
 `Git Large File Storage <https://github.com/git-lfs/git-lfs>`_ (Git LFS) is a
 commandline tool that extends Git with the ability to manage large files. In
-that it appears similar to Git-annex.
+that it appears similar to git-annex.
 
 .. todo::
 
@@ -180,7 +180,7 @@ How can I copy data out of a DataLad dataset?
 Moving or copying data out of a DataLad dataset is always possible and works in
 many cases just like in any regular directory. The only
 caveat exists in the case of annexed data: If file content is managed with
-Git-annex and stored in the :term:`object-tree`, what *appears* to be the
+git-annex and stored in the :term:`object-tree`, what *appears* to be the
 file in the dataset is merely a symlink (please read section :ref:`symlink`
 for details). Moving or copying this symlink will not yield the
 intended result -- instead you will have a broken symlink outside of your

--- a/docs/basics/101-180-FAQ.rst
+++ b/docs/basics/101-180-FAQ.rst
@@ -109,15 +109,15 @@ machine.
    party infrastructure
 
 
-How does Github relate to DataLad?
+How does GitHub relate to DataLad?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-DataLad can make good use of Github, if you have figured out storage for your
+DataLad can make good use of GitHub, if you have figured out storage for your
 large files otherwise. You can make DataLad publish file content to one location
-and afterwards automatically push an update to Github, such that
-users can install directly from Github and seemingly also obtain large file
-content from Github. Github is also capable of resolving submodule/subdataset
-links to other Github repos, which makes for a nice UI.
+and afterwards automatically push an update to GitHub, such that
+users can install directly from GitHub and seemingly also obtain large file
+content from GitHub. GitHub is also capable of resolving submodule/subdataset
+links to other GitHub repos, which makes for a nice UI.
 
 
 What is the difference between a superdataset, a subdataset, and a dataset?

--- a/docs/basics/_examples/DL-101-123-110
+++ b/docs/basics/_examples/DL-101-123-110
@@ -18,7 +18,7 @@ over configurations in files.
 The git config --list --show-origin command is a useful tool
 to give an overview over existing configurations. Particularly
 important may be the .gitattributes file, in which one can set
-rules for Git-annex about which files should be version-controlled
+rules for git-annex about which files should be version-controlled
 with Git instead of being annexed.
 
 EOT

--- a/docs/basics/_examples/DL-101-137-126
+++ b/docs/basics/_examples/DL-101-137-126
@@ -93,7 +93,7 @@ over configurations in files.
 The git config --list --show-origin command is a useful tool
 to give an overview over existing configurations. Particularly
 important may be the .gitattributes file, in which one can set
-rules for Git-annex about which files should be version-controlled
+rules for git-annex about which files should be version-controlled
 with Git instead of being annexed.
 
 It can be useful to use pre-configured procedures that can apply

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -44,7 +44,7 @@ Datalad, Run!
 
 
 #########################
-Under the hood: Git-annex
+Under the hood: git-annex
 #########################
 
 .. toctree::

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,7 +6,7 @@ Contributing
 Thanks for being curious about contributing!
 We greatly appreciate and welcome contributions to this book, be it in the form
 of an `issue <https://github.com/datalad-handbook/book/issues/new>`_, a pull request,
-or a discussion you had with anyone on the team via a non-Github communication channel!
+or a discussion you had with anyone on the team via a non-GitHub communication channel!
 To find out how we acknowledge contributions, please read the paragraph
 :ref:`acknowledge` at the bottom of
 this page.
@@ -186,7 +186,7 @@ execute them::
 Easy pull requests
 ^^^^^^^^^^^^^^^^^^
 
-The easiest way to do a pull request is within the web-interface that Github
+The easiest way to do a pull request is within the web-interface that GitHub
 and `readthedocs <https://readthedocs.org>`_ provide. If you visit the rendered
 version of the handbook at `handbook.datalad.org <http://handbook.datalad.org/>`_
 and click on the small, floating ``v:latest`` element at the lower
@@ -195,7 +195,7 @@ lets you make your changes and submit a pull request.
 
 .. figure:: img/contrib.png
    :figwidth: 100%
-   :alt: Access the Github interface to submit a pull request right from within
+   :alt: Access the GitHub interface to submit a pull request right from within
          Readthedocs.
 
    You can find an easy way to submit a pull request right from within the handbook.
@@ -286,7 +286,7 @@ Acknowledging Contributors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have helped this project, we would like to acknowledge your contribution in the
-`Github repository <https://github.com/datalad-handbook/book>`_ in our README with
+`GitHub repository <https://github.com/datalad-handbook/book>`_ in our README with
 `allcontributors.org <https://allcontributors.org/>`_, and the project's
 `.zenodo <https://github.com/datalad-handbook/book/blob/master/.zenodo.json>`_ and
 `CONTRIBUTORS.md <https://github.com/datalad-handbook/book/blob/master/CONTRIBUTORS.md>`_

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -88,7 +88,7 @@ Glossary
    GitHub
       GitHub is an online platform where one can store and share version controlled projects
       using Git (and thus also DataLad project).See
-      `Github.com <https://github.com/>`_.
+      `GitHub.com <https://github.com/>`_.
 
    Gitk
       A repository browser that displays changes in a repository or a selected set of commits. It

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -11,14 +11,14 @@ Glossary
       Example: ``/home/user/Pictures/xkcd-webcomics/530.png``. See also :term:`relative path`.
 
    adjusted branch
-      (Git-annex term) TODO
+      (git-annex term) TODO
 
    annex
       Git annex concept: a different word for :term:`object-tree`.
 
    annex UUID
        A :term:`UUID` assigned to an annex of each individual :term:`clone` of a dataset repository.
-       :term:`Git-annex` uses this UUID to track file content availability information.
+       :term:`git-annex` uses this UUID to track file content availability information.
        The UUID is available under the configuration key ``annex.uuid`` and is stored in the
        configuration file of a local clone (``<dataset root>/.git/config``).
        A single dataset instance (i.e. a local clone) has exactly one annex UUID,
@@ -77,7 +77,7 @@ Glossary
       more about git in `this (free) book <https://git-scm.com/book/en/v2>`_
       or `these interactive Git tutorials <https://try.github.io/>`_ on :term:`GitHub`.
 
-   Git-annex
+   git-annex
       A distributed file synchronization system, enabling sharing and synchronizing collections
       of large files. It allows managing files with :term:`Git`, without checking the file content into Git.
 
@@ -124,7 +124,7 @@ Glossary
       A common text-editor.
 
    object-tree
-      Git-annex concept: The place where :term:`Git-annex` stores available file contents. Files that are annexed get
+      git-annex concept: The place where :term:`git-annex` stores available file contents. Files that are annexed get
       a :term:`symlink` added to :term:`Git` that points to the file content. A different word for :term:`annex`.
 
    provenance

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -415,7 +415,7 @@ please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
          $ sudo apt-update && sudo apt upgrade
 
-   - **Step 6**: Install datalad and everything it needs from Neurodebian
+   - **Step 6**: Install datalad and everything it needs from NeuroDebian
 
       .. code-block:: bash
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -19,7 +19,7 @@ The content in this chapter is largely based on the information given on the
 and the `DataLad documentation <http://docs.datalad.org/en/latest/gettingstarted.html>`_.
 
 Beyond DataLad itself, the installation requires Python, Pythons package manager ``pip``,
-:term:`Git`, and :term:`Git-annex`. The instructions below detail how to install
+:term:`Git`, and :term:`git-annex`. The instructions below detail how to install
 each of these components for different common operating systems. Please
 `file an issue <https://github.com/datalad-handbook/book/issues/new>`_
 if you encounter problems.
@@ -47,7 +47,7 @@ Also, should you be confused by the name:
 enabling this repository will not do any harm if your field is not neuroscience.
 
 The following command installs
-DataLad and all of its software dependencies (including the Git-annex-standalone package):
+DataLad and all of its software dependencies (including the git-annex-standalone package):
 
 .. code-block:: bash
 
@@ -69,7 +69,7 @@ can be installed with `Miniconda <https://docs.conda.io/en/latest/miniconda.html
   # upgrade to the latest release candidate to match the requires of the book
   $ conda install -c conda-forge/label/rc datalad
 
-This should install :term:`Git`, :term:`Git-annex`, and DataLad.
+This should install :term:`Git`, :term:`git-annex`, and DataLad.
 The installer automatically configures the shell to make conda-installed
 tools accessible, so no further configuration is necessary.
 
@@ -84,12 +84,12 @@ needs to be installed from the Mac App Store.
 Homebrew then can be installed using the command following the
 instructions on their webpage (linked above).
 
-Next, `install Git-annex <https://git-annex.branchable.com/install/OSX/>`_. The
+Next, `install git-annex <https://git-annex.branchable.com/install/OSX/>`_. The
 easiest way to do this is via ``brew``::
 
    $ brew install git-annex
 
-Once Git-annex is available, DataLad can be installed via Pythons package
+Once git-annex is available, DataLad can be installed via Pythons package
 manager ``pip`` as described below. ``pip`` should already be installed by
 default. Recent macOS versions may have ``pip3`` instead of ``pip`` -- use
 :term:`tab completion` to find out which is installed. If it is ``pip3``, run::
@@ -121,7 +121,7 @@ a user's home directory:
 
    $ pip install --user datalad~=0.12.0rc6
 
-In addition, it is necessary to have a current version of :term:`Git-annex` installed which is
+In addition, it is necessary to have a current version of :term:`git-annex` installed which is
 not set up automatically by using the ``pip`` method.
 You can find detailed installation instructions on how to do this
 `here <https://git-annex.branchable.com/install/>`__.
@@ -184,9 +184,9 @@ please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
         Note: Is has to be from ``conda-forge``, the anaconda version does not
         provide the ``cp`` command.
 
-   - **Step 3**: Install Git-annex
+   - **Step 3**: Install git-annex
 
-      - Obtain the current Git-annex versions installer
+      - Obtain the current git-annex versions installer
         `from here <https://downloads.kitenet.net/git-annex/windows/current/>`_.
         Save the file, and double click the downloaded
         :command:`git-annex-installer.exe` in your Downloads.
@@ -423,7 +423,7 @@ please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
    .. todo::
 
-      - maybe update Step 6 to use ``pip3`` to install DataLad and Git-annex.
+      - maybe update Step 6 to use ``pip3`` to install DataLad and git-annex.
 
 
 Initial configuration

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -13,7 +13,7 @@ you to fire up your terminal and follow along.
 
 You do not need to be a programmer, computer scientist, or Linux-crank.
 If you have never touched your computers shell before, you will be fine.
-No knowledge about :term:`Git` or :term:`Git-annex` is required or necessary.
+No knowledge about :term:`Git` or :term:`git-annex` is required or necessary.
 Regardless of your background and personal use cases for DataLad, the
 handbook will show you the principles of DataLad, and from chapter 1 onwards
 you will be using them.
@@ -87,10 +87,10 @@ Note further that...
 
 .. gitusernote::
 
-   DataLad uses :term:`Git` and :term:`Git-annex` underneath the hood. Readers that
+   DataLad uses :term:`Git` and :term:`git-annex` underneath the hood. Readers that
    are familiar with these tools can find occasional notes on how a DataLad
    command links to a Git(-annex) command or concept in boxes like this.
-   There is, however, absolutely no knowledge of Git or Git-annex necessary
+   There is, however, absolutely no knowledge of Git or git-annex necessary
    to follow this book. You will, though, encounter Git commands throughout
    the book when there is no better alternative, and executing those commands will
    suffice to follow along.

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -127,7 +127,7 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
    transform and work with it while capturing all :term:`provenance`,
    or share it with whomever you want). At the same time, DataLad does all of the magic
    necessary to get this awesome feature to work quietly in the background.
-   The annex is set-up automatically, and the tool :term:`Git-annex`
+   The annex is set-up automatically, and the tool :term:`git-annex`
    (https://git-annex.branchable.com) manages it all underneath the hood. Worry-free
    large-content data management? Check!
 

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -152,7 +152,7 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
 #. Simultaneously, though, DataLad aims to
    **maximize the (re-)use of existing 3rd-party data resources and infrastructure**.
    Users *can* use existing central infrastructure should they want to.
-   DataLad works with any infrastructure from :term:`Github` to
+   DataLad works with any infrastructure from :term:`GitHub` to
    `Dropbox <https://www.dropbox.com>`_, `Figshare <https://figshare.com/>`_
    or institutional repositories,
    enabling users to harvest all of the advantages of their preferred

--- a/docs/usecases/collaborative_data_management.rst
+++ b/docs/usecases/collaborative_data_management.rst
@@ -82,7 +82,7 @@ make it easier to keep his analysis organized and share it later.
 The dataset that Bob wants to work with is structural brain imaging data from the
 `studyforrest project <http://studyforrest.org/>`_, a public
 data resource that the original authors share as a DataLad dataset through
-:term:`Github`. This means that Bob can simply install the relevant dataset from this
+:term:`GitHub`. This means that Bob can simply install the relevant dataset from this
 service and into his own dataset. To do that, he installs it as a subdataset
 into a directory he calls ``src/`` as he wants to make it obvious which parts
 of his analysis steps and code require 3rd party data:

--- a/docs/usecases/collaborative_data_management.rst
+++ b/docs/usecases/collaborative_data_management.rst
@@ -64,7 +64,7 @@ to be a YODA dataset right at the time of creation:
    $ datalad create -c yoda --description "my 1st phd project on work computer" myanalysis
 
 After creation, there already is a ``code/`` directory, and all of its
-inputs are version-controlled by :term:`Git` instead of :term:`Git-annex`
+inputs are version-controlled by :term:`Git` instead of :term:`git-annex`
 thanks to the yoda procedure:
 
 .. runrecord:: _examples/collab-102

--- a/docs/usecases/datasets.rst
+++ b/docs/usecases/datasets.rst
@@ -44,7 +44,7 @@ all of these changes can be written to your DataLad datasets history.
 .. gitusernote::
 
    A DataLad dataset is a Git repository. Large file content in the
-   dataset in the annex is tracked with Git-annex. An ``ls -a``
+   dataset in the annex is tracked with git-annex. An ``ls -a``
    reveals that Git is secretly working in the background:
 
    .. runrecord:: _examples/dataset3

--- a/docs/usecases/datastorage_for_institutions.rst
+++ b/docs/usecases/datastorage_for_institutions.rst
@@ -76,7 +76,7 @@ calculations instead of data storage, the cluster gets a remote data
 store: Data lives as DataLad datasets on a different machine than the one
 the scientific analyses are computed on.
 For access to the annexed data in datasets, the data store is configured as a
-Git-annex `RIA-remote <https://libraries.io/pypi/ria-remote>`_.
+git-annex `RIA-remote <https://libraries.io/pypi/ria-remote>`_.
 In case of filesystem inode limitations on the machine
 serving as the data store (e.g., HPC storage systems), full datasets can be
 (compressed) 7-zip archives, without losing the ability to query available files.
@@ -136,11 +136,11 @@ but scaling requires them to use ``$COMPUTE``. Results from ``$COMPUTE`` are pus
 back to ``$DATA``, and hence anything that is relevant for a computation is tracked
 (and backed-up) there.
 
-The data store as a Git-annex RIA remote
+The data store as a git-annex RIA remote
 """"""""""""""""""""""""""""""""""""""""
 
-The remote data store exists thanks to Git-annex (which DataLad builds upon):
-Large files in datasets are stored as *values* in Git-annex's object tree. A *key*
+The remote data store exists thanks to git-annex (which DataLad builds upon):
+Large files in datasets are stored as *values* in git-annex's object tree. A *key*
 generated from their contents is checked into Git and used to reference the
 location of the value in the object tree [#f1]_. The object tree (or *keystore*)
 with the data contents can be located anywhere -- its location only needs to be
@@ -151,7 +151,7 @@ about where data is stored, as they can access it just as easily as before.
 .. findoutmore:: What is a special remote?
 
    A `special-remote <https://git-annex.branchable.com/special_remotes/>`_ is an
-   extension to Git's concept of remotes, and can enable Git-annex to transfer
+   extension to Git's concept of remotes, and can enable git-annex to transfer
    data to and from places that are not Git repositories (e.g., cloud services
    or external machines such as an HPC system). Don't envision a special-remote as a
    physical place or location -- a special-remote is just a protocol that defines
@@ -159,8 +159,8 @@ about where data is stored, as they can access it just as easily as before.
 
 The machines in question, parts of an old compute cluster, and parts of the
 supercomputer at the JSC are configured to receive and store data using the
-Git-annex remote for indexed file archives (`RIA <https://libraries.io/pypi/ria-remote>`_)
-special remote. The Git-annex RIA-remote is similar to Git-annex's built-in
+git-annex remote for indexed file archives (`RIA <https://libraries.io/pypi/ria-remote>`_)
+special remote. The git-annex RIA-remote is similar to git-annex's built-in
 `directory <https://git-annex.branchable.com/special_remotes/directory/>`_
 special remote, but distinct in certain aspects:
 
@@ -253,7 +253,7 @@ Here is how the RIA-remote features look like in real life:
   any standard dataset or repository -- contains the keystore (object tree) under
   ``annex/objects`` (highlighted above as well). Details on how this object tree
   is structured are outlined in the hidden section in :ref:`symlink`.
-- These keystores can be 7zipped if necessary to hold (additional) Git-annex objects,
+- These keystores can be 7zipped if necessary to hold (additional) git-annex objects,
   either for compression gains, or for use on HPC-systems with inode limitations.
 
 This implementation is fully self-contained, and is a plain file system storage,
@@ -299,7 +299,7 @@ control capabilities their work also becomes more transparent, open, and reprodu
 
 .. findoutmore:: Software Requirements
 
-   - Git-annex version 7.20 or newer
+   - git-annex version 7.20 or newer
    - DataLad version 0.12.5 (or later), or any DataLad development version more
      recent than May 2019 (critical feature: https://github.com/datalad/datalad/pull/3402)
    - The ``cfg_inm7`` run procedure as provided with ``pip install git+https://jugit.fz-juelich.de/inm7/infrastructure/inm7-datalad.git``
@@ -308,9 +308,9 @@ control capabilities their work also becomes more transparent, open, and reprodu
 
 .. rubric:: Footnotes
 
-.. [#f1] To re-read about how Git-annex's object tree works, check out section
+.. [#f1] To re-read about how git-annex's object tree works, check out section
          :ref:`symlink`, and pay close attention to the hidden section.
-         Additionally, you can find much background information in Git-annex's
+         Additionally, you can find much background information in git-annex's
          `documentation <https://git-annex.branchable.com/internals/>`_.
 
 .. [#f2] To re-read about DataLad's run-procedures, check out section

--- a/docs/usecases/reproducible-paper.rst
+++ b/docs/usecases/reproducible-paper.rst
@@ -40,7 +40,7 @@ by hand, he finally submits the paper. Trying to stand with his values of
 open and reproducible science, he struggles to bundle all scripts, algorithm code, and data
 he used in a shareable form, and frankly, with all the extra time this manuscript took
 him so far, he lacks motivation and time. In the end, he writes a three page long README
-file in his Github code repository, includes his email for data requests, and
+file in his GitHub code repository, includes his email for data requests, and
 secretly hopes that no-one will want to recompute his results, because by now even he
 himself forgot which script ran on which dataset and what data was fixed in which way,
 or whether he was careful enough to copy all of the results correctly. In the review process,
@@ -63,7 +63,7 @@ and within it, in the directory ``test/data/``, are additional DataLad subdatase
 contain the data he used for testing.
 Lastly, the DataLad superdataset contains a ``LaTeX`` ``.tex`` file with the text of the manuscript.
 When everything is set up, a single command line call triggers (optional) data retrieval
-from Github repositories of the datasets, computation of
+from GitHub repositories of the datasets, computation of
 results and figures, automatic embedding of results and figures into his manuscript
 upon computation, and PDF compiling.
 When he notices the error in his script, his manuscript is recompiled and updated
@@ -72,7 +72,7 @@ he updates the respective DataLad dataset
 to the fixed state while preserving the history of the data repository.
 
 
-He makes his superdataset a public repository on Github, and anyone who clones it can obtain the
+He makes his superdataset a public repository on GitHub, and anyone who clones it can obtain the
 data automatically and recompute and recompile the full manuscript with all results.
 Steve never had more confidence in his research results and proudly submits his manuscript.
 During review, the color scheme update in his algorithm sourcecode is integrated with a simple
@@ -129,14 +129,14 @@ live in the ``data/`` directory.
 To populate the DataLad dataset, add all the
 data collections you want to perform analyses on as individual DataLad subdatasets within
 ``data/``.
-In this example, all data collections are already DataLad datasets or git repositories and hosted on Github.
+In this example, all data collections are already DataLad datasets or git repositories and hosted on GitHub.
 :command:`datalad install` therefore installs them as subdatasets. ``-s`` specifies the source,
 and ``-d ../`` registers them as subdatasets to the superdataset [#f2]_.
 
 .. code-block:: bash
 
    $ cd data
-   # install existing git repositories with data (-s specifies the source, in this case, Github repositories)
+   # install existing git repositories with data (-s specifies the source, in this case, GitHub repositories)
    # -d points to the root of the superdataset
    datalad install -d ../ -s https://github.com/psychoinformatics-de/studyforrest-data-phase2.git
 
@@ -152,7 +152,7 @@ and ``-d ../`` registers them as subdatasets to the superdataset [#f2]_.
 Any script we need for the analysis should live inside ``code/``. During script writing, save any changes
 to you want to record in your history with :command:`datalad save`.
 
-The eventual outcome of this work is a Github repository that anyone can use to get the data
+The eventual outcome of this work is a GitHub repository that anyone can use to get the data
 and recompute all results
 when running the script after cloning and setting up the necessary software.
 This requires minor preparation:

--- a/versioneer.py
+++ b/versioneer.py
@@ -165,7 +165,7 @@ which may help identify what went wrong).
 ## Known Limitations
 
 Some situations are known to cause problems for Versioneer. This details the
-most significant ones. More can be found on Github
+most significant ones. More can be found on GitHub
 [issues page](https://github.com/warner/python-versioneer/issues).
 
 ### Subprojects


### PR DESCRIPTION
Please check individual commits.  
I guess the main arguable one is Git-annex -> git-annex.  Even though it is Git, Joey called it git-annex (lower cased) -- see https://git-annex.branchable.com.  I think it would be best to stick to the casing as used by the projects themselves, even though they might be confusingly different, like here Git and git-annex.

PS I was not allowed to push even trivial fix (Neurodebian) directly into master -- so now you are doomed to review! ;)