### PR TITLE
Colored boxes around gitusernotes

### DIFF
--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -23,11 +23,13 @@ def depart_gitusernote_html(self, node):
 
 
 def visit_gitusernote_latex(self, node):
-    self.body.append('\n\n\\sphinxstrong{Note for Git users:}\n\n')
+    # wrap the Gitusernote in a colored box (defined in conf.py preamble)
+    self.body.append('\n\n\\sphinxstrong{\\textcolor{purple}{Note for Git users:}}'
+                     '\n\n\\begin{colbox}{C9C0BB}\n\n')
 
 
 def depart_gitusernote_latex(self, node):
-    self.body.append("\n\n")
+    self.body.append("\n\n\\end{colbox}")
 
 
 class GitUserNote(BaseAdmonition):

--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -24,8 +24,8 @@ def depart_gitusernote_html(self, node):
 
 def visit_gitusernote_latex(self, node):
     # wrap the Gitusernote in a colored box (defined in conf.py preamble)
-    self.body.append('\n\n\\sphinxstrong{\\textcolor{purple}{Note for Git users:}}'
-                     '\n\n\\begin{colbox}{C9C0BB}\n\n')
+    self.body.append('\n\n\\begin{colbox}{C9C0BB}\n'
+                     '\n\n\\sphinxstrong{\\textcolor{purple}{Note for Git users:}}\n\n')
 
 
 def depart_gitusernote_latex(self, node):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,6 +289,15 @@ latex_elements = {
 \setcounter{tocdepth}{1}
 \usepackage{xcolor}
 \setcounter{secnumdepth}{0}
+\newsavebox{\selvestebox}
+\newenvironment{colbox}[1]
+  {\newcommand\colboxcolor{#1}%
+   \begin{lrbox}{\selvestebox}%
+   \begin{minipage}{\dimexpr\columnwidth-2\fboxsep\relax}}
+  {\end{minipage}\end{lrbox}%
+   \begin{center}
+   \colorbox[HTML]{\colboxcolor}{\usebox{\selvestebox}}
+   \end{center}}
 """,
 }
 


### PR DESCRIPTION
I'm trying to inch closer towards distinguishing gitusernotes and findoutmores in the PDF output.
With the current changes I can get something like this for the Gitusernote (somewhat arbitrary color
choices):
![image](https://user-images.githubusercontent.com/29738718/73862804-5dad4f00-483f-11ea-945d-8ad6a174b486.png)

Yet to succeed for the Findoutmores...