### PR TITLE
Fix code that works to build the book but not when copied

### DIFF
--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -280,7 +280,7 @@ like this into a single line.
    $ datalad download-url http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf \
      --dataset . \
      -m "add beginners guide on bash" \
-     -O books/bash_guide.pdf \
+     -O books/bash_guide.pdf
 
 Afterwards, a fourth book is inside your ``books/`` directory:
 

--- a/docs/basics/101-132-advancednesting.rst
+++ b/docs/basics/101-132-advancednesting.rst
@@ -174,7 +174,7 @@ dataset, i.e., ``DataLad-101``, as the dataset to save to:
    :language: console
    :workdir: dl-101/DataLad-101/
 
-   $ datalad save -d . -m "finished my midterm project!" midterm_project
+   $ datalad save -d . -m "finished my midterm project" midterm_project
 
 .. findoutmore:: More on how save can operate on nested datasets
 

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -583,7 +583,7 @@ but also a modification to ``notes.txt``:
    :language: console
    :workdir: dl-101/DataLad-101
 
-   $ cat << EOT > notes.txt
+   $ cat << EOT >> notes.txt
 
    Git has many handy tools to go back in forth in
    time and work with the history of datasets.

--- a/docs/basics/_examples/DL-101-102-112
+++ b/docs/basics/_examples/DL-101-102-112
@@ -1,7 +1,7 @@
 $ datalad download-url http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf \
   --dataset . \
   -m "add beginners guide on bash" \
-  -O books/bash_guide.pdf \
+  -O books/bash_guide.pdf
 [INFO] Downloading 'http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf' into '/home/me/dl-101/DataLad-101/books/bash_guide.pdf'
 download_url(ok): /home/me/dl-101/DataLad-101/books/bash_guide.pdf (file)
 add(ok): books/bash_guide.pdf (file)

--- a/docs/basics/_examples/DL-101-132-110
+++ b/docs/basics/_examples/DL-101-132-110
@@ -1,4 +1,4 @@
-$ datalad save -d . -m "finished my midterm project!" midterm_project
+$ datalad save -d . -m "finished my midterm project" midterm_project
 add(ok): midterm_project (file)
 save(ok): . (dataset)
 action summary:

--- a/docs/basics/_examples/DL-101-137-142
+++ b/docs/basics/_examples/DL-101-137-142
@@ -1,4 +1,4 @@
-$ cat << EOT > notes.txt
+$ cat << EOT >> notes.txt
 
 Git has many handy tools to go back in forth in
 time and work with the history of datasets.


### PR DESCRIPTION
Not a problem for the handbook build, but executing the full command in the terminal when copied from the book will not work.