### PR TITLE
Pin Sphinx version for readthedocs to prevent #379

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytz
 requests
 six
 snowballstemmer
-Sphinx
+Sphinx==2.1.2
 sphinx-sitemap
 sphinxcontrib-websupport
 urllib3


### PR DESCRIPTION
ATM we don't have a readthedocs.yml file, and Readthedocs builds the handbook with the most recent Sphinx release (2.3.1). I believe that this version leads to a tiny bug, described in #379. By pinning Sphinx to an earlier version in ``requirements.txt`` and providing a ``readthedocs.yml`` file, I hope to get rid of the broken meta property tag.

Hopefully fixes #379.