### PR TITLE
BF: alabaster version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alabaster
+alabaster >= 0.7.11
 Babel
 certifi
 chardet

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requires = [
     'sphinxcontrib-svg2pdfconverter',
     'sphinxcontrib-plantuml',
     'autorunrecord',
+    'alabaster>=0.7.11',
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Was trying to build https://github.com/brainhack-princeton/handbook which is based on the datalad-handbook "setup" to run into
```
unsupported theme option 'show_relbar_bottom' given
```
According to https://alabaster.readthedocs.io/en/latest/changelog.html it seems was added in 0.7.11 so added versioned dependency.  I am not 100% sure on either changes to setup.py are due, or they should be restricted solely to the dependencies of the `dataladhandbook_support/`, if so -- just CP bf071c5e3613e13c093639829dfba765785871ed and abandon the other commit/PR.

Cheers