### PR TITLE
Run: mention that the command needs to be the last element of a run call

### DIFF
--- a/docs/basics/101-112-run4.rst
+++ b/docs/basics/101-112-run4.rst
@@ -124,6 +124,12 @@ It does not warn if the repository is dirty, but importantly, it
 **only** saves modifications to the *listed outputs* (which is a problem in the
 vast amount of cases where one does not exactly know which outputs are produced).
 
+.. note::
+
+   The ``--explicit`` flag has to be given anywhere *prior* to the command that
+   should be run -- the command needs to be the last element of a
+   :command:`datalad run` call.
+
 A :command:`datalad status` will show that your previously modified ``notes.txt``
 is still modified:
 


### PR DESCRIPTION
This adds a small note on ``--explicit`` and `run`, and results from the fact that until now I wasn't aware that simply appending an ``--explicit`` to a `datalad run ...` is not possible.