### PR TITLE
Mention git annex unannex

### DIFF
--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -606,6 +606,61 @@ section.
       $ cd ../DataLad-101 && git reset --hard master
 
 
+Getting contents out of git-annex
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Files in your dataset can either be handled by :term:`Git` or :term:`Git-annex`.
+Self-made or predefined configurations to ``.gitattributes``, defaults, or the
+``--to-git`` option to :command:`datalad save` allow you to control which tool
+does what on up to single-file basis. Accidentally though, you may give a file of yours
+to git-annex when it was intended to be stored in Git, or you want to get a previously
+annexed file into Git.
+
+Consider you intend to share the cropped ``.png`` images you created from the
+``longnow`` logos. Would you publish your ``DataLad-101`` dataset so :term:`GitHub`
+or :term:`GitLab`, these files would not be available to others, because annexed
+dataset contents can not be published to these services.
+Even though you could find a third party service of your choice
+and publish your dataset *and* the annexed data (section
+
+.. todo::
+
+   link section (:ref: `sharethirdparty`) once done
+
+will demonstrate how this can be done), you're feeling lazy today. And since it
+is only two files, and they are quite small, you decide to store them in Git --
+this way, the files would be available without configuring an external data
+store.
+
+To get contents out of the dataset's annex you need to *unannex* them. This is
+done with the git-annex command :command:`git annex unannex`. Let's see how it
+works:
+
+.. runrecord:: _examples/DL-101-136-147
+   :language: console
+   :workdir: dl-101/DataLad-101
+
+   $ git annex unannex recordings/*logo_small.jpg
+
+Your dataset's history records the unannexing of the files.
+
+.. runrecord:: _examples/DL-101-136-148
+   :language: console
+   :workdir: dl-101/DataLad-101
+
+   $ git log -p -n 1
+
+Once files have been unannexed, they are "untracked" again, and you can save them
+into Git, either by adding a rule to ``.gitattributes``, or with
+:command:`datalad save --to-git`:
+
+.. runrecord:: _examples/DL-101-136-149
+   :language: console
+   :workdir: dl-101/DataLad-101
+
+   $ datalad save --to-git -m "save cropped logos to Git" recordings/*jpg
+
+
 Deleting (annexed) files/directories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -324,8 +324,8 @@ annexed would revert the save of the symlink into Git, but it will
 not revert the *annexing* of the file.
 Thus, what will be left in the dataset is an untracked symlink.
 
-To undo an accidental save that annexed a file, the annexed file
-has to be "unannexed" first with a :command:`datalad unlock` command.
+To undo an accidental save of that annexed a file, the annexed file
+has to be "unlocked" first with a :command:`datalad unlock` command.
 
 We will simulate such a situation by creating a PDF file that
 gets annexed with an accidental :command:`datalad save`:

--- a/docs/basics/_examples/DL-101-136-147
+++ b/docs/basics/_examples/DL-101-136-147
@@ -1,0 +1,3 @@
+$ git annex unannex recordings/*logo_small.jpg
+unannex recordings/interval_logo_small.jpg ok
+unannex recordings/salt_logo_small.jpg ok

--- a/docs/basics/_examples/DL-101-136-148
+++ b/docs/basics/_examples/DL-101-136-148
@@ -1,0 +1,23 @@
+$ git log -p -n 1
+commit efb894252c434dca89c158c257d40c3403a73da1
+Author: Elena Piscopia <elena@example.net>
+Date:   Thu Jan 9 10:54:33 2020 +0100
+
+    content removed from git annex
+
+diff --git a/recordings/interval_logo_small.jpg b/recordings/interval_logo_small.jpg
+deleted file mode 120000
+index f4d6fd6..0000000
+--- a/recordings/interval_logo_small.jpg
++++ /dev/null
+@@ -1 +0,0 @@
+-../.git/annex/objects/36/jF/MD5E-s100877--0fea9537f9fe255d827e4401a7d539e7.jpg/MD5E-s100877--0fea9537f9fe255d827e4401a7d539e7.jpg
+\ No newline at end of file
+diff --git a/recordings/salt_logo_small.jpg b/recordings/salt_logo_small.jpg
+deleted file mode 120000
+index 55ada0f..0000000
+--- a/recordings/salt_logo_small.jpg
++++ /dev/null
+@@ -1 +0,0 @@
+-../.git/annex/objects/xJ/4G/MD5E-s260607--4e695af0f3e8e836fcfc55f815940059.jpg/MD5E-s260607--4e695af0f3e8e836fcfc55f815940059.jpg
+\ No newline at end of file

--- a/docs/basics/_examples/DL-101-136-149
+++ b/docs/basics/_examples/DL-101-136-149
@@ -1,0 +1,7 @@
+$ datalad save --to-git -m "save cropped logos to Git" recordings/*jpg
+add(ok): recordings/interval_logo_small.jpg (file)
+add(ok): recordings/salt_logo_small.jpg (file)
+save(ok): . (dataset)
+action summary:
+  add (ok: 2)
+  save (ok: 1)


### PR DESCRIPTION
This closes #303. I have added a paragraph on ``git annex unlock``, and how to get previously annexed contents stored in Git.