### PR TITLE
attempt correct meta data descriptors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -110,5 +110,6 @@
   ],
   "access_right": "open",
   "license": "CC-BY-SA",
-  "upload_type": "book"
+  "upload_type": "publication",
+  "publication_type": "book"
 }


### PR DESCRIPTION
Previous zenodo archival attempts failed, 'https://developers.zenodo.org/#representation' hints at
wrong meta data information about upload types