### PR TITLE
Standalone section on push

### DIFF
--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -424,7 +424,7 @@ YODA principles.
          check out `this section <https://the-turing-way.netlify.com/reproducible_environments/06/containers#Containers_section>`_
          in the wonderful book `The Turing Way <https://the-turing-way.netlify.com/introduction/introduction>`_,
          a comprehensive guide to reproducible data science, or read about it in
-         section :ref:`yoda_project`.
+         section :ref:`containersrun`.
 
 .. [#f3] This directory structure is very comprehensive, and displays many best-practices for
          reproducible data science. For example,

--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -204,8 +204,8 @@ could be an analysis dataset created by a statistician for a scientific
 project, and it could be shared between collaborators or
 with others during development of the project. In this
 superdataset, code is created that operates on input data to
-compute outputs, and the code and outputs are captured, version-
-controlled, and linked to the input data. Each input data in turn
+compute outputs, and the code and outputs are captured,
+version-controlled, and linked to the input data. Each input data in turn
 is a (potentially nested) subdataset, but this is not visible
 in the directory hierarchy.
 Figure 3 in comparison emphasizes a process view on a project and

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -675,9 +675,36 @@ On GitHub, you will see a new, empty repository with the name
 ``midtermproject``. However, the repository does not yet contain
 any of your dataset's history or files. This requires *publishing* the current
 state of the dataset to this :term:`sibling` with the :command:`datalad push`
-(:manpage:`datalad-push` manual) command. The :command:`datalad push` command
-will make the last saved state of your dataset available to the :term:`sibling`
-you provide with the ``--to`` option.
+(:manpage:`datalad-push` manual) command.
+
+.. note::
+
+    Publishing is one of the remaining big concepts that this handbook tries to
+    convey. However, publishing is a complex concept that encompasses a large
+    proportion of the previous handbook content as a prerequisite. In order to be
+    not too overwhelmingly detailed, the upcoming sections will approach
+    :command:`push` from a "learning-by-doing" perspective:
+    You will see a first :command:`push` to GitHub below, and the findoutmore at
+    the end of this section will already give a practical glimpse into the
+    difference between annexed contents and contents stored in Git when pushed
+    to GitHub. The chapter :ref:`chapter_thirdparty` will extend on this,
+    but the section
+
+    .. todo::
+
+       write and link
+
+    will finally combine and link all the previous contents to give a comprehensive
+    and detailed wrap up of the concept of publishing datasets. In this section,
+    you will also find a detailed overview on how :command:`push` works and which
+    options are available. If you are impatient or need an overview on publishing,
+    feel free to skip ahead. If you have time to follow along, reading the next
+    sections will get you towards a complete picture of publishing a bit more
+    small-stepped and gently.
+    For now, we will start with learning by doing, and
+    the fundamental basics of :command:`datalad push`: The command
+    will make the last saved state of your dataset available (i.e., publish it)
+    to the :term:`sibling` you provide with the ``--to`` option.
 
 .. runrecord:: _examples/DL-101-130-118
    :language: console
@@ -685,17 +712,15 @@ you provide with the ``--to`` option.
 
    $ datalad push --to github
 
-.. gitusernote::
-
-   The :command:`datalad push` uses ``git push``, and ``git annex copy`` under
-   the hood. Publication targets need to either be configured remote Git repositories,
-   or git-annex special remotes (if they support data upload).
-
-Here is one important detail, though: By default, your tags will not be published.
+Thus, you have now published your dataset's history to a public place for others
+to see and clone. Below we will explore how this may look and feel for others.
+There is one important detail first, though: By default, your tags will not be published.
+Thus, the tag ``ready4analysis`` is not pushed to GitHub, and currently this
+version identifier is unavailable to anyone else but you.
 The reason for this is that tags are viral -- they can be removed locally, and old
 published tags can cause confusion or unwanted changes. In order to publish a tag,
-an additional :command:`git push` with the ``--tags`` option to the
-sibling would be required:
+an additional :command:`git push` (yes, we need to push with Git, not DataLad here)
+with the ``--tags`` option is required:
 
 .. code-block:: bash
 
@@ -744,7 +769,11 @@ reproduce your data science project easily from scratch!
 
       $ datalad get prediction_report.csv pairwise_relationships.png
 
-   Why is that? The file content of these files is managed by git-annex, and
+   Why is that? This is the first detail of publishing datasets we will dive into.
+   When publishing dataset content to GitHub with :command:`datalad push`, it is
+   the dataset's *history*, i.e., everything that is stored in Git, that is
+   published. The file *content* of these particular files, though, is managed
+   by :term:`git-annex` and not stored in Git, and
    thus only information about the file name and location is known to Git.
    Because GitHub does not host large data for free, annexed file content always
    needs to be deposited somewhere else (e.g., a web server) to make it
@@ -778,6 +807,12 @@ reproduce your data science project easily from scratch!
 
     .. figure:: ../artwork/src/reproduced.svg
        :width: 50%
+
+.. gitusernote::
+
+   The :command:`datalad push` uses ``git push``, and ``git annex copy`` under
+   the hood. Publication targets need to either be configured remote Git repositories,
+   or git-annex special remotes (if they support data upload).
 
 
 .. only:: adminmode

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -719,8 +719,7 @@ Thus, the tag ``ready4analysis`` is not pushed to GitHub, and currently this
 version identifier is unavailable to anyone else but you.
 The reason for this is that tags are viral -- they can be removed locally, and old
 published tags can cause confusion or unwanted changes. In order to publish a tag,
-an additional :command:`git push` (yes, we need to push with Git, not DataLad here)
-with the ``--tags`` option is required:
+an additional :command:`git push` [#f6]_ with the ``--tags`` option is required:
 
 .. code-block:: bash
 
@@ -869,3 +868,21 @@ reproduce your data science project easily from scratch!
 .. [#f5] Such a token can be obtained, for example, using the command line
          GitHub interface (https://github.com/sociomantic/git-hub) by running:
          ``git hub setup`` (if no 2FA is used).
+
+.. [#f6] Note that this is a :command:`git push`, not :command:`datalad push`.
+         Tags could be pushed upon a :command:`datalad push`, though, if one
+         configures (what kind of) tags to be pushed. This would need to be done
+         on a per-sibling basis in ``.git/config`` in the ``remote.*.push``
+         configuration. If you had a :term:`sibling` "github", the following
+         configuration would push all tags that start with a ``v`` upon a
+         :command:`datalad push --to github`::
+
+            $ git config --local remote.github.push 'refs/tags/v*'
+
+         This configuration would result in the following entry in ``.git/config``::
+
+            [remote "github"]
+                  url = git@github.com/adswa/midtermproject.git
+                  fetch = +refs/heads/*:refs/remotes/github/*
+                  annex-ignore = true
+                  push = refs/tags/v*

--- a/docs/basics/101-134-summary.rst
+++ b/docs/basics/101-134-summary.rst
@@ -23,7 +23,9 @@ for yourself why and how software containers can go hand-in-hand with DataLad:
 - A software container encapsulates a complete software environment, independent
   from the environment of the computer it runs on. This allows you to create or
   use secluded software and also share it together with your analysis to ensure
-  computational reproducibility.
+  computational reproducibility. The DataLad extension
+  `datalad containers <http://docs.datalad.org/projects/container/en/latest/>`_
+  can make this possible.
 
 - The command :command:`datalad containers-add` registers an Image from a path or
   url to your dataset.

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -376,59 +376,6 @@ that is: The symlink, as information about file availability, but no file
 content. Anyone who attempts to :command:`datalad get` a file from a dataset clone
 if its contents were not published will fail.
 
-.. findoutmore:: What if I do not want to share a dataset with everyone, or only some files of it?
-
-   There are a number of ways to restrict access to your dataset or individual
-   files of your dataset. One is via choice of (third party) hosting service
-   for annexed file contents.
-   If you chose a service only selected people have access to, and publish annexed
-   contents exclusively there, then only those selected people can perform a
-   successful :command:`datalad get`. On shared file systems you may achieve
-   this via :term:`permissions` for certain groups or users, and for third party
-   infrastructure you may achieve this by invitations/permissions/... options
-   of the respective service.
-
-   If it is individual files that you do not want to share, you can selectively
-   publish the contents of all files you want others to have, and withhold the data
-   of the files you do not want to share. This can be done by publishing only
-   selected files by providing paths, or overriding default push behavior with
-   the ``-f/--force`` option. In the latter case, specifying ``-f no-datatransfer``
-   would for example not push any annexed contents.
-
-   Let's say you have a dataset with three files:
-
-   - ``experiment.txt``
-   - ``subject_1.dat``
-   - ``subject_2.dat``
-
-   Consider that all of these files are annexed. While the information in
-   ``experiment.txt`` is fine for everyone to see, ``subject_1.dat`` and
-   ``subject_2.dat`` contain personal and potentially identifying data that
-   can not be shared. Nevertheless, you want collaborators to know that these
-   files exist. The use case
-
-   .. todo::
-
-      Write use case "external researcher without data access"
-
-   details such a scenario and demonstrates how external collaborators (with whom data
-   can not be shared) can develop scripts against the directory structure and
-   file names of a dataset, submit those scripts to the data owners, and thus still perform an
-   analysis despite not having access to the data.
-
-   By publishing only the file contents of ``experiment.txt`` with
-
-   .. code-block:: bash
-
-      $ datalad push --to github experiment.txt
-
-   only meta data about file availability of ``subject_1.dat`` and ``subject_2.dat``
-   exists, but as these files' annexed data is not published, a :command:`datalad get`
-   will fail. Note, though, that :command:`push` will publish the complete
-   dataset history (unless you specify a commit range with the ``--since`` option
-   -- see the `manual <http://docs.datalad.org/en/latest/generated/man/datalad-push.html>`_
-   for more information).
-
 
 From the perspective of whom you share your dataset with...
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -104,6 +104,13 @@ very familiar with.
 Setting up 3rd party services to host your data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+
+   The tutorial below is functional, but there is work towards a wrapper
+   function to ease creating and working with rclone-based special remotes:
+   https://github.com/datalad/datalad/pull/4162.
+   Once finished, this section will be updated accordingly.
+
 In this paragraph you will see how a third party service can be configured
 to host your data. Note that the *exact* procedures are different from service
 to service -- this is inconvenient, but inevitable given the

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -549,6 +549,10 @@ be able to fetch content from the tarball shared on Figshare via DataLad.
          is disabled by default, and to enable it you would need to have administrative
          access to the server and client side of your GitLab instance. Find out more
          `here <https://docs.gitlab.com/ee/administration/git_annex.html>`_.
+         Alternatively, GitHub can integrate with
+         `GitLFS <https://git-lfs.github.com/>`_, a non-free, centralized service
+         that allows to store large file contents. The last paragraph in this
+         section shows an example on how to use their free trial version.
 
 .. [#f2] ``rclone`` is a useful special-remote for this example, because
          you can not only use it for Dropbox, but also for many other

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -43,8 +43,8 @@ and name, and selecting a user name and password, you should upload your
    All this takes is a single command in the terminal. The resulting files are
    text files that look like someone spilled alphabet soup in them, but constitute
    a secure password procedure.
-   You keep the private key on your own machine (the system you are connecting from
-   , and that **only you have access to**),
+   You keep the private key on your own machine (the system you are connecting from,
+   and that **only you have access to**),
    and copy the public key to the system or service you are connecting to.
    On the remote system or service, you make the public key an *authorized key* to
    allow authentication via the SSH key pair instead of your password. This
@@ -52,7 +52,7 @@ and name, and selecting a user name and password, you should upload your
    to achieve.
    You should protect your SSH keys on your machine with a passphrase to prevent
    others -- e.g., in case of theft -- to log in to servers or services with
-   SSH authentication [#f1]_, and configure an ``ssh agent``
+   SSH authentication [#f2]_, and configure an ``ssh agent``
    to handle this passphrase for you with a single command. How to do all of this
    is detailed in the above tutorial.
 

--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -1,0 +1,188 @@
+Overview: Publishing datasets
+-----------------------------
+
+The sections :ref:`yoda_project`, :ref:`sharethirdparty`, and :ref:`gin` have each
+shown you crucial aspects of the functions of dataset publishing with
+:command:`datalad push`. This section wraps them all together.
+
+The general overview
+^^^^^^^^^^^^^^^^^^^^
+
+:command:`datalad push` is the command to turn to when you want to publish datasets.
+It is capable of publishing all dataset content, i.e., files stored in :term:`Git`,
+and files stored with :term:`git-annex`, to a known dataset :term:`sibling`.
+
+.. gitusernote::
+
+   The :command:`datalad push` uses ``git push``, and ``git annex copy`` under
+   the hood. Publication targets need to either be configured remote Git repositories,
+   or git-annex special remotes (if they support data upload).
+
+In order to publish a dataset, the dataset needs to have a sibling to push to.
+This, for instance, can be a :term:`GitHub`, :term:`GitLab`, or :term:`Gin`
+repository, but it can also be a Remote Indexed Archive (RIA) store for backup
+or storage of datasets [#f1]_, or a regular clone [#f2]_.
+
+.. findoutmore:: all of the ways to configure siblings
+
+   - Add an existing repository as a sibling with the :command:`datalad siblings`
+     command. Here is an example::
+
+        $ datalad siblings add --name github-repo --url <url.to.github>
+
+   - Create a sibling from scratch, right from within your repository:
+     This can be done with the commands :command:`create-sibling-github` (for GitHub)
+     or :command:`create-siblings-gitlab` (for GitLab), or
+     :command:`create-sibling-ria` (for a remote indexed archive dataset store [#f1]_).
+     Note that :command:`create-sibling-ria` can add an existing store as a sibling
+     or create a new one from scratch
+
+In order to publish dataset content, DataLad needs to know to which sibling
+content shall be pushed. This can be specified with the ``--to`` option directly
+from the command line::
+
+   $ datalad push --to <sibling>
+
+If you have more than one :term:`branch` in your dataset, note that a
+:command:`datalad push` command will by default update all branches that both
+the sibling and the dataset share. If such advanced aspects of pushing are
+relevant for your workflow, please check out the hidden section at the end of
+this paragraph.
+
+By default, :command:`push` will make the last saved state of the dataset
+available. Consequently, if the sibling is in the same state as the dataset,
+no push is attempted.
+Additionally, :command:`push` will attempt to automatically decide what type
+of dataset contents are going to be published. With a sibling that has a
+:term:`special remote` configured as a :term:`publication dependency`,
+or a sibling that contains an annex (such as a Gin repository or a
+:term:`Remote Indexed Archive (RIA) store`), both the contents
+stored in Git (i.e., a dataset's history) as well as file contents stored in
+git-annex will be published.
+
+Alternatively, one can enforce particular operations or push a subset of dataset
+contents. For one, when specifying a path in the :command:`datalad push` command,
+only data or changes for those paths are considered for a push.
+Additionally, one can select a particular mode of operation with the ``-f/--force``
+option. Several different modes are possible:
+
+- ``no-datatransfer``: With this option, annexed contents are not published. This
+  means that the sibling will have information on the annexed files' names, but
+  file contents will not be available, and thus ``datalad get`` calls in the
+  sibling would fail.
+- ``datatransfer``: With this option, the underlying ``git annex copy`` call to
+  publish file contents is evoked without a ``--fast`` option. Usually, the
+  ``--fast`` option increases the speed of the operation, as it disables a check
+  whether the sibling already has content. This however, might skip copying content
+  in some cases. Therefore, ``--force datatransfer`` is a slower, but more fail-safe
+  option to publish annexed file contents.
+- ``gitpush``: This option triggers a ``git push --force``. Be very careful using
+  this option - it will push all branches that are known to the sibling, and if
+  the changes on these branches are conflicting with the changes that exist in
+  the sibling, the changes that exist in the sibling will be overwritten.
+- ``all``: The final mode, ``all``, combines modes ``gitpush`` and ``datatransfer``,
+  thus attempting to really get your dataset contents published.
+
+.. findoutmore:: Details on push for Gitusers
+
+   The commands :command:`git push` and :command:`datalad push` appear similar,
+   but there are crucial differences between them. Depending on how well you
+   know Git, and how complex your DataLad workflows are, you should be aware of
+   them to pick the correct command for your use case.
+
+   If you have more than one :term:`branch` in your dataset, a
+   :command:`datalad push --to <sibling>` will update all branches that the
+   sibling already has. In other words, :command:`push` honors Git's
+   configuration of upstream branches, so whenever there is any branch
+   configured for push, it will push those, and all of them.
+   If you only want to push a single branch, you will need
+   to `configure push targets <https://git-scm.com/docs/git-push>`_ , or use
+   :command:`git push <sibling> <branch>`/
+   :command:`git push -u <sibling> <branch>` syntax.
+
+
+
+
+
+Setting access control via publishing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are a number of ways to restrict access to your dataset or individual
+files of your dataset. One is via choice of (third party) hosting service
+for annexed file contents.
+If you chose a service only selected people have access to, and publish annexed
+contents exclusively there, then only those selected people can perform a
+successful :command:`datalad get`. On shared file systems you may achieve
+this via :term:`permissions` for certain groups or users, and for third party
+infrastructure you may achieve this by invitations/permissions/... options
+of the respective service.
+
+If it is individual files that you do not want to share, you can selectively
+publish the contents of all files you want others to have, and withhold the data
+of the files you do not want to share. This can be done by publishing only
+selected files by providing paths, or overriding default push behavior with
+the ``-f/--force`` option. In the latter case, specifying ``-f no-datatransfer``
+would for example not push any annexed contents.
+
+Let's say you have a dataset with three files:
+
+- ``experiment.txt``
+- ``subject_1.dat``
+- ``subject_2.dat``
+
+Consider that all of these files are annexed. While the information in
+``experiment.txt`` is fine for everyone to see, ``subject_1.dat`` and
+``subject_2.dat`` contain personal and potentially identifying data that
+can not be shared. Nevertheless, you want collaborators to know that these
+files exist. The use case
+
+.. todo::
+
+  Write use case "external researcher without data access"
+
+details such a scenario and demonstrates how external collaborators (with whom data
+can not be shared) can develop scripts against the directory structure and
+file names of a dataset, submit those scripts to the data owners, and thus still perform an
+analysis despite not having access to the data.
+
+By publishing only the file contents of ``experiment.txt`` with
+
+.. code-block:: bash
+
+  $ datalad push --to github experiment.txt
+
+only meta data about file availability of ``subject_1.dat`` and ``subject_2.dat``
+exists, but as these files' annexed data is not published, a :command:`datalad get`
+will fail. Note, though, that :command:`push` will publish the complete
+dataset history (unless you specify a commit range with the ``--since`` option
+-- see the `manual <http://docs.datalad.org/en/latest/generated/man/datalad-push.html>`_
+for more information).
+
+
+.. rubric:: Footnotes
+
+.. [#f1]  RIA siblings are filesystem-based, scalable storage solutions for
+          DataLad datasets. You can find out more about them in the usecase
+          :ref:`usecase_datastore`.
+
+.. [#f2] If you are unfamiliar with Git, please be aware that cloning a dataset
+         to a different place and subsequently pushing to it can lead to Git
+         error messages if changes are pushed to a currently checked out
+         :term:`branch` of the sibling (in technical Git terms: When pushing to
+         a checked-out branch of a non-bare repository remote).
+         As an example, consider what happens
+         if we attempt a :command:`datalad push` to the sibling ``roommate``
+         that we created in the chapter :ref:`chapter_collaboration`:
+
+         .. runrecord:: _examples/DL-101-141-101
+            :language: console
+            :workdir: dl-101/DataLad-101
+
+            $ datalad push --to roommate
+
+         Publishing fails with the error message
+         ``[remote rejected] (branch is currently checked out)``.
+         This can be prevented with
+         `configuration settings <https://github.blog/2015-02-06-git-2-3-has-been-released/>`_
+         in Git versions 2.3 or higher, or by pushing to a branch of the sibling
+         that is currently not checked-out.

--- a/docs/basics/_examples/DL-101-141-101
+++ b/docs/basics/_examples/DL-101-141-101
@@ -1,0 +1,7 @@
+$ datalad push --to roommate
+[INFO] Start enumerating objects 
+[INFO] Start counting objects 
+[INFO] Start compressing objects 
+[INFO] Start writing objects 
+[ERROR] refs/heads/master->roommate:refs/heads/master [remote rejected] (branch is currently checked out) [publish(/home/me/dl-101/DataLad-101)] 
+publish(error): . (dataset) [refs/heads/master->roommate:refs/heads/master [remote rejected] (branch is currently checked out)]

--- a/docs/basics/basics8toc.rst
+++ b/docs/basics/basics8toc.rst
@@ -1,16 +1,15 @@
-.. _chapter_help:
+.. _chapter_thirdparty:
 
-**VIII - Help yourself**
-------------------------
+**VIII - Third party infrastructure**
+-------------------------------------
 
-.. figure:: ../artwork/src/help.svg
+.. figure:: ../artwork/src/clouds.svg
 
 .. toctree::
    :maxdepth: 1
    :numbered:
-   :caption: Dealing with problems, filesystems, and version histories
+   :caption: Leverage third party services to share datasets
 
-   101-135-intro
-   101-136-filesystem
-   101-137-history
-   101-135-help
+   101-138-sharethirdparty
+   101-139-gin
+   101-140-summary

--- a/docs/basics/basics8toc.rst
+++ b/docs/basics/basics8toc.rst
@@ -12,4 +12,5 @@
 
    101-138-sharethirdparty
    101-139-gin
+   101-141-push
    101-140-summary

--- a/docs/basics/basics9toc.rst
+++ b/docs/basics/basics9toc.rst
@@ -1,15 +1,16 @@
-.. _chapter_thirdparty:
+.. _chapter_help:
 
-**IX - Third party infrastructure**
------------------------------------
+**IX - Help yourself**
+----------------------
 
-.. figure:: ../artwork/src/clouds.svg
+.. figure:: ../artwork/src/help.svg
 
 .. toctree::
    :maxdepth: 1
    :numbered:
-   :caption: Leverage third party services to share datasets
+   :caption: Dealing with problems, filesystems, and version histories
 
-   101-138-sharethirdparty
-   101-139-gin
-   101-140-summary
+   101-135-intro
+   101-136-filesystem
+   101-137-history
+   101-135-help

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -174,6 +174,16 @@ Glossary
       a digital resource. It provides a critical foundation for assessing authenticity, enables trust,
       and allows reproducibility.
 
+   publication dependency
+      DataLad concept: An existing :term:`sibling` is linked to a new sibling
+      so that the existing sibling is always published prior to the new sibling.
+      The existing sibling could be a :term:`special remote` to publish file
+      contents stored in the dataset :term:`annex` automatically with every
+      :command:`datalad push` to the new sibling. Publication dependencies can be
+      set with the option ``publish-depends`` in the commands
+      :command:`datalad siblings`, :command:`datalad create-sibling`, and
+      :command:`datalad create-sibling-github/gitlab`.
+
    relative path
       A path related to the present working directory. Relative paths never start with ``/``.
       Example: ``../Pictures/xkcd-webcomics/530.png``. See also :term:`absolute path`.


### PR DESCRIPTION
This sits on top of #412 and adds a standalone section to elaborate on and wrap up the details of ``datalad push``.

This fixes #281.