### PR TITLE
WIP: autorunrecord option to create pushtargets

### DIFF
--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -643,7 +643,7 @@ configure this repository as a sibling of the dataset:
     .. runrecord:: _examples/DL-101-130-116
        :language: console
        :workdir: dl-101/DataLad-101/midterm_project
-       :realcommand: python -c "from datalad.core.distributed.tests.test_push import mk_push_target; from datalad.api import Dataset as ds; mk_push_target(ds=ds('/home/me/dl-101/DataLad-101/midterm_project'), name='github', path='/home/me/pushes/midtermproject', annex=False, bare=True)"
+       :makepushtarget: {"ds_path" : "/home/me/dl-101/DataLad-101/midterm_project", "name" : "github", "push_path" : "/home/me/pushes/midtermproject", "annex" : "False", "bare" : "True"}
 
 
 .. code-block:: bash

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -95,8 +95,7 @@ and you can type "yes" to continue::
     .. runrecord:: _examples/DL-101-139-101
        :language: console
        :workdir: dl-101/DataLad-101
-       :realcommand: python -c "from datalad.core.distributed.tests.test_push import mk_push_target; from datalad.api import Dataset as ds; mk_push_target(ds=ds('/home/me/dl-101/DataLad-101'), name='gin', path='/home/me/pushes/DataLad-101', annex=True, bare=True)"
-
+       :makepushtarget: {"ds_path" : "/home/me/dl-101/DataLad-101", "name" : "gin", "push_path" : "/home/me/pushes/DataLad-101", "annex" : "True", "bare" : "True"}
 
 Afterwards, you can publish your dataset with :command:`datalad push`. As the
 repository on GIN supports a dataset annex, there is no publication dependency

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -135,6 +135,30 @@ simple ``code-block::`` directives are sufficient.
 (foldable sections that contain content that goes beyond the basics). Make use
 of them, if applicable to your contribution.
 
+**Push targets:**  In order to be executable, :command:`datalad push` commands
+that appear to push to siblings on webhosting sites (such as :term:`GitHub` or
+:term:`Gin`) actually push to locally set up push targets. Those push targets
+can be created and added as a sibling by using the ``makepushtarget`` option of
+the ``runrecord`` directive. It needs the following arguments, specified as a
+Python dictionary:
+
+- ``ds_path``: A path to the dataset that should get a sibling (required)
+- ``name``: The name of the sibling (required)
+- ``push_path``: A path to where the push target should be created (required)
+- ``annex``: Should the push target have an annex or not (default: False)
+- ``bare``: Should the push target be a bare repository (default: True)
+
+Here is an example ``runrecord`` that creates a sibling called ``github`` and creates
+a bare pure Git repository to push to under ``/home/me/pushes/midterm_project``:
+
+.. code-block:: rst
+
+   .. runrecord:: _examples/DL-101-130-116
+      :language: console
+      :workdir: dl-101/DataLad-101/midterm_project
+      :makepushtarget: {"ds_path" : "/home/me/dl-101/DataLad-101/midterm_project", "name" : "github", "push_path" : "/home/me/pushes/midtermproject", "annex" : "False", "bare" : "True"}
+
+
 **Creating live code demos out of runrecord directives**:
 The book has the capability to turn code snippets into a script that the tool
 `cast_live <https://github.com/datalad/datalad/blob/master/tools/cast_live>`_


### PR DESCRIPTION
Uses the runrecord option ``makepushtarget`` as proposed in mih/autorunrecord#6.

**todo**
- [ ] update the requirements file