### PR TITLE
UX: copybutton for easier copying of code snippets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,8 +79,10 @@ extensions = [
     'sphinxcontrib.rsvgconverter',
     'sphinxcontrib.plantuml',
     'dataladhandbook_support',
+    'sphinx_copybutton'
 ]
 
+copybutton_skip_text = "$"
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
The copybutton Sphinx extension introduced a feature to specify text (such as leading `$` in our code snippets) to be explicitly not copied. With this, 90% of code snippets are easy to copy. It adds a small copy symbol to the snippet and copies the code (no command output) to the clipboard.

It works for multiline-commands (e.g., ``run``), but unfortunately not for any of the here documents. Especially for the codelists, though, I envision this feature to be helpful.