### PR TITLE
Tweaks to the structure of the later sections and chapter

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -43,4 +43,5 @@
   <li><a href="http://docs.datalad.org/en/latest/#">Developer Docs</a></li>
   <li><a href="https://github.com/datalad/datalad">Datalad@GitHub</a></li>
   <li><a href="https://github.com/datalad-handbook/book">Handbook@GitHub</a></li>
+  <li><a href="http://handbook.datalad.org/en/latest/101-180-FAQ.html">Frequently Asked Questions</a></li>
 </ul>

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -43,5 +43,5 @@
   <li><a href="http://docs.datalad.org/en/latest/#">Developer Docs</a></li>
   <li><a href="https://github.com/datalad/datalad">Datalad@GitHub</a></li>
   <li><a href="https://github.com/datalad-handbook/book">Handbook@GitHub</a></li>
-  <li><a href="http://handbook.datalad.org/en/latest/101-180-FAQ.html">Frequently Asked Questions</a></li>
+  <li><a href="http://handbook.datalad.org/en/latest/basics/101-180-FAQ.html">Frequently Asked Questions</a></li>
 </ul>

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -3,16 +3,9 @@
 How to get help
 ---------------
 
-After all of the DataLad-101 lectures and tutorials so far,
-you really begin to appreciate the pre-crafted examples the
-lecturer provided the students with.
-
-"Nothing really goes wrong, and if so, it's intended", you
-acknowledge. "But how does this prepare me for life after
-the course? I've seen a lot of different errors and know many
-caveats and principles already, but I certainly will mess
-something up at one point, and how will I get help then?"
-
+All DataLad errors or problems you encounter during ``DataLad-101`` are intentional
+and serve illustrative purposes. But what if you run into any DataLad errors
+outside of this course?
 Fortunately, the syllabus has a whole section on that, and on
 one lazy, warm summer-afternoon you flip through it.
 
@@ -82,7 +75,7 @@ as an excerpt here):
 .. runrecord:: _examples/DL-101-135-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :lines: 1-40
+   :lines: 1-60
 
    $ datalad get --help
 

--- a/docs/basics/101-135-intro.rst
+++ b/docs/basics/101-135-intro.rst
@@ -13,6 +13,6 @@ the dataset to undo what I screwed up? Also, I'm not sure whether I know what I
 can and can not do with the files inside of my dataset... What if I would
 like to remove one, for example?”
 
-Therefore, a this upcoming chapter is a series of tutorials about common
+Therefore, this upcoming chapter is a series of tutorials about common
 file system operations, interactions with the history of datasets, and how
 to get help after errors.

--- a/docs/basics/101-135-intro.rst
+++ b/docs/basics/101-135-intro.rst
@@ -1,0 +1,18 @@
+.. _intro:
+
+What to do if things go wrong
+-----------------------------
+
+After all of the DataLad-101 lectures and tutorials so far, you really begin to
+appreciate the pre-crafted examples and tasks the handbook provides.
+“Nothing really goes wrong, and if so, it’s intended”, you acknowledge.
+“But how does this prepare me for life after the course? I’ve seen a lot of
+different errors and know many caveats and principles already, but I certainly
+will mess something up at one point. How can I get help, or use the history of
+the dataset to undo what I screwed up? Also, I'm not sure whether I know what I
+can and can not do with the files inside of my dataset... What if I would
+like to remove one, for example?”
+
+Therefore, a this upcoming chapter is a series of tutorials about common
+file system operations, interactions with the history of datasets, and how
+to get help after errors.

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -229,8 +229,8 @@ with the HEAD pointer.
 
 .. findoutmore:: Git terminology: branches and HEADs?
 
-   A Git repository (and thus any DataLad dataset) is build up as a tree of
-   commits. A *branch* is a named pointer (reference) to a commit, and allows
+   A Git repository (and thus any DataLad dataset) is built up as a tree of
+   commits. A *branch* is a named pointer (reference) to a commit, and allows you
    to isolate developments. The default branch is called ``master``. ``HEAD`` is
    a pointer to the branch you are currently on, and thus to the last commit
    in the given branch.

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -277,7 +277,7 @@ to track:
 
    $ datalad save -m "save my favorite Git joke" Gitjoke2.txt
 
-Finally, lets check how the history looks afterwards:
+Finally, let's check how the history looks afterwards:
 
 .. runrecord:: _examples/DL-101-137-112
    :workdir: dl-101/DataLad-101

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -225,8 +225,28 @@ in your dataset -- just not written to the history anymore. Let's
 try this to get a feel for it.
 
 The COMMIT in the command can either be a hash or a reference
-with the HEAD pointer. Let's stay with the hash, and reset to the
-commit prior to saving the Gitjokes.
+with the HEAD pointer.
+
+.. findoutmore:: Git terminology: branches and HEADs?
+
+   A Git repository (and thus any DataLad dataset) is build up as a tree of
+   commits. A *branch* is a named pointer (reference) to a commit, and allows
+   to isolate developments. The default branch is called ``master``. ``HEAD`` is
+   a pointer to the branch you are currently on, and thus to the last commit
+   in the given branch.
+
+   .. figure:: ../artwork/src/git_branch_HEAD.png
+
+   Using ``HEAD``, you can identify the most recent commit, or count backwards
+   starting from the most recent commit. ``HEAD~1`` is the ancestor of the most
+   recent commit, i.e., one commit back (``f30ab`` in the figure above). Apart from
+   the notation ``HEAD~N``, there is also ``HEAD^N`` used to count backwards, but
+   less frequently used and of importance primarily in the case of *merge*
+   commits.
+   `This post <https://stackoverflow.com/questions/2221658/whats-the-difference-between-head-and-head-in-git>`__
+   explains the details well.
+
+Let's stay with the hash, and reset to the commit prior to saving the Gitjokes.
 
 First, find out the shasum, and afterwards, reset it.
 

--- a/docs/basics/101-179-gitignore.rst
+++ b/docs/basics/101-179-gitignore.rst
@@ -14,9 +14,9 @@ The most striking was that it by default
 will save the complete datasets status if one does not provide
 a path to a file change. This would result in all content
 that is either modified or untracked being saved in a single
-commit. This, by the way, is the reason why a :command:`datalad run`
-requires a clean dataset: The :command:`datalad save` that a :command:`datalad run` ends with
-internally should only save changes that can be attributed to
+commit. You know already that this is the reason why a :command:`datalad run`
+requires a clean dataset: The final :command:`datalad save` after
+:command:`datalad run` should only save changes that can be attributed to
 the command that was run, and not changes that existed already
 but were yet unsaved.
 

--- a/docs/code_from_chapters/intro.rst
+++ b/docs/code_from_chapters/intro.rst
@@ -1,0 +1,8 @@
+.. _codecasts:
+
+About code lists
+^^^^^^^^^^^^^^^^
+
+The following pages aggregate code examples from the book into a numbered list
+of easy to copy-paste code snippets. These sections are meant to be supplementary
+to lectures and workshops based on the handbook.

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -163,6 +163,16 @@ Appendix
    glossary
    basics/101-180-FAQ
    contributing
+
+########################
+Code lists from chapters
+########################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Easy access to copy-paste snippets for workshops
+
+   code_from_chapters/intro
    code_from_chapters/01_dataset_basics_code
    code_from_chapters/02_reproducible_execution_code
    code_from_chapters/10_yoda_code

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -116,13 +116,12 @@
 
 .. toctree::
    :maxdepth: 1
-   :caption: What to do if things go wrong
+   :caption: Dealing with problems, filesystems, and version histories
 
-   basics/101-135-help
+   basics/101-135-intro
    basics/101-136-filesystem
    basics/101-137-history
-   basics/101-180-FAQ
-
+   basics/101-135-help
 
 ###############################
 **Basics 9** -- Further options

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -161,6 +161,7 @@ Appendix
    :caption: Further information and references
 
    glossary
+   basics/101-180-FAQ
    contributing
    code_from_chapters/01_dataset_basics_code
    code_from_chapters/02_reproducible_execution_code


### PR DESCRIPTION
This attempts a clearer structure in the later sections of the book.

- FAQs are moved to Appendix, and linked in sidebar
- Code snippet lists have their own section and are moved out of the appendix
- The chapter "Help yourself" is reordered and has a short intro now