### PR TITLE
Further Latex improvements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -278,7 +278,7 @@ latex_show_urls = 'footnote'
 latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',
-    'figure_align': 'tbp',
+    'figure_align': 'H',
     'fncychap' : r'\usepackage[Bjarne]{fncychap}',
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     'preamble': r"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,7 +274,7 @@ latex_logo = None
 
 latex_toplevel_sectioning = 'part'
 latex_show_pagerefs = True
-#latex_show_urls = 'footnote'
+latex_show_urls = 'footnote'
 latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,6 +279,7 @@ latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',
     'figure_align': 'H',
+    'extraclassoptions': 'openany,oneside',
     'fncychap' : r'\usepackage[Bjarne]{fncychap}',
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     'preamble': r"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,24 +279,14 @@ latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',
     'figure_align': 'tbp',
+    'fncychap' : r'\usepackage[Bjarne]{fncychap}',
+    'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     'preamble': r"""
 \usepackage{charter}
 \usepackage[defaultsans]{lato}
 \usepackage{inconsolata}
 \setcounter{tocdepth}{0}
 \usepackage{xcolor}
-\newsavebox\mytempbox
-\definecolor{sphinxnoteBgColor}{RGB}{255, 193, 84}
-\renewenvironment{sphinxnote}[1]
-   {\begin{lrbox}{\mytempbox}\begin{minipage}{\columnwidth}%
-    \begin{sphinxlightbox}\sphinxstrong{#1} }
-   {\end{sphinxlightbox}\end{minipage}\end{lrbox}%
-    \colorbox{sphinxnoteBgColor}{\usebox{\mytempbox}}}
-\renewenvironment{sphinximportant}[2]
-   {\begin{lrbox}{\mytempbox}\begin{minipage}{\columnwidth}%
-    \begin{sphinxlightbox}\sphinxstrong{#1} }
-   {\end{sphinxlightbox}\end{minipage}\end{lrbox}%
-    \colorbox{sphinxnoteBgColor}{\usebox{\mytempbox}}}
 """,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,7 +274,7 @@ latex_logo = None
 
 latex_toplevel_sectioning = 'part'
 latex_show_pagerefs = True
-latex_show_urls = 'footnote'
+#latex_show_urls = 'footnote'
 latex_elements = {
     'papersize': 'a4',
     'pointsize': '11pt',

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -209,7 +209,9 @@ Code lists from chapters
 ..
   stuff that we do not need or show at the moment
 
-.. toctree::
-   :hidden:
+.. only:: adminmode
 
-   usecases/datasets
+   .. toctree::
+      :hidden:
+
+      usecases/datasets

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -162,3 +162,19 @@ it is not. The section :ref:`executive_summary` will give you a one-page summary
 of the functionality and commands you will learn with this handbook. But before we
 get there, let's get ready to *use* DataLad. For this, the next
 section will show you how to use the handbook.
+
+.. raw:: latex
+
+   \begingroup
+   \sphinxsetup{%
+         VerbatimColor={named}{OldLace},
+         TitleColor={named}{DarkGoldenrod},
+         hintBorderColor={named}{LightCoral},
+         attentionborder=3pt,
+         attentionBorderColor={named}{Crimson},
+         attentionBgColor={named}{FloralWhite},
+         noteborder=2pt,
+         noteBorderColor={named}{Orange},
+         cautionborder=3pt,
+         cautionBorderColor={named}{Cyan},
+         cautionBgColor={named}{LightCyan}}


### PR DESCRIPTION
- ~remove URLs in Footnotes. We can rely on the href'ed text~
- Colored subheadings in more DataLad-dy color scheme, code boxes. TODO directives are not brightly orange anymore, but framed between slim orange bars
- Enforce figure positions in the text. This places the figures where they need to be, and prevents empty pages surrounding a single figure on an additional otherwise empty page.
- remove blank pages after toctrees and after headings (-> 50 pages fewer).