### PR TITLE
reset sibling configuration properly

### DIFF
--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -603,7 +603,7 @@ section.
 
       $ cd ../mock_user && mv onemoredir/DataLad-101 .
       $ rm -r onemoredir
-      $ cd ../DataLad-101 && git reset --hard master
+      $ cd ../DataLad-101 &&  sed -i 's/..\/mock_user\/onemoredir\/DataLad-101/..\/mock_user\/DataLad-101/' .git/config
 
 
 Getting contents out of git-annex


### PR DESCRIPTION
previously, the git reset was attempted in a file in .git. I just noticed it while playing around with `update` in the created dataset.