### PR TITLE
Minor sentence and typo fixing

### DIFF
--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -151,7 +151,7 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
 
 #. Simultaneously, though, DataLad aims to
    **maximize the (re-)use of existing 3rd-party data resources and infrastructure**.
-   Users *can* use an existing central infrastructure should they want to.
+   Users *can* use existing central infrastructures should they want to.
    DataLad works with any infrastructure from :term:`GitHub` to
    `Dropbox <https://www.dropbox.com>`_, `Figshare <https://figshare.com/>`_
    or institutional repositories,

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -112,7 +112,7 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
    on the internet, or `anything else <https://media.giphy.com/media/3o6YfXCehdioMXYbcs/giphy.gif>`_.
 
 #. **A dataset is a Git repository**. 
-   A dataset is a Git repository. All features of the :term:`version control` system :term:`Git`
+   All features of the :term:`version control` system :term:`Git`
    also apply to everything managed by DataLad – plus many more.
    If you do not know or use Git yet, there is no need to panic – there is no necessity to 
    learn all of Git to follow along in learning and using DataLad. You will 
@@ -121,10 +121,10 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
    on how DataLad uses Git as a fundamental layer and learn some of Git.
 
 #. **A DataLad dataset can take care of managing and version controlling arbitrarily large data**.
-   To do this, it has an optional *annex* for (large) file content:
+   To do this, it has an optional *annex* for (large) file content.
    Thanks to this :term:`annex`, DataLad can easily track files that are many TB or PB in size
-   (something that Git could not do, and that allows you to restore previous versions of data,
-   transform and work with it while capturing all :term:`provenance`,
+   (something that Git could not do, and allows you to transform, work with, and restore previous 
+   versions of data, while capturing all :term:`provenance`,
    or share it with whomever you want). At the same time, DataLad does all of the magic
    necessary to get this awesome feature to work quietly in the background.
    The annex is set-up automatically, and the tool :term:`git-annex`
@@ -136,22 +136,22 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
    your files into something that only DataLad or a specialized tool can read.
    A PDF file (or any other type of
    file) stays a PDF file (or whatever other type of file it was)
-   whether it is managed by DataLad or not. This guarantees that users will not loose
-   data or data access if DataLad would vanish from their system, or even when DataLad
-   would vanish from the face of Earth. Using DataLad thus does not require or generate
+   whether it is managed by DataLad or not. This guarantees that users will not lose
+   data or access if DataLad would vanish from their system (or from the face of the 
+   Earth). Using DataLad thus does not require or generate
    data structures that can only be used or read with DataLad -- DataLad does not
    tie you down, it liberates you.
 
 #. Furthermore, DataLad is developed for **complete decentralization**.
    There is no required central server or service necessary to use DataLad. In this
-   way, no central infrastructure needs to be maintained (or paid for) --
-   your own laptop is the perfect place to live for your DataLad project, as is your
-   institutions webserver, or any other common computational infrastructure you
+   way, no central infrastructure needs to be maintained (or paid for).
+   Your own laptop is the perfect place for your DataLad project to live, as is your
+   institution's webserver, or any other common computational infrastructure you
    might be using.
 
 #. Simultaneously, though, DataLad aims to
    **maximize the (re-)use of existing 3rd-party data resources and infrastructure**.
-   Users *can* use existing central infrastructure should they want to.
+   Users *can* use an existing central infrastructure should they want to.
    DataLad works with any infrastructure from :term:`GitHub` to
    `Dropbox <https://www.dropbox.com>`_, `Figshare <https://figshare.com/>`_
    or institutional repositories,
@@ -164,10 +164,10 @@ it is not.
 
 Additionally, as some last key facts about DataLad, it comes with a
 command line interface enabling usage from within a terminal, and a Python API
-to use its features within your software and scripts. And while being a general,
+to use its features within your software and scripts. While being a general,
 multi-purpose tool, it comes with plenty of extensions that provide helpful,
 domain specific features that may very well fit your precise use case.
 
-But enough of the abstract talking.
-You came here to learn, and the handbook will not waste your time further by
-requiring you to only read -- let's start to *use* DataLad.
+But enough of the abstract talk.
+You came here to learn, and the handbook will not waste your time any further by
+having you only read about DataLad -- let's start to *use* DataLad.


### PR DESCRIPTION
The section ends with the paragraph "_But enough of the abstract talking. You came here to learn, and the handbook will not waste your time further by requiring you to only read – let’s start to use DataLad._"

However, the next section is "How to use the handbook". I suggest removing this pargraph, or moving it to the "How to use the handbook" section.