### PR TITLE
restructure and fix zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,11 +3,6 @@
   "description": "<p>The DataLad Handbook is a comprehensive educational resource for data management with DataLad.</p>",
   "creators": [
     {
-      "name": "Hanke, Michael",
-      "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
-      "orcid": "0000-0001-6398-6370"
-    },
-    {
       "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
       "name": "Wagner, Adina S.",
       "orcid": "0000-0003-2917-3450"
@@ -16,12 +11,10 @@
       "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
       "name": "Waite, Laura K.",
       "orcid": "0000-0003-2213-7465"
-    }
-  ],
-  "contributors": [
+    },
     {
       "affiliation": "Dartmouth College, Hanover, NH, United States",
-      "name": "Meyer, Kyle",
+      "name": "Meyer, Kyle"
     },
     {
       "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
@@ -100,7 +93,12 @@
     },
     {
      "name": "Hutton, Alexandre",
-     "affiliation": "McGill University",
+     "affiliation": "McGill University"
+    },
+    {
+      "name": "Hanke, Michael",
+      "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
+      "orcid": "0000-0001-6398-6370"
     }
   ],
   "keywords": [


### PR DESCRIPTION
- There were two commas that invalidated the json file
- Removed creators versus contributors distinction to put mih at the bottom to be last author

[jsonlint](https://jsonlint.com/) says its valid json, and authorship is fixed to Wagner, A. S. ... & Hanke, M.