### PR TITLE
Add a short initial section on configuring providers

### DIFF
--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -1,0 +1,86 @@
+.. _providers:
+
+Configuring new data providers
+------------------------------
+
+DataLad can download files via the ``http``, ``https``, ``ftp``, and ``s3``
+protocol. If data retrieval requires authentication, DataLad's provides an interface to
+query, request, and store the most common type of credentials. An example of this
+is shown in the usecase :ref:`usecase_HCP_dataset`: :command:`datalad get` will
+ask for AWS S3 credential to retrieve data that is stored in S3 buckets from
+the command line once, and -- given valid credentials -- download the files
+and all future files from this bucket right away. There
+are a number of natively supported types of authentication (a list is given in
+the hidden section below) and out-of-the box access to a broad range
+of providers such as `S3 <https://aws.amazon.com/s3/?nc1=h_ls>`_ or
+`LORIS <https://loris.ca/>`_.
+If you attempt to retrieve data from supported providers that require authentication,
+you will be prompted for your credentials from the command line at the time of
+the first download, and subsequent downloads handle authentication in the background.
+
+If a provider requires authentication but it is not known to DataLad yet, the
+download will fail. However, the provider can be configured by
+the user to enable interactions with it.
+With a provider configuration in place, commands such as :command:`datalad download-url`
+or :command:`datalad add-urls` can work with urls of custom providers, and
+:command:`datalad get` is enabled to retrieve file contents from these sources.
+The configuration can either be done in the terminal upon a prompt from the
+command line when a download fails due to a missing provider configuration,
+or by placing provider-specific configuration files into ``.datalad/providers``.
+
+In order to configure a provider configuration, one needs to input a
+provider name, a regular expression that can match a url one would want to download
+from, an authentication type, and a credential type. The example below sheds some
+light one this.
+
+.. findoutmore:: Which authentication and credential types are possible?
+
+   The following credential types are supported:
+
+   - ``'user_password'``
+   - ``'aws-s3'``
+   - ``'nda-s3'``
+   - ``'token'``
+   - ``'loris-token'``
+
+   The following authentication types are supported:
+
+   - ``'html_form'``
+   - ``'http_auth'``
+   - ``'http_basic_auth'``
+   - ``'http_digest_auth'``
+   - ``'bearer_token'``
+   - ``'aws-s3'``
+   - ``'nda-s3'``
+   - ``'loris-token'``
+
+   Some pointers to read up more on these authetication types are here:
+   `http basic access <https://en.wikipedia.org/wiki/Basic_access_authentication>`_,
+   `http and html form-based authentication <https://en.wikipedia.org/wiki/HTTP%2BHTML_form-based_authentication>`_,
+   `digest access authentication <https://en.wikipedia.org/wiki/Digest_access_authentication>`_,
+   `http bearer token authentication <https://tools.ietf.org/html/rfc6750>`_.
+
+Example: DataLad access to an XNAT server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`XNAT <https://www.xnat.org/about/>`_ is an open source imaging informatics platform
+and it allows for data download after authentication.
+In order to allow file retrieval from a custom deployed
+`XNAT server <https://www.xnat.org/about/>`_ with DataLad, a file following a
+similar structure as the example below (with adjusted urls and ports)
+can be placed into ``.datalad/providers/xnat.cfg``:
+
+.. code-block:: bash
+
+   [provider:xnat]
+   url_re = https://nmrxnat.ime.kfa-juelich.de:8443/xnat/.*
+   credential = nmrxnat.ime.kfa-juelich.de:8443/xnat
+   authentication_type = http_basic_auth
+
+   [credential:nmrxnat.ime.kfa-juelich.de:8443/xnat]
+   type = user_password
+
+In the dataset that this file was placed into, downloading commands such as
+:command:`datalad download-url` that point to
+``https://nmrxnat.ime.kfa-juelich.de:8443/xnat`` will work and ask (once) for
+the user's user name and password.

--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -104,29 +104,38 @@ with DataLad can only succeed if a "provider configuration", i.e., a configurati
 how to access the data, for this specific webserver with information on how to
 authenticate exists.
 
-"Provider configurations" are small text files that exist on a per-dataset level
-in ``.datalad/providers/<name>.cfg``. They can be created and saved to the dataset
+"Provider configurations" are small text files that either exist on a per-dataset
+level in ``.datalad/providers/<name>.cfg``, or on a user-level in
+``~/.config/datalad/providers/<name>.cfg``. They can be created and saved
 by hand, or configured "on the fly" from the command line upon unsuccessful
 download attempts. A configuration file follows a similar structure as the example
 below:
 
 .. code-block:: bash
 
-   [provider:example.com]
+   [provider:my-webserver]
    url_re = https://example.com/~myuser/protected/.*
-   credential = example.com/~myuser
+   credential = my-webserver
    authentication_type = http_basic_auth
 
-   [credential:example.com/~myuser]
+   [credential:my-webserver]
    type = user_password
 
-In the dataset that this file was placed into, downloading commands
-that point to ``https://example.com/~myuser/protected/<path>`` will ask (once) for
+For a *local* [#f1]_, i.e., dataset-specific, configuration, place the file into
+``.datalad/providers/my-webserver.cfg``. Subsequently, in the dataset that
+this file was placed into, downloading commands that point to
+``https://example.com/~myuser/protected/<path>`` will ask (once) for
 the user's user name and password, and subsequently store these credentials.
+In order to make it a *global* configuration,
+i.e., enable downloads from the webserver from within all datasets of the user,
+place the file into the users home directory under
+``~/.config/datalad/providers/my-webserver.cfg``.
 
 If the file is generated "on the fly" from the terminal, it will prompt for
 exactly the same information as specified in the example above and write the
-required ``.cfg`` based on the given information. Here is how that would look like::
+required ``.cfg`` based on the given information. Note that this will configure
+data access *globally*, i.e., it will place the file under
+``~/.config/datalad/providers/<name>.cfg``. Here is how that would look like::
 
    $ datalad download-url  https://example.com/~myuser/protected/my_protected_file
     [INFO   ] Downloading 'https://example.com/~myuser/protected/my_protected_file' into '/tmp/ds/'
@@ -186,5 +195,11 @@ required ``.cfg`` based on the given information. Here is how that would look li
       download_url (ok: 1)
       save (ok: 1)
 
-Subsequently, all downloads from ``https://example.com/~myuser/protected/*`` will
-succeed.
+Subsequently, all downloads from ``https://example.com/~myuser/protected/*``
+by the user will succeed. If something went wrong during this interactive
+configuration, delete or edit the file at ``~/.config/datalad/providers/<name>.cfg``.
+
+.. rubric:: Footnotes
+
+.. [#f1] To re-read on configurations and their scope, check out chapter
+         :ref:`chapter_config` again.

--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -38,11 +38,11 @@ the entered credentials stay valid.
 
 If a particular storage solution requires authentication but it is not known
 to DataLad yet, the download will fail. Here is how this looks like if data is
-retrieved from a server that requires HTTP authentication, but is not configured
-for data access::
+retrieved from a server that requires HTTP authentication, but DataLad -- or the
+dataset -- lacks a configuration for data access about this server::
 
    $ datalad download-url  https://example.com/myuser/protected/path/to/file
-     [INFO   ] Downloading 'https://example.com/myuser/protected/path/to/file' into 'local/path/file'
+     [INFO   ] Downloading 'https://example.com/myuser/protected/path/to/file' into 'local/path/'
      Authenticated access to https://example.com/myuser/protected/path/to/file has failed.
      Would you like to setup a new provider configuration to access url? (choices: [yes], no): yes
 
@@ -130,7 +130,8 @@ required ``.cfg`` based on the given information. Here is how that would look li
     Would you like to setup a new provider configuration to access url? (choices: [yes], no): yes
 
     New provider name
-    Unique name to identify 'provider' for https://example.com/~myuser/protected/my_protected_file [https://example.com]: my-webserver
+    Unique name to identify 'provider' for https://example.com/~myuser/protected/my_protected_file [https://example.com]:
+    my-webserver
 
     New provider regular expression
     A (Python) regular expression to specify for which URLs this provider

--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -35,6 +35,17 @@ requested data will be downloaded, and all subsequent retrievals via
 :command:`get` will authenticate automatically, without user input, as long as
 the entered credentials stay valid.
 
+.. findoutmore:: How does the authentication work?
+
+   Passwords, user names, tokens, or any other login information is stored in
+   your system's (encrypted) `keyring <https://en.wikipedia.org/wiki/GNOME_Keyring>`_.
+   It is a built-in credential store, used in all major operating systems, and
+   can store credentials securely.
+   DataLad uses the `Python keyring <https://keyring.readthedocs.io/en/latest/>`_
+   package to access the keyring. In addition to a standard interface to the
+   keyring, this library also has useful special purpose backends that come in
+   handy in corner cases such as HPC/cluster computing, where no interactive
+   sessions are available.
 
 If a particular storage solution requires authentication but it is not known
 to DataLad yet, the download will fail. Here is how this looks like if data is

--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -8,7 +8,7 @@ protocol from various data storage solutions via its downloading commands
 (:command:`datalad download-url`, :command:`datalad addurls`,
 :command:`datalad get`).
 If data retrieval from a storage solution requires *authentication*,
-i.e., for example via a username and password combination, DataLad provides an
+for example via a username and password combination, DataLad provides an
 interface to query, request, and store the most common type of credentials that
 are necessary to authenticate, for a range of authentication types.
 There are a number of natively supported types of authentication and out-of-the
@@ -58,10 +58,14 @@ The configuration can either be done in the terminal upon a prompt from the
 command line when a download fails due to a missing provider configuration as
 shown above, or by placing a configuration file for the required data access into
 ``.datalad/providers/<provider-name>.cfg``.
-The following information is needed: An arbitrary name that the data access is
-identified with, a regular expression that can match a url one would want to
-download from, an authentication type, and a credential type. The example
-below sheds some light one this.
+The following information is needed:
+
+- An arbitrary name that the data access is identified with,
+- a regular expression that can match a url one would want to download from,
+- an authentication type, and
+- a credential type.
+
+The example below sheds some light one this.
 
 .. findoutmore:: Which authentication and credential types are possible?
 

--- a/docs/basics/101-146-providers.rst
+++ b/docs/basics/101-146-providers.rst
@@ -1,86 +1,114 @@
 .. _providers:
 
-Configuring new data providers
-------------------------------
+Configure custom data access
+----------------------------
 
 DataLad can download files via the ``http``, ``https``, ``ftp``, and ``s3``
-protocol. If data retrieval requires authentication, DataLad's provides an interface to
-query, request, and store the most common type of credentials. An example of this
-is shown in the usecase :ref:`usecase_HCP_dataset`: :command:`datalad get` will
-ask for AWS S3 credential to retrieve data that is stored in S3 buckets from
-the command line once, and -- given valid credentials -- download the files
-and all future files from this bucket right away. There
-are a number of natively supported types of authentication (a list is given in
-the hidden section below) and out-of-the box access to a broad range
-of providers such as `S3 <https://aws.amazon.com/s3/?nc1=h_ls>`_ or
-`LORIS <https://loris.ca/>`_.
-If you attempt to retrieve data from supported providers that require authentication,
-you will be prompted for your credentials from the command line at the time of
-the first download, and subsequent downloads handle authentication in the background.
+protocol from various data storage solutions via its downloading commands
+(:command:`datalad download-url`, :command:`datalad addurls`,
+:command:`datalad get`).
+*Authentication* during such retrieval is the process by which is verified that
+someone is who they claim they are, for example via a username and password
+combination. If data retrieval from a storage solution requires authentication,
+DataLad provides an interface to query, request, and store the most common
+type of credentials that are necessary to authenticate, for a range of
+authentication types.
+There are a number of natively supported types of authentication and out-of-the
+box access to a broad range of access providers, from common solutions such as
+`S3 <https://aws.amazon.com/s3/?nc1=h_ls>`_ to special purpose solutions, such as
+`LORIS <https://loris.ca/>`_. For any supported access type that requires
+authentication, the procedure is always the same:
+Upon first access via any downloading command, users will be prompted for their
+credentials from the command line. Subsequent downloads handle authentication
+in the background as long as the credentials stay valid. An example of this
+credential management is shown in the usecase :ref:`usecase_HCP_dataset`:
+Data is stored in S3 buckets that require authentication with AWS credentials.
+The first :command:`datalad get` to retrieve any of the data will prompt for
+the credentials from the terminal. If the given credentials are valid, the
+requested data will be downloaded, and all subsequent retrievals via
+:command:`get` will authenticate automatically, without user input, as long as
+the entered credentials stay valid.
 
-If a provider requires authentication but it is not known to DataLad yet, the
-download will fail. However, the provider can be configured by
-the user to enable interactions with it.
-With a provider configuration in place, commands such as :command:`datalad download-url`
-or :command:`datalad add-urls` can work with urls of custom providers, and
+
+If a particular storage solution requires authentication but it is not known
+to DataLad yet, the download will fail. Here is how this looks like if data is
+retrieved from a server that requires HTTP authentication, but is not configured
+for data access::
+
+   $ datalad download-url  https://example.com/myuser/protected/path/to/file
+     [INFO   ] Downloading 'https://example.com/myuser/protected/path/to/file' into 'local/path/file'
+     Authenticated access to https://example.com/myuser/protected/path/to/file has failed.
+     Would you like to setup a new provider configuration to access url? (choices: [yes], no): yes
+
+However, data access can be configured by
+the user if the required authentication and credential type are supported by
+DataLad (a list is given in the hidden section below).
+With a data access configuration in place, commands such as
+:command:`datalad download-url` or :command:`datalad addurls` can work with urls
+the point to the location of the data to be retrieved, and
 :command:`datalad get` is enabled to retrieve file contents from these sources.
 The configuration can either be done in the terminal upon a prompt from the
-command line when a download fails due to a missing provider configuration,
-or by placing provider-specific configuration files into ``.datalad/providers``.
-
-In order to configure a provider configuration, one needs to input a
-provider name, a regular expression that can match a url one would want to download
-from, an authentication type, and a credential type. The example below sheds some
-light one this.
+command line when a download fails due to a missing provider configuration as
+shown above, or by placing a configuration file for the required data access into
+``.datalad/providers``.
+The following information is needed: An arbitrary name that the data access is
+identified with, a regular expression that can match a url one would want to
+download from, an authentication type, and a credential type. The example
+below sheds some light one this.
 
 .. findoutmore:: Which authentication and credential types are possible?
 
-   The following credential types are supported:
+   When configuring custom data access, credential and authentication type
+   are required information. Below, we list the most common choices for these fields.
 
-   - ``'user_password'``
-   - ``'aws-s3'``
-   - ``'nda-s3'``
-   - ``'token'``
-   - ``'loris-token'``
+   Among the most common credential types, ``'user_password'``, ``'aws-s3'``, and
+   ``'token'`` authentication is supported. For a full list, including some
+   less common authentication types, please see the technical documentation
+   of DataLad.
 
-   The following authentication types are supported:
+   For authentication, the most common supported solutions are ``'html_form'``,
+   ``'http_auth'`` (   `http and html form-based authentication <https://en.wikipedia.org/wiki/HTTP%2BHTML_form-based_authentication>`_),
+   ``'http_basic_auth'`` (`http basic access <https://en.wikipedia.org/wiki/Basic_access_authentication>`_),
+   ``'http_digest_auth'`` (   `digest access authentication <https://en.wikipedia.org/wiki/Digest_access_authentication>`_),
+   ``'bearer_token'`` (`http bearer token authentication <https://tools.ietf.org/html/rfc6750>`_)
+   and ``'aws-s3'``. A full list can be found in the technical docs.
 
-   - ``'html_form'``
-   - ``'http_auth'``
-   - ``'http_basic_auth'``
-   - ``'http_digest_auth'``
-   - ``'bearer_token'``
-   - ``'aws-s3'``
-   - ``'nda-s3'``
-   - ``'loris-token'``
 
-   Some pointers to read up more on these authetication types are here:
-   `http basic access <https://en.wikipedia.org/wiki/Basic_access_authentication>`_,
-   `http and html form-based authentication <https://en.wikipedia.org/wiki/HTTP%2BHTML_form-based_authentication>`_,
-   `digest access authentication <https://en.wikipedia.org/wiki/Digest_access_authentication>`_,
-   `http bearer token authentication <https://tools.ietf.org/html/rfc6750>`_.
+Example: Data access to a server that requires basic HTTP authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Example: DataLad access to an XNAT server
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Consider a private `Apache webserver <https://httpd.apache.org/>`_ with an
+``.htaccess`` file that configures a range of allowed users to access a certain
+protected directory on this server via
+`basic HTTP authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_.
+If opened in a browser, such a setup would prompt visitors of this directory on
+the webserver for their username and password, and only grant access if valid
+credentials are entered. Unauthenticated requests cause ``401 Unauthorized Status``
+responses.
 
-`XNAT <https://www.xnat.org/about/>`_ is an open source imaging informatics platform
-and it allows for data download after authentication.
-In order to allow file retrieval from a custom deployed
-`XNAT server <https://www.xnat.org/about/>`_ with DataLad, a file following a
-similar structure as the example below (with adjusted urls and ports)
-can be placed into ``.datalad/providers/xnat.cfg``:
+By default, when DataLad attempts to retrieve files from this protected directory,
+the authentication and credential type that are required are unknown to DataLad
+and authentication fails. An attempt to download or get a file from this directory
+with DataLad can only succeed if a "provider configuration", i.e., a configuration
+how to access the data, for this specific webserver with information on how to
+authenticate exists.
+
+"Provider configurations" are small text files that exist on a per-dataset level
+in ``.datalad/providers/<name>.cfg``. They can be created and saved to the dataset
+by hand, or configured "on the fly" from the command line upon unsuccessful
+download attempts. A configuration file follows a similar structure as the example
+below:
 
 .. code-block:: bash
 
-   [provider:xnat]
-   url_re = https://nmrxnat.ime.kfa-juelich.de:8443/xnat/.*
-   credential = nmrxnat.ime.kfa-juelich.de:8443/xnat
+   [provider:example.com]
+   url_re = https://example.com/~myuser/protected/.*
+   credential = example.com/~myuser
    authentication_type = http_basic_auth
 
-   [credential:nmrxnat.ime.kfa-juelich.de:8443/xnat]
+   [credential:example.com/~myuser]
    type = user_password
 
-In the dataset that this file was placed into, downloading commands such as
-:command:`datalad download-url` that point to
-``https://nmrxnat.ime.kfa-juelich.de:8443/xnat`` will work and ask (once) for
-the user's user name and password.
+In the dataset that this file was placed into, downloading commands
+that point to ``https://example.com/~myuser/protected/<path>`` will ask (once) for
+the user's user name and password, and subsequently store these credentials

--- a/docs/basics/basics10toc.rst
+++ b/docs/basics/basics10toc.rst
@@ -16,3 +16,4 @@
    101-179-gitignore
    101-144-intro_extensions
    101-145-hooks
+   101-146-providers


### PR DESCRIPTION
This is quickly written down and without much substance to it (quite difficult to dig through the docstring-less ``downloaders`` code base). If it contains too many errors, we can add the XNAT configuration as a gist for now and wait until I know more about file transfer and credential management.