### PR TITLE
Cheatsheetfix

### DIFF
--- a/docs/basics/101-136-cheatsheet.rst
+++ b/docs/basics/101-136-cheatsheet.rst
@@ -6,5 +6,5 @@ DataLad cheat sheet
 Click on the image below to obtain a PDF version of the cheat sheet. Individual
 sections are linked to chapters or technical docs.
 
-.. figure:: ../artwork/src/datalad-cheatsheet.svg
+.. figure:: ../artwork/src/datalad-cheatsheet_p1_plain.svg
    :target: https://github.com/datalad-handbook/artwork/blob/master/src/datalad-cheatsheet.pdf


### PR DESCRIPTION
This fixes #360. 
I have pushed updates to the submodules Makefile that render a separate, page-wise plain .svg version with all text being converted to paths (to prevent browser-dependent appearance of the fonts used in the .svg). With this PR, the cheatsheet preview links to this new file.