### PR TITLE
Improve flow of Introduction and a few adjustments with regard to the OHBM abstract

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -24,14 +24,17 @@ concepts of DataLad datasets together by creating one.
 
 Find a nice place on your computer's file system to put a dataset for ``DataLad-101``,
 and create a fresh, empty dataset with the :command:`datalad create` command (:manpage:`datalad-create` manual).
+
+Note the command structure of :command:`datalad create` (optional bits are enclosed in ``[ ]``)::
+
+  datalad create [--description "..."] [-c <config options>] PATH
+
 In a bit of time, you will thank yourself for adding a description about the *location*
 of your dataset with the *optional* ``--description`` flag. (At the moment,
 we will not dive into the details of where that description ends up or
 becomes useful in the future, but in more advanced parts of the book
-we will see how this gets handy.)
-Note the command structure of :command:`datalad create` (optional bits are enclosed in ``[ ]``)::
+we will see how this gets handy.) Let's start:
 
-  datalad create [--description "..."] [-c <config options>] PATH
 
 .. runrecord:: _examples/DL-101-101-101
    :language: console

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -4,7 +4,7 @@
 
 .. toctree::
    :maxdepth: 1
-   :caption: What DataLad is all about
+   :caption: What DataLad and the handbook are all about
 
    intro/philosophy
    intro/narrative

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -163,6 +163,7 @@ Appendix
    glossary
    basics/101-180-FAQ
    contributing
+   teaching
    acknowledgements
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,7 +17,7 @@ The steps below outline how the book "works". It is recommended to also create a
 to discuss changes or additions you plan to make in advance.
 
 Software setup
-""""""""""""""
+^^^^^^^^^^^^^^
 
 Depending on the size of your contribution, you may want to be able to build the book
 locally to test and preview your changes. If you are fixing typos, tweak the
@@ -65,7 +65,7 @@ a second machine ``/home/mih``, for example, leading to some potential confusion
 Therefore, you need to create this directory, and also --
 for consistency in the Git logs as well -- a separate, mock Git identity
 (we chose `Elena Piscopia <https://en.wikipedia.org/wiki/Elena_Cornaro_Piscopia>`_, the first
-woman to receive a PhD -- do not worry, this does not mess with your own Git identity):
+woman to receive a PhD. Do not worry, this does not mess with your own Git identity):
 
 .. code-block:: bash
 
@@ -74,11 +74,6 @@ woman to receive a PhD -- do not worry, this does not mess with your own Git ide
    $ HOME=/home/me git config --global user.name "Elena Piscopia"
    $ HOME=/home/me git config --global user.email "elena@example.net"
 
-.. todo::
-
-   remove separate Git identity until https://github.com/datalad/datalad/issues/3750
-   is fixed
-
 Once this is configured, you can build the book locally by running ``make`` in the root
 of the repository, and open it in your browser, for example with
 ``firefox docs/_build/html/index.html``.
@@ -86,7 +81,7 @@ of the repository, and open it in your browser, for example with
 .. _directive:
 
 Directives and casts
-""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^
 
 If you are writing larger sections that contain code, ``gitusernote``\s, ``findoutmore``\s,
 or other special directives, please make sure that you read this paragraph.
@@ -107,8 +102,8 @@ created content or dataset history. Build code snippets that add to these workin
 by using the ``runrecord`` directive. Commands wrapped in these will write the output
 of a command into example files stored inside of the DataLad Handbook repository clone
 in ``docs/PART/_examples`` (where ``PART`` is ``basics`` or ``usecases``).
-Make sure to name this files according to the following
-schema, because they are executed sequentially:
+Make sure to name these files according to the following
+schema, because they are executed *sequentially*:
 ``_examples/DL-101-1<nr-of-section>-1<nr-of-example>``, e.g.,
 ``_examples/DL-101-101-101`` for the first example in the first section
 of the given part.
@@ -124,8 +119,9 @@ Here is how a ``runrecord`` directive can look like:
       $ this line will be executed
 
 Afterwards, the resulting example files need to be committed into Git. To clear existing
-examples in ``docs/PART/_examples`` and the mock directories in ``/home/me``, run ``make clean`` and
-``make clean-examples``.
+examples in ``docs/PART/_examples`` and the mock directories in ``/home/me``, run
+``make clean`` (to remove working directories and examples for all parts of the book)
+or ``make clean-examples`` (to remove only examples and workdirs of the Basics part).
 
 However, for simple code snippets outside of the narrative of ``DataLad-101``,
 simple ``code-block::`` directives are sufficient.
@@ -180,6 +176,9 @@ the `DataLad Course <https://github.com/datalad-handbook/course>`_ to
 execute them::
 
    ~ course$ tools/cast_live path/to/casts
+
+The section :ref:`teach` outlines more on this and other teaching materials the
+handbook provides.
 
 .. _easy:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -80,7 +80,7 @@ of the repository, and open it in your browser, for example with
 
 .. _directive:
 
-Directives and casts
+Directives and demos
 ^^^^^^^^^^^^^^^^^^^^
 
 If you are writing larger sections that contain code, ``gitusernote``\s, ``findoutmore``\s,
@@ -131,7 +131,7 @@ simple ``code-block::`` directives are sufficient.
 (foldable sections that contain content that goes beyond the basics). Make use
 of them, if applicable to your contribution.
 
-**Creating code live casts out of runrecord directives**:
+**Creating live code demos out of runrecord directives**:
 The book has the capability to turn code snippets into a script that the tool
 `cast_live <https://github.com/datalad/datalad/blob/master/tools/cast_live>`_
 can use to cast and execute it in a demonstration shell. This feature is
@@ -139,15 +139,15 @@ intended for educational courses and other types of demonstrations. The
 following prerequisites exist:
 
 - A snippet only gets added to a cast, if the ``:cast:`` option in the
-  ``runrecord`` specifies a filename where to save the cast to (it does not
+  ``runrecord`` specifies a filename where to save the demo to (it does not
   need to be an existing file).
 - If ``:realcommand:`` options are specified, they will become the executable
   part of the cast. If note, the code snippet in the code-block of the
   ``runrecord`` will become the executable part of the cast.
 - An optional ``:notes:`` lets you add "speakernotes" for the cast.
-- Casts are produced upon ``make``, but only if the environment variable
+- Demos are produced upon ``make``, but only if the environment variable
   ``CAST_DIR`` is set.
-  This should be a path that points to any directory in which casts should be
+  This should be a path that points to any directory in which demos should be
   created and saved. An invocation could look like this::
 
      $ CAST_DIR=/home/me/casts make
@@ -170,7 +170,7 @@ execution of ``runrecords``. If you are adding code into an existing cast,
 i.e., in between two snippets that get written to the same cast, make sure that
 the cast will still run smoothly afterwards!
 
-**Running code live casts from created casts**:
+**Running live code demos from created casts**:
 If you have created a cast, you can use the tool ``live_cast`` in ``tools/`` in
 the `DataLad Course <https://github.com/datalad-handbook/course>`_ to
 execute them::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,14 +17,24 @@ The DataLad Handbook
 **Welcome to the DataLad handbook!**
 ------------------------------------
 
+This handbook is a living resource about why and -- more importantly -- *how* to
+use DataLad. It aims to provide novices and advanced users of all backgrounds
+with both the basics of DataLad and start-to-end use cases of specific
+applications. If you want to get hands-on experience and learn DataLad, the *Basics*
+part of this book will teach you. If you want to know what is possible, the
+*use cases* will show you. And if you want to help others to get started with DataLad,
+the `companion repository <https://github.com/datalad-handbook/course>`_ provides
+free and open source teaching material tailored to the handbook.
+
+Before you read on, please note that the handbook is based on **DataLad version 0.12**,
+but the section :ref:`install` will set you up with what you need if you currently do
+not have DataLad 0.12 or higher installed. If you're new here, please start
+the handbook `here <intro/philosophy.html>`_.
+
 .. important::
 
    The handbook is currently in beta stage.
    If you would be willing to provide feedback on its contents, please
    `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
-
-The handbook is based on **DataLad version 0.12**. The
-section :ref:`install` will set you up with what you need if you currently do
-not have DataLad 0.12 or higher installed.
 
 .. include:: contents.rst.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,18 +14,17 @@ The DataLad Handbook
       :alt: Virtual directory tree of a nested DataLad dataset
 
 
+**Welcome to the DataLad handbook!**
+------------------------------------
+
 .. important::
 
-   **Welcome to the DataLad handbook!**
-
-   We are happy about and greatly appreciate your interest in the handbook.
-   Currently, the handbook is under initial development. You are welcome to
-   check out the existing content, but please consider the handbook to be in
-   alpha stage -- expect thourough changes and developments in all aspects of
-   the book until further notice. Please also note that all examples are based
-   on **DataLad version 0.12**.
-
-   If you would be willing to provide feedback on this, or a future beta version, please
+   The handbook is currently in beta stage.
+   If you would be willing to provide feedback on its contents, please
    `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
+
+The handbook is based on **DataLad version 0.12**. The
+section :ref:`install` will set you up with what you need if you currently do
+not have DataLad 0.12 or higher installed.
 
 .. include:: contents.rst.inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ applications. If you want to get hands-on experience and learn DataLad, the *Bas
 part of this book will teach you. If you want to know what is possible, the
 *use cases* will show you. And if you want to help others to get started with DataLad,
 the `companion repository <https://github.com/datalad-handbook/course>`_ provides
-free and open source teaching material tailored to the handbook.
+`free and open source teaching material <teaching.html>`_ tailored to the handbook.
 
 Before you read on, please note that the handbook is based on **DataLad version 0.12**,
 but the section :ref:`install` will set you up with what you need if you currently do

--- a/docs/intro/executive_summary.rst
+++ b/docs/intro/executive_summary.rst
@@ -128,3 +128,6 @@ cheat-sheet in section
 .. todo::
 
    link cheat sheet
+
+But enough of the introduction now -- let's dive into the
+`Basics <../basics/101-101-create.html>`_!

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -11,6 +11,10 @@ Installation and configuration
   ``datalad~=0.12.0rc6``, via ``pip`` or ``conda``. Until 0.12 is released, please use
   ``pip`` or ``conda``-based methods to install the release candidate.
 
+  If you already have DataLad installed but are unsure whether it is the correct
+  version, you can get information on your version of DataLad by typing
+  ``datalad --version`` into your terminal.
+
 Install DataLad
 ^^^^^^^^^^^^^^^
 

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -38,8 +38,8 @@ As the handbook is to be a practical guide it includes as many hands-on examples
 as we can fit into it. Code snippets look like this, and you should
 **copy them into your own terminal to try them out**, but you can also
 **modify them to fit your custom needs in your own use cases**.
-Note in the example below that shows the creation of a DataLad dataset how
-we distinguish ``comments (#)`` from ``commands ($)`` and their output:
+Note how we distinguish ``comments (#)`` from ``commands ($)`` and their output
+in the example below (it shows the creation of a DataLad dataset):
 
 .. code-block:: bash
 
@@ -55,10 +55,12 @@ error when executed.
 
 The book is split in two different parts. The upcoming chapters
 are the *Basics* that intend to show you the core DataLad functionality
-and challenges you to use it. It is recommended to start with this part
-and read it from start to end.
+and challenge you to use it. If you want to learn how to use DataLad, it is
+recommended to start with this part and read it from start to end.
 In the chapter *use cases* you will find concrete examples of
 DataLad applications for general inspiration -- this is the second part of this book.
+If you want to get an overview of what is possible with DataLad, this section will
+show you in a concise and non-technical manner.
 Pick whatever you find interesting and disregard the rest. Afterwards,
 you might even consider :ref:`contribute` to this book by sharing your own use case.
 
@@ -94,7 +96,7 @@ Note further that...
    the book when there is no better alternative, and executing those commands will
    suffice to follow along.
 
-Apart from core DataLad commands (introduced in the second part of this book),
+Apart from core DataLad commands (introduced in the *Basics* part of this book),
 DataLad also comes with many extensions and advanced commands not (yet) referenced
 in this handbook. The development of many of these features
 is ongoing, and this handbook will incorporate all DataLad commands and extensions

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -81,20 +81,18 @@ evolution**?
 digital workflow of using data -- regardless of the data's type, content, size,
 location, generation, or development.  It provides functionality to share,
 search, obtain, and version control data in a distributed fashion, and it aids
-managing the evolution of digital objects in a way that fulfills the FAIR
+managing the evolution of digital objects in a way that fulfills the `FAIR <https://www.go-fair.org/>`_
 principles.
-
-This handbook is a living resource about why and -- more importantly -- *how* to
-use DataLad. It aims to provide novices and advanced users of all backgrounds
-with both the basics of DataLad and start-to-end use cases of specific
-applications. Jump right into the handbook, and be ready to use your computer as
-this handbook is a hands-on experience.
 
 
 The DataLad Philosophy
 ^^^^^^^^^^^^^^^^^^^^^^
+From a software point of view, DataLad is a command line tool, with an additional
+Python API to use its features within your software and scripts.
+While being a general, multi-purpose tool, there are also plenty of extensions
+that provide helpful, domain specific features that may very well fit your precise use case.
 
-DataLad is built up on a handful of principles. It is this underlying philosophy
+But beyond software facts, DataLad is built up on a handful of principles. It is this underlying philosophy
 that captures the spirit of what DataLad is, and here is a brief overview on it.
 
 #. **DataLad only cares (knows) about two things: Datasets and files.**
@@ -160,14 +158,7 @@ that captures the spirit of what DataLad is, and here is a brief overview on it.
 
 These principles hopefully gave you some idea of what to expect from DataLad,
 cleared some worries that you might have had, and highlighted what DataLad is and what
-it is not.
-
-Additionally, as some last key facts about DataLad, it comes with a
-command line interface enabling usage from within a terminal, and a Python API
-to use its features within your software and scripts. While being a general,
-multi-purpose tool, it comes with plenty of extensions that provide helpful,
-domain specific features that may very well fit your precise use case.
-
-But enough of the abstract talk.
-You came here to learn, and the handbook will not waste your time any further by
-having you only read about DataLad -- let's start to *use* DataLad.
+it is not. The section :ref:`executive_summary` will give you a one-page summary
+of the functionality and commands you will learn with this handbook. But before we
+get there, let's get ready to *use* DataLad. For this, the next
+section will show you how to use the handbook.

--- a/docs/teaching.rst
+++ b/docs/teaching.rst
@@ -31,29 +31,29 @@ Slides are made using `reveal.js <https://github.com/hakimel/reveal.js/>`_.
 They are available as PDFs in ``talks/PDFs/``, or as the source ``html`` files
 in ``talks/``.
 
-Enhance talks and workshops with code casts
+Enhance talks and workshops with code demos
 """""""""""""""""""""""""""""""""""""""""""
 
 Any number of code snippets in the handbook that are created with the ``runrecord``
 directive can be aggregated into a series of commands that can be sequentially
-executed as a code cast using the
+executed as a code demo using the
 `cast_live <https://github.com/datalad-handbook/course/blob/master/tools/cast_live>`_
 tool provided in the `companion course repository <https://github.com/datalad-handbook/course>`_.
-These code casts allow you to remote-control a second terminal that executes
+These code demos allow you to remote-control a second terminal that executes
 the code snippets upon pressing ``Enter`` and can provide you with simultaneous
 speaker notes.
 
-A number of casts exist that accompany the slides for the data management sessions
-in ``casts``, but you can also create your own casts. To find out how to do this,
-please consult the section `directives and casts <http://handbook.datalad.org/en/latest/contributing.html#directives-and-casts>`_
+A number of demos exist that accompany the slides for the data management sessions
+in ``casts``, but you can also create your own. To find out how to do this,
+please consult the section `directives and demos <http://handbook.datalad.org/en/latest/contributing.html#directives-and-demos>`_
 in the contributing guide.
 To use the tool, download the ``cast_live`` script and the ``cast_bash.rc`` file
 that accompanies it (e.g., by simply cloning/installing the
-course repository), and provide a path to the cast you want to run::
+course repository), and provide a path to the demo you want to run::
 
    $ cast_live casts/01_dataset_basics
 
-For existing casts, the chapter `Code from chapters <code_from_chapters/intro.html>`_
+For existing code demos, the chapter `Code from chapters <code_from_chapters/intro.html>`_
 contains numbered lists of code snippets to allow your audience to copy-paste what
 you execute to follow along.
 

--- a/docs/teaching.rst
+++ b/docs/teaching.rst
@@ -1,0 +1,85 @@
+.. _teach:
+
+Teaching with the DataLad Handbook
+----------------------------------
+
+The handbook is a free and open source educational instrument made available
+under a Creative Commons Attribution-ShareAlike (CC-BY-SA) license [#f1]_.
+We are happy if the handbook serves as a helpful tool for other trainers, and
+try to provide many useful additional teaching-related functions and contents.
+Below, you can find them listed:
+
+Use the handbook as a textbook/syllabus
+"""""""""""""""""""""""""""""""""""""""
+
+The Basics sections of the handbook is a stand-alone course that you can refer
+trainees to. Regardless of background, users should be able to work through this
+part of the book on their own. From our own teaching experiences, it is feasible
+and useful to work through any individual basics chapter in one go, and assign
+them as weekly or bi-weekly readings.
+
+Use slides from the DataLad course
+""""""""""""""""""""""""""""""""""
+
+In parallel to the handbook, we are conducting data management workshops with
+attendees of every career stage (MSc students up to PIs). The sessions are either
+part of a lecture series (with bi-weekly 90 minute sessions) or workshops of different
+lengths. Sessions in the lecture series are based on each chapter. Longer workshops
+combine several chapters. You can find the slides for the workshops in the
+`companion course repository <https://github.com/datalad-handbook/course>`_.
+Slides are made using `reveal.js <https://github.com/hakimel/reveal.js/>`_.
+They are available as PDFs in ``talks/PDFs/``, or as the source ``html`` files
+in ``talks/``.
+
+Enhance talks and workshops with code casts
+"""""""""""""""""""""""""""""""""""""""""""
+
+Any number of code snippets in the handbook that are created with the ``runrecord``
+directive can be aggregated into a series of commands that can be sequentially
+executed as a code cast using the
+`cast_live <https://github.com/datalad-handbook/course/blob/master/tools/cast_live>`_
+tool provided in the `companion course repository <https://github.com/datalad-handbook/course>`_.
+These code casts allow you to remote-control a second terminal that executes
+the code snippets upon pressing ``Enter`` and can provide you with simultaneous
+speaker notes.
+
+A number of casts exist that accompany the slides for the data management sessions
+in ``casts``, but you can also create your own casts. To find out how to do this,
+please consult the section `directives and casts <http://handbook.datalad.org/en/latest/contributing.html#directives-and-casts>`_
+in the contributing guide.
+To use the tool, download the ``cast_live`` script and the ``cast_bash.rc`` file
+that accompanies it (e.g., by simply cloning/installing the
+course repository), and provide a path to the cast you want to run::
+
+   $ cast_live casts/01_dataset_basics
+
+For existing casts, the chapter `Code from chapters <code_from_chapters/intro.html>`_
+contains numbered lists of code snippets to allow your audience to copy-paste what
+you execute to follow along.
+
+
+Use artwork used in the handbook
+""""""""""""""""""""""""""""""""
+
+The handbook's `artwork <https://github.com/datalad-handbook/artwork>`_ repository
+contains the sources for figures used in the handbook.
+
+Use the handbook as a template for your own teaching material
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If you want to document a different software tool in a similar way the handbook does
+it, please feel free to use the handbook as a template.
+
+
+
+.. rubric:: Footnotes
+
+.. [#f1] CC-BY-SA means that you are free to
+
+    - share - copy and redistribute the material in any medium or format
+    - adapt - remix, transform, and build upon the material for any purpose, even commercially
+
+    under the following terms:
+
+    #. Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+    #. ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.


### PR DESCRIPTION
This introduces changes to the first parts of the book:

- I'm removing the alpha stage note on the front page, and replace it with a short introduction of the aims of the handbook as stated in our abstract
- A few tweaks to some introductory sections to connect them better, define the scope, a bit of restructuring, ...
- Adding a ``Teaching with the DataLad Handbook`` section that points to the educational resources for trainers we provide