### PR TITLE
prepare minimal, functional cast on yoda project

### DIFF
--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -204,6 +204,8 @@ you use the ``cfg_yoda`` procedure to help you structure the dataset [#f1]_:
 .. runrecord:: _examples/DL-101-130-103
    :language: console
    :workdir: dl-101/DataLad-101
+   :cast: 10_yoda
+   :notes: Let's create a data analysis project with a yoda procedure
 
    # inside of DataLad-101
    $ datalad create -c yoda --dataset . midterm_project
@@ -232,6 +234,8 @@ by installing it as a subdataset. Make sure to install it as a subdataset of
 .. runrecord:: _examples/DL-101-130-105
    :language: console
    :workdir: dl-101/DataLad-101
+   :cast: 10_yoda
+   :notes: Now install input data as a subdataset
 
    $ cd midterm_project
    # we are in midterm_project, thus -d . points to the root of it.
@@ -246,9 +250,12 @@ looks like this:
 .. runrecord:: _examples/DL-101-130-106
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: here is how the directory structure looks like
 
    $ cd ../
    $ tree -d
+   $ cd midterm_project
 
 Importantly, all of the subdatasets are linked to the higher-level datasets,
 and despite being inside of ``DataLad-101``, your ``midterm_project`` is an independent
@@ -287,6 +294,8 @@ To compute the analysis you create the following Python script inside of ``code/
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
    :emphasize-lines: 5, 10, 13, 22, 41
+   :cast: 10_yoda
+   :notes: Let's create code for an analysis
 
    $ cat << EOT > code/script.py
 
@@ -349,6 +358,8 @@ Let's run a quick :command:`datalad status`...
 .. runrecord:: _examples/DL-101-130-108
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: datalad status will show a new file
 
    $ datalad status
 
@@ -359,6 +370,8 @@ point with the ``--version-tag`` option of :command:`datalad save`.
 .. runrecord:: _examples/DL-101-130-109
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: Save the analysis to the history
 
    $ datalad save -m "add script for kNN classification and plotting" --version-tag ready4analysis code/script.py
 
@@ -410,6 +423,8 @@ you can wrap the execution of the script (which is a simple
 .. runrecord:: _examples/DL-101-130-111
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: The datalad run command can reproducibly execute a command reproducibly
 
    $ datalad run -m "analyze iris data with classification analysis" \
      --input "input/iris.csv" \
@@ -439,6 +454,8 @@ dataset:
 .. runrecord:: _examples/DL-101-130-112
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: Let's take a look at the history
 
    $ git log --oneline
 
@@ -451,6 +468,8 @@ dataset that you can use for this [#f4]_.
 .. runrecord:: _examples/DL-101-130-113
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: create human readable information for your project
 
    # with the >| redirection we are replacing existing contents in the file
    $ cat << EOT >| README.md
@@ -470,15 +489,18 @@ dataset that you can use for this [#f4]_.
 .. runrecord:: _examples/DL-101-130-114
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: The README file is now modified
 
    $ datalad status
 
 .. runrecord:: _examples/DL-101-130-115
    :language: console
    :workdir: dl-101/DataLad-101/midterm_project
+   :cast: 10_yoda
+   :notes: Let's save this change
 
    $ datalad save -m "Provide project description" README.md
-
 
 Note that one feature of the YODA procedure was that it configured certain files
 (for example everything inside of ``code/``, and the ``README.md`` file in the

--- a/docs/code_from_chapters/10_yoda_code.rst
+++ b/docs/code_from_chapters/10_yoda_code.rst
@@ -1,0 +1,122 @@
+Code from chapter: 10_yoda
+--------------------------
+
+Code snippet 123::
+
+   # inside of DataLad-101
+   datalad create -c yoda --dataset . midterm_project
+
+
+Code snippet 124::
+
+   cd midterm_project
+   # we are in midterm_project, thus -d . points to the root of it.
+   datalad install -d . --source https://github.com/datalad-handbook/iris_data.git input/
+
+
+Code snippet 125::
+
+   cd ../
+   tree -d
+   cd midterm_project
+
+
+Code snippet 126::
+
+   cat << EOT > code/script.py
+
+   import pandas as pd
+   import seaborn as sns
+   import datalad.api as dl
+   from sklearn import model_selection
+   from sklearn.neighbors import KNeighborsClassifier
+   from sklearn.metrics import classification_report
+
+   data = "input/iris.csv"
+
+   # make sure that the data is obtained (get will also install linked sub-ds!):
+   dl.get(data)
+
+   # prepare the data as a pandas dataframe
+   df = pd.read_csv(data)
+   attributes = ["sepal_length", "sepal_width", "petal_length","petal_width", "class"]
+   df.columns = attributes
+
+   # create a pairplot to plot pairwise relationships in the dataset
+   plot = sns.pairplot(df, hue='class')
+   plot.savefig('pairwise_relationships.png')
+
+   # perform a K-nearest-neighbours classification with scikit-learn
+   # Step 1: split data in test and training dataset (20:80)
+   array = df.values
+   X = array[:,0:4]
+   Y = array[:,4]
+   test_size = 0.20
+   seed = 7
+   X_train, X_test, Y_train, Y_test = model_selection.train_test_split(X, Y,
+                                                                       test_size=test_size,
+                                                                       random_state=seed)
+   # Step 2: Fit the model and make predictions on the test dataset
+   knn = KNeighborsClassifier()
+   knn.fit(X_train, Y_train)
+   predictions = knn.predict(X_test)
+
+   # Step 3: Save the classification report
+   report = classification_report(Y_test, predictions, output_dict=True)
+   df_report = pd.DataFrame(report).transpose().to_csv('prediction_report.csv')
+
+   EOT
+
+
+Code snippet 127::
+
+   datalad status
+
+
+Code snippet 128::
+
+   datalad save -m "add script for kNN classification and plotting" --version-tag ready4analysis code/script.py
+
+
+Code snippet 129::
+
+   datalad run -m "analyze iris data with classification analysis" \
+     --input "input/iris.csv" \
+     --output "prediction_report.csv" \
+     --output "pairwise_relationships.png" \
+     "python3 code/script.py"
+
+
+Code snippet 130::
+
+   git log --oneline
+
+
+Code snippet 131::
+
+   # with the >| redirection we are replacing existing contents in the file
+   cat << EOT >| README.md
+
+   # Midterm YODA Data Analysis Project
+
+   ## Dataset structure
+
+   - All inputs (i.e. building blocks from other sources) are located in input/.
+   - All custom code is located in code/.
+   - All results (i.e., generated files) are located in the root of the dataset:
+     - "prediction_report.csv" contains the main classification metrics.
+     - "output/pairwise_relationships.png" is a plot of the relations between features.
+
+   EOT
+
+
+Code snippet 132::
+
+   datalad status
+
+
+Code snippet 133::
+
+   datalad save -m "Provide project description" README.md
+
+

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -162,7 +162,7 @@ Appendix
    contributing
    code_from_chapters/01_dataset_basics_code
    code_from_chapters/02_reproducible_execution_code
-
+   code_from_chapters/10_yoda_code
 
 * :ref:`genindex`
 * :ref:`search`


### PR DESCRIPTION
This can create a minimal YODA project example. The assortment of code snippets used consists of the following:

- Create ``midterm_project`` as a yoda-configured subdataset of DataLad-101
- Install the iris dataset as a subdataset
- Prepare a simple data analysis script
- Perform the analysis with ``datalad run``
- Add a human readable description

I am planning to use this cast in the Workshop in Aachen next week (see https://github.com/datalad-handbook/course/issues/18)

- [x] prepare cast (will be added to course repo in https://github.com/datalad-handbook/course/pull/21)
- [x] add code list