### PR TITLE
fix cheat sheet link and preview

### DIFF
--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -359,7 +359,7 @@ was applied.
    .. todo::
 
       It might be helpful to have (or reference) a table with all available
-      procedures and a short explanation. Maybe on the cheatsheet.
+      procedures and a short explanation. Maybe on the cheat sheet.
 
 Summing up, DataLad's :command:`run-procedure` command is a handy tool
 with useful existing procedures but much flexibility for your own

--- a/docs/basics/101-136-cheatsheet.rst
+++ b/docs/basics/101-136-cheatsheet.rst
@@ -10,5 +10,5 @@ DataLad cheat sheet
 Click on the image below to obtain a PDF version of the cheat sheet. Individual
 sections are linked to chapters or technical docs.
 
-.. figure:: ../artwork/src/datalad-cheatsheet.pdf
-   :target: https://github.com/datalad-handbook/artwork/blob/master/src/datalad-cheatsheet.pdf
+.. figure:: ../artwork/src/datalad-cheatsheet.svg
+   :target: ../artwork/src/datalad-cheatsheet.pdf

--- a/docs/basics/101-136-cheatsheet.rst
+++ b/docs/basics/101-136-cheatsheet.rst
@@ -5,7 +5,7 @@
 DataLad cheat sheet
 -------------------
 
-.. index:: ! Cheatsheet
+.. index:: ! Cheat sheet
 
 Click on the image below to obtain a PDF version of the cheat sheet. Individual
 sections are linked to chapters or technical docs.

--- a/docs/intro/executive_summary.rst
+++ b/docs/intro/executive_summary.rst
@@ -123,7 +123,7 @@ custom data structures or the need for central infrastructure or third party
 services.
 If you are interested in more high-level information on DataLad, you can find
 answers to common questions in the section :ref:`FAQ`, and a concise command
-cheat-sheet in section :ref:`cheat`.
+cheat sheet in section :ref:`cheat`.
 
 But enough of the introduction now -- let's dive into the
 :ref:`basics-intro`


### PR DESCRIPTION
This is all untested, as I did not build the handbook (the build system scares me ;-). So all file paths are where I assume the files are.

This PR:
* normalizes the spelling of cheat sheet (all forms used were valid; but it should be consistent)
* fix the preview image for the cheat sheet (pdf is not recognized by browsers as an image type)
* simplifies the link to the PDF, so the user doesn't end up on GitHub having to click "download" to get the PDF.

This PR took the conservative approach and simplifies the process from 3 steps to 2 when acquiring the cheat sheet. If you don't have plans to add content to the cheat sheet webpage, you could  remove it entirely and just link to the cheat sheet directly, reducing the steps to 1.