### PR TITLE
DataLad Colors

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -39,8 +39,9 @@ div.admonition-todo {
  * idea is to clearly set them apart from the normal
  * content, because they should be completely optional */
 div.gitusernote {
-    background-color: #c3ebffff;
-    border: 1px solid #7fd4ffff;
+    background-color: rgba(62, 44, 0, 0.2);
+    border: 2px solid rgba(241, 80, 47, 1);
+    border-style: groove;
 }
 
 div.sphinxsidebar {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -61,3 +61,24 @@ div.body li, div.body dd {
 table.docutils .justify-align {
     text-align: justify;
 }
+
+
+progress {
+  color: #ffa200;
+}
+
+progress::-webkit-progress-value {
+  background: #ffa200;
+}
+
+progress::-moz-progress-bar {
+  background: #ffa200;
+}
+
+progress::-webkit-progress-value {
+  background: #ffa200;
+}
+
+progress::-webkit-progress-bar {
+  background: #ffa200;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -7,7 +7,7 @@
 /* force the arrow into the same line */
 .toggle .header p {display: inline; }
 /*text color for fat text*/
-.toggle .header strong {color: #2980b9 }
+.toggle .header strong {color: #ffa200 }
 
 
 .toggle .header:before {
@@ -20,12 +20,12 @@
 
 .toggle {
     display: block;
-    border: 1px solid #2980b9;
+    border: 1px solid #333333ff;
     padding-top: 10px;
     padding-left: 10px;
     padding-right: 10px;
     padding-bottom: 10px;
-    background: rgba(41,128,185,0.1);
+    background: #eee;
 }
 
 /* make TODOslook plain and stand out at the same time

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,6 +280,19 @@ latex_elements = {
 \usepackage[defaultsans]{lato}
 \usepackage{inconsolata}
 \setcounter{tocdepth}{0}
+\usepackage{xcolor}
+\newsavebox\mytempbox
+\definecolor{sphinxnoteBgColor}{RGB}{255, 193, 84}
+\renewenvironment{sphinxnote}[1]
+   {\begin{lrbox}{\mytempbox}\begin{minipage}{\columnwidth}%
+    \begin{sphinxlightbox}\sphinxstrong{#1} }
+   {\end{sphinxlightbox}\end{minipage}\end{lrbox}%
+    \colorbox{sphinxnoteBgColor}{\usebox{\mytempbox}}}
+\renewenvironment{sphinximportant}[2]
+   {\begin{lrbox}{\mytempbox}\begin{minipage}{\columnwidth}%
+    \begin{sphinxlightbox}\sphinxstrong{#1} }
+   {\end{sphinxlightbox}\end{minipage}\end{lrbox}%
+    \colorbox{sphinxnoteBgColor}{\usebox{\mytempbox}}}
 """,
 }
 


### PR DESCRIPTION
This inches towards #38. A main deficiency of the PDF is that the colored admonition boxes are not preserved. Instead, notes or other directives that are not codeblocks are simply distinguished from normal text by a bit of spacing and table lines(?). This adds almost-DataLad-colored boxes around Note and Important directives (haven't figured out a general Admonition role yet...)


**Before**:

![image](https://user-images.githubusercontent.com/29738718/70083647-1e7b3b80-160d-11ea-8cf5-9bb4df69cccf.png)

**After**:

![image](https://user-images.githubusercontent.com/29738718/70083598-fd1a4f80-160c-11ea-8208-fe282f1f6ae1.png)


This needs further work (e.g., also TODOs are now brightly orange), but its a start 