### PR TITLE
Hidden index pages between sections

### DIFF
--- a/docs/basics/intro.rst
+++ b/docs/basics/intro.rst
@@ -1,0 +1,12 @@
+.. _basics-intro:
+
+Basics
+------
+
+The Basics will show you the building blocks of DataLad in a continuous narrative.
+Start up a terminal, and code along!
+For the best experience, try reading the Basics chapter sequentially.
+
+
+.. figure:: ../artwork/src/building_blocks.svg
+   :width: 70%

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -12,10 +12,14 @@
    intro/howto
    intro/executive_summary
 
-
 ################################
 **Basics 1** -- DataLad datasets
 ################################
+
+.. toctree::
+   :hidden:
+
+   basics/intro.rst
 
 .. toctree::
    :maxdepth: 1
@@ -141,6 +145,11 @@
 #############
 **Use Cases**
 #############
+
+.. toctree::
+   :hidden:
+
+   usecases/intro
 
 .. toctree::
    :maxdepth: 1

--- a/docs/usecases/intro.rst
+++ b/docs/usecases/intro.rst
@@ -1,0 +1,21 @@
+.. _usecase-intro:
+
+Usecases
+--------
+
+In this part of the book you will find concrete examples of DataLad applications for general
+inspiration. You can get an overview of what is possible by browsing through them,
+and step-by-step solutions for a range of problems in every single one.
+Provided you have read the previous :ref:`basics-intro` sections, the usecases' code
+examples are sufficient (though sparser than in Basics) to recreate or apply
+the solutions they demonstrate.
+
+.. figure:: ../artwork/src/recipe.svg
+   :width: 70%
+
+Contributing
+^^^^^^^^^^^^
+
+If you are using DataLad for a use  case that is not yet in this chapter, we would
+be delighted to have you tell us about it in the form of a usecase.
+Please see the `contributing guide <../contributing.html>`_ for more info.

--- a/docs/usecases/intro.rst
+++ b/docs/usecases/intro.rst
@@ -13,6 +13,19 @@ the solutions they demonstrate.
 .. figure:: ../artwork/src/recipe.svg
    :width: 70%
 
+
+**Use case overview:**
+
+.. toctree::
+   :maxdepth: 1
+
+   collaborative_data_management
+   provenance_tracking
+   reproducible-paper
+   supervision
+   reproducible_neuroimaging_analysis
+   datastorage_for_institutions
+
 Contributing
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
This adds a hidden page between "Introduction" and "Basics" and between "Basics" and "Usecases". They are hidden in the toctree, but readers can get to them if they navigate from section to section with the side bar navigation.
These intermediate pages should notify readers that they are transitioning from one part of the book to another, which is particularly helpful between Basics and Usecases, since there is no clear "The Basics end here" in the at this point last Basics section.