### PR TITLE
More warning/error messages/hints to help

### DIFF
--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -241,22 +241,7 @@ because remotes are not available:
 
     paste some "please make these remotes available output"
 
-Filesystem related warnings
-"""""""""""""""""""""""""""
 
-The unix command ``PWD`` ("print working directory") does not resolve symlinks by
-default, but Python's ``getcwd`` ("get current working directory") function does.
-When ``PWD`` and the current working directory differ, the current working
-directory is used instead of ``PWD``, and this is announced with a warning
-similar to this:
-
-.. code-block::
-
-   [WARNING] realpath of PWD=</some/path/to/symlinked/file> is </resolved/path/to/symlinked/file> whenever os.getcwd()=<path/to/dataset>.
-   From now on will be returning os.getcwd(). Directory symlinks in the paths will be resolved.
-
-There is no action to be taken based on this warning. Usually, everything should
-be fine.
 
 .. todo::
 

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -241,7 +241,22 @@ because remotes are not available:
 
     paste some "please make these remotes available output"
 
+Filesystem related warnings
+"""""""""""""""""""""""""""
 
+The unix command ``PWD`` ("print working directory") does not resolve symlinks by
+default, but Python's ``getcwd`` ("get current working directory") function does.
+When ``PWD`` and the current working directory differ, the current working
+directory is used instead of ``PWD``, and this is announced with a warning
+similar to this:
+
+.. code-block::
+
+   [WARNING] realpath of PWD=</some/path/to/symlinked/file> is </resolved/path/to/symlinked/file> whenever os.getcwd()=<path/to/dataset>.
+   From now on will be returning os.getcwd(). Directory symlinks in the paths will be resolved.
+
+There is no action to be taken based on this warning. Usually, everything should
+be fine.
 
 .. todo::
 

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -176,7 +176,13 @@ to a non-bare repository. Unlike :term:`bare Git repositories`, non-bare
 repositories can not be pushed to at all times. To fix this, you either want to
 `checkout another branch <https://git-scm.com/docs/git-checkout>`_
 in the ``roommate`` sibling or push to a non-checked out branch in the ``roommate``
-sibling.
+sibling. Alternatively, you can configure ``roommate`` to receive the push with
+Git's ``receive.denyCurrentBranch`` configuration key. By default, this configuration
+is set to ``refuse``. Setting it to ``updateInstead``
+with ``git config receive.denyCurrentBranch updateInstead`` will allow updating
+the checked out branch. See ``git config``\s
+`man page entry <https://git-scm.com/docs/git-config#Documentation/git-config.txt-receivedenyCurrentBranch>`_
+on ``receive.denyCurrentBranch`` for more.
 
 
 **Detached HEADs**


### PR DESCRIPTION
- Add receive.denyCurrentBranch configuration  as an alternative to enable pushing to non-bare repositories