### PR TITLE
Restructure usecases

### DIFF
--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -12,18 +12,28 @@
    intro/howto
    intro/executive_summary
 
-.. figure:: artwork/src/basics.svg
-   :width: 60%
-   :target: http://handbook.datalad.org/en/latest/basics/intro.html
+.. only:: latex
+
+   ##########
+   **Basics**
+   ##########
+
+.. only:: html
+
+   .. figure:: artwork/src/basics.svg
+      :width: 60%
+      :target: http://handbook.datalad.org/en/latest/basics/intro.html
 
 ################################
 **Basics 1** -- DataLad datasets
 ################################
 
-.. toctree::
-   :hidden:
+.. only:: html
 
-   basics/intro.rst
+   .. toctree::
+      :hidden:
+
+      basics/intro.rst
 
 .. toctree::
    :maxdepth: 1
@@ -158,20 +168,31 @@
    basics/101-144-intro_extensions
    basics/101-145-hooks
 
-.. figure:: artwork/src/usecases.svg
-   :width: 60%
-   :target: http://handbook.datalad.org/en/latest/usecases/intro.html
+.. only:: latex
 
-.. toctree::
-   :hidden:
-   :maxdepth: 1
-   :caption: Hands-on real-world applications with step-by-step recipes...
+   #############
+   **Use cases**
+   #############
 
-   usecases/intro
+.. only:: html
+
+   .. figure:: artwork/src/usecases.svg
+      :width: 60%
+      :target: http://handbook.datalad.org/en/latest/usecases/intro.html
+
 
 ###############################
 **Use case I** -- Collaboration
 ###############################
+
+.. only:: html
+
+   .. toctree::
+      :hidden:
+      :maxdepth: 1
+      :caption: Hands-on real-world applications with step-by-step recipes...
+
+      usecases/intro
 
 .. toctree::
    :maxdepth: 1

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -12,6 +12,10 @@
    intro/howto
    intro/executive_summary
 
+.. figure:: artwork/src/basics.svg
+   :width: 60%
+   :target: http://handbook.datalad.org/en/latest/basics/intro.html
+
 ################################
 **Basics 1** -- DataLad datasets
 ################################
@@ -129,9 +133,9 @@
    basics/101-135-help
 
 
-#######################################
-**Basics 9** Third party infrastructure
-#######################################
+##########################################
+**Basics 9** -- Third party infrastructure
+##########################################
 
 .. toctree::
    :maxdepth: 1
@@ -154,24 +158,80 @@
    basics/101-144-intro_extensions
    basics/101-145-hooks
 
-#############
-**Use Cases**
-#############
+.. figure:: artwork/src/usecases.svg
+   :width: 60%
+   :target: http://handbook.datalad.org/en/latest/usecases/intro.html
 
 .. toctree::
    :hidden:
-
-   usecases/intro
-
-.. toctree::
    :maxdepth: 1
    :caption: Hands-on real-world applications with step-by-step recipes...
 
+   usecases/intro
+
+###############################
+**Use case I** -- Collaboration
+###############################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Bob uses public data for a data analysis project and collaborates with Alice to develop his analysis scripts.
+
    usecases/collaborative_data_management
+
+
+#############################
+**Use case II** -- Provenance
+#############################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Track provenance of dataset contents: From their origin from websources to scripts or commands that used, modified, or produced them.
+
    usecases/provenance_tracking
+
+
+#################################################
+**Use case III** -- Reproducible Research Objects
+#################################################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Share code, data, and computational workflows of your science, and allow others to not only recompute your results, but also build a PDF manuscript from scratch.
+
    usecases/reproducible-paper
+
+
+##############################
+**Use case IV** -- Supervision
+##############################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Use DataLad in a supervision setup and benefit from easy data management workflows and automatic log keeping.
+
    usecases/supervision
+
+
+#######################################
+**Use case V** -- Reproducible Analysis
+#######################################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: A thorough demonstration of data management and data analysis practices to create reproducible (neuro-)science.
+
    usecases/reproducible_neuroimaging_analysis
+
+
+#################################
+**Use case VI** -- Infrastructure
+#################################
+
+.. toctree::
+   :maxdepth: 1
+   :caption: An implementation of a domain-agnostic data store to enable scalability of scientific computing.
+
    usecases/datastorage_for_institutions
 
 ########

--- a/docs/intro/philosophy.rst
+++ b/docs/intro/philosophy.rst
@@ -3,6 +3,10 @@
 A brief overview of DataLad
 ---------------------------
 
+.. figure:: ../artwork/src/enter.svg
+   :width: 70%
+
+
 There can be numerous reasons why you ended up with this handbook in front of
 you -- We do not know who you are, or why you are here.
 You could have any background, any amount of previous experience with

--- a/docs/usecases/intro.rst
+++ b/docs/usecases/intro.rst
@@ -16,15 +16,12 @@ the solutions they demonstrate.
 
 **Use case overview:**
 
-.. toctree::
-   :maxdepth: 1
-
-   collaborative_data_management
-   provenance_tracking
-   reproducible-paper
-   supervision
-   reproducible_neuroimaging_analysis
-   datastorage_for_institutions
+- :ref:`usecase_collab`
+- :ref:`usecase_provenance_tracking`
+- :ref:`usecase_reproducible_paper`
+- :ref:`usecase_student_supervision`
+- :ref:`usecase_reproduce_neuroimg`
+- :ref:`usecase_datastore`
 
 Contributing
 ^^^^^^^^^^^^


### PR DESCRIPTION
Whether or not we will go forward with https://github.com/datalad/datalad/pull/4046#issuecomment-575920252, this restructures the toctree:

- Use cases are numbered (I went for roman numbers, but that's an arbitrary choice made for slightly better distinction to the Basics numbering) and get short, general headings
- Each use case gets a short description in the toctree
- Small figures separate major parts of the book (Intro-Basics, Basics-Usecases)

I think this makes the use cases more visible. 

TODO:

- [x] fixup PDF version. 