### PR TITLE
Data sharing via Gin -- Update

### DIFF
--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -69,10 +69,13 @@ information about where to obtain annexed file contents from such that
 :command:`datalad get` works.
 
 This tutorial showcases how this can be done, and shows the basics of how
-datasets can be shared via a third party infrastructure. A much easier
-alternative using another third party infrastructure is introduced in the next
-section, :ref:`gin`, using the free G-Node infrastructure. If you prefer this as an
-easier start, feel free to skip ahead.
+datasets can be shared via a third party infrastructure.
+
+.. note::
+
+   A much easier alternative using another third party infrastructure is
+   introduced in the next section, :ref:`gin`, using the free G-Node
+   infrastructure. If you prefer this as an easier start, feel free to skip ahead.
 
 From your perspective (as someone who wants to share data), you will
 need to

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -26,6 +26,11 @@ In order to use GIN for hosting and sharing your datasets, you need to
 - upload your public :term:`SSH key` for SSH access
 - create an empty repository on GIN and publish your dataset to it
 
+.. todo::
+
+   Revise this last step once there is a ``datalad create-sibling-gin``
+   command: https://github.com/datalad/datalad/issues/2680
+
 Once you have `registered <https://gin.g-node.org/user/sign_up>`_
 an account on the GIN server by providing your e-mail address, affiliation,
 and name, and selecting a user name and password, you should upload your

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -160,7 +160,7 @@ an SSH key as detailed above, and cloning via the SSH url:
 
    $ datalad clone git@gin.g-node.org:/adswa/DataLad-101.git
 
-.. findoutmore:: How do I now if my repository is private?
+.. findoutmore:: How do I know if my repository is private?
 
    Private repos are marked with a lock sign. To make it public, untick the
    "Private" box, found under "Settings":

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -128,6 +128,48 @@ GIN web interface (unlike :term:`GitHub`) can even preview your annexed contents
 
 .. figure:: ../artwork/src/GIN_dl101_repo.png
 
+.. _access:
+
+Sharing and accessing the dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once your dataset is published, you can point collaborators and friends to it.
+
+If it is a **public** repository, retrieving the dataset and getting access to
+all published data contents (in a read-only fashion) is done by cloning the
+repository's ``https`` url. This does not require a user account on Gin.
+
+.. runrecord:: _examples/DL-101-139-107
+   :language: console
+   :workdir: dl-101/clone_of_dl-101
+
+   $ datalad clone https://gin.g-node.org/adswa/DataLad-101
+
+Subsequently, :command:`datalad get` calls will be able to retrieve all annexed
+file contents that have been published to the repository.
+
+If it is a **private** dataset, cloning the dataset from Gin requires a user
+name and password for anyone you want to share your dataset with.
+The "Collaboration" tab under Settings lets you set fine-grained access rights,
+and it is possible to share datasets with collaborators that are not registered
+on GIN with provided Guest accounts.
+In order to get access to annexed contents, cloning *requires* setting up
+an SSH key as detailed above, and cloning via the SSH url:
+
+.. code-block:: bash
+
+   $ datalad clone git@gin.g-node.org:/adswa/DataLad-101.git
+
+.. findoutmore:: How do I now if my repository is private?
+
+   Private repos are marked with a lock sign. To make it public, untick the
+   "Private" box, found under "Settings":
+
+   .. figure:: ../artwork/src/GIN_private.png
+
+In order to publish changes to a Gin repository, the repository needs
+to be cloned via its SSH url.
+
 
 .. _subdspublishing:
 
@@ -205,13 +247,6 @@ the problem:
 If the subdataset was not published before, you could publish the subdataset to
 a location of your choice, and modify the ``.gitmodules`` entry accordingly.
 
-Sharing the dataset
-^^^^^^^^^^^^^^^^^^^
-
-Once your dataset is published, you can point collaborators and friends to it.
-The "Collaboration" tab under Settings lets you set fine-grained access rights,
-and it is possible to share datasets with collaborators that are not registered
-on GIN.
 
 
 .. rubric:: Footnotes

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -8,7 +8,14 @@ free data management system designed for comprehensive and reproducible manageme
 of scientific data. It is a web-based repository store and provides
 fine-grained access control to share data. :term:`GIN` builds up on :term:`Git` and
 :term:`git-annex`, and is an easy alternative to other third-party services to host
-and share your DataLad datasets [#f1]_.
+and share your DataLad datasets [#f1]_. It allows to share datasets and their
+contents with selected collaborators or making them publicly and anonymously
+available.
+
+.. note::
+
+   If you reached this section to find out how to access a DataLad dataset
+   shared on Gin, please skip to the section :ref:`access`.
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/docs/basics/_examples/DL-101-139-107
+++ b/docs/basics/_examples/DL-101-139-107
@@ -1,0 +1,10 @@
+$ datalad clone https://gin.g-node.org/adswa/DataLad-101
+[INFO] Cloning dataset to <Dataset path=/home/me/dl-101/clone_of_dl-101/DataLad-101> 
+[INFO] Attempting to clone from https://gin.g-node.org/adswa/DataLad-101 to /home/me/dl-101/clone_of_dl-101/DataLad-101 
+[INFO] Start enumerating objects 
+[INFO] Start counting objects 
+[INFO] Start compressing objects 
+[INFO] Start receiving objects 
+[INFO] Start resolving deltas 
+[INFO] Completed clone attempts for <Dataset path=/home/me/dl-101/clone_of_dl-101/DataLad-101> 
+install(ok): /home/me/dl-101/clone_of_dl-101/DataLad-101 (dataset)


### PR DESCRIPTION
This updates the third party sharing chapter with Gin's new ability to allow anonymous read-only access to datasets. I have also pointed out more prominently that Gin is an easy alternative to other third party services in the first section by transforming it into a note, but please weigh in on whether we may want to rewrite the section on Gin to become the first section in this chapter.

@achilleas-k, if you have links to cross-reference to your docs, or any general feedback, let me know!