### PR TITLE
add sphinx-notfound-page to the requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ extensions = [
     'sphinxcontrib.rsvgconverter',
     'sphinxcontrib.plantuml',
     'dataladhandbook_support',
+    'notfound.extension',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ snowballstemmer
 Sphinx==2.1.2
 sphinx-sitemap
 sphinxcontrib-websupport
+sphinx-notfound-page
 urllib3
 sphinxcontrib-svg2pdfconverter
 sphinxcontrib-plantuml


### PR DESCRIPTION
A first try to use the page-not-found extension. Its a slight shot in the dark, there is no way to preview the outcome:

> If you open the 404.html file on the browser, you will see that all of the images and css does not display properly. This is because all the URLs are absolute and since the file is being rendered from file:// in the browser, it does not know where to find those resources.

> Do not worry too much about this, this is the expected behavior and those resources will appear once the docs are deployed.