### PR TITLE
ENH: extensions - add crawler and mention that they might be available "natively"

### DIFF
--- a/docs/basics/101-144-intro_extensions.rst
+++ b/docs/basics/101-144-intro_extensions.rst
@@ -70,4 +70,11 @@ such as in
 
    $ pip install datalad-container
 
-Afterwards, the new DataLad functionality the extension provides is readily available.
+Afterwards, the new DataLad functionality the extension provides is
+readily available.
+
+Some extensions could also be available from the
+software distribution (e.g., NeuroDebian or conda) you used to install
+DataLad itself.  Visit `github.com/datalad/datalad-extensions/
+<https://github.com/datalad/datalad-extensions/>`_ to review available
+versions and their status.

--- a/docs/basics/101-144-intro_extensions.rst
+++ b/docs/basics/101-144-intro_extensions.rst
@@ -38,9 +38,9 @@ the following DataLad extensions are available:
        :command:`crawl-init`/:command:`crawl` commands, this extension
        allows to automate creation of DataLad datasets from resources
        available online, and efficiently keep them
-       up-to-date. Majority of datasets on `datasets.datalad.org
-       <http://datasets.datalad.org/>`_ are created and updated using
-       this extension functionality.
+       up-to-date. The majority of datasets in :term:`the DataLad superdataset ///`
+       on `datasets.datalad.org <http://datasets.datalad.org/>`_ are created and
+       updated using this extension functionality.
 
        .. todo::
 

--- a/docs/basics/101-144-intro_extensions.rst
+++ b/docs/basics/101-144-intro_extensions.rst
@@ -32,6 +32,20 @@ the following DataLad extensions are available:
        the ability to transparently execute commands in containerized
        computational environments. The section :ref:`containersrun` demonstrates
        how this extension can be used, as well as the usecase :ref:`usecase_reproduce_neuroimg`.
+   * - `DataLad Crawler <http://docs.datalad.org/projects/crawler/en/latest/>`_
+     - One of the initial goals behind DataLad was to provide access
+       to already existing data resources. With
+       :command:`crawl-init`/:command:`crawl` commands, this extension
+       allows to automate creation of DataLad datasets from resources
+       available online, and efficiently keep them
+       up-to-date. Majority of datasets on `datasets.datalad.org
+       <http://datasets.datalad.org/>`_ are created and updated using
+       this extension functionality.
+
+       .. todo::
+
+          contribute a section or a demo, e.g. based on `existing one <http://docs.datalad.org/projects/crawler/en/latest/demos/track_data_from_webpage.html>`__
+
    * - `DataLad Neuroimaging <https://datalad-neuroimaging.readthedocs.io/en/latest/>`_
      - Metadata extraction support for a range of standards common to
        neuroimaging data. The usecase :ref:`usecase_reproduce_neuroimg` demonstrates


### PR DESCRIPTION
- crawler (the cradle of DataLad AFAIK) was left behind :-(  It could be an ugly old duckling ATM, but IMHO still worth mentioning.
- `pip` is one way to install.  
Installation chapter already introduces to `conda` etc.  So I think it is worthwhile at least mentioning that extensions might also be available from originally used distribution.
I also expect https://github.com/datalad/datalad-extensions (or later some gh-pages view of it) will be improved to provide an overview of their status etc.