### PR TITLE
always append mih as last author to list of authors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,9 @@ authors = [
         (Path(__file__).parent.parent / '.all-contributorsrc').open()).get(
             'contributors', [])
 ]
+# make sure mih is last author
+authors.append(authors.pop(authors.index('Michael Hanke')))
+
 
 # autorunrecord setup (extension used to run and capture the output of
 # examples)


### PR DESCRIPTION
The change in this PR ensures that @mih will always stay the last author of the book in the PDF version.