### PR TITLE
Do not use docutil nodes for markup purposes, more beautiful boxes

### DIFF
--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -23,13 +23,22 @@ def depart_gitusernote_html(self, node):
 
 
 def visit_gitusernote_latex(self, node):
-    # wrap the Gitusernote in a colored box (defined in conf.py preamble)
-    self.body.append('\n\n\\begin{colbox}{C9C0BB}\n'
-                     '\n\n\\sphinxstrong{\\textcolor{purple}{Note for Git users:}}\n\n')
+    self.body.append("""
+    \\begin{tcolorbox}[
+        enhanced,
+        breakable,
+        drop lifted shadow,
+        sharp corners,
+        title=Note for Git users,
+        coltitle=dataladgray,
+        colbacktitle=dataladblue,
+        colframe=dataladblue!70!black,
+        fonttitle=\\bfseries]
+    """)
 
 
 def depart_gitusernote_latex(self, node):
-    self.body.append("\n\n\\end{colbox}")
+    self.body.append('\n\n\\end{tcolorbox}\n')
 
 
 class GitUserNote(BaseAdmonition):
@@ -53,14 +62,23 @@ def depart_findoutmore_html(self, node):
 
 
 def visit_findoutmore_latex(self, node):
-    self.body.append('\\begin{colortext}\n'
-                     '\n\\ruleline{Findoutmore}')
-    #import pdb; pdb.set_trace()
+    self.body.append("""
+    \\begin{tcolorbox}[
+        enhanced,
+        breakable,
+        drop lifted shadow,
+        sharp corners,
+        title=Find out more,
+        coltitle=dataladgray,
+        colbacktitle=dataladyellow,
+        colframe=dataladyellow!70!black,
+        fonttitle=\\bfseries]
+    """)
 
 
 def depart_findoutmore_latex(self, node):
-    self.body.append('\n\n\\ruleline{-}\n'
-                     '\\end{colortext}')
+    self.body.append('\n\n\\end{tcolorbox}\n')
+
 
 class FindOutMore(BaseAdmonition):
     """findoutmore RST directive
@@ -92,15 +110,10 @@ class FindOutMore(BaseAdmonition):
         toggle = findoutmore(
             'toogle',
             # header line with 'Find out more' prefix
-            nodes.container(
-                'label',
-                nodes.paragraph(
-                    'title', '',
-                    nodes.strong('strong', 'Find out more: '),
-                    # place actual admonition title we removed
-                    # above
-                    nodes.Text(self.arguments[0]),
-                ),
+            nodes.paragraph(
+                # place actual admonition title we removed
+                # above
+                'title', self.arguments[0],
                 # add (CSS) class
                 classes=['header'],
             ),

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -28,6 +28,18 @@
     background: #eee;
 }
 
+.findoutmore .header:before {
+    content: "⇩ Find out more: ";
+    color: #ffa200;
+    font-weight: bold;
+}
+
+.findoutmore .header.open:before {
+    content: "⇧ Find out more: ";
+    color: #ffa200;
+    font-weight: bold;
+}
+
 /* make TODOslook plain and stand out at the same time
  * TODOs should not be a frequent feature in the handbook */
 div.admonition-todo {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,8 +289,17 @@ latex_elements = {
 \usepackage{charter}
 \usepackage[defaultsans]{lato}
 \usepackage{inconsolata}
+
+% nice boxes
+\usepackage[skins,breakable]{tcolorbox}
+\tcbset{enhanced}
+
 \setcounter{tocdepth}{1}
 \usepackage{xcolor}
+\definecolor{dataladyellow}{HTML}{FFA200}
+\definecolor{dataladblue}{HTML}{7FD5FF}
+\definecolor{dataladgray}{HTML}{333333}
+
 \setcounter{secnumdepth}{0}
 \newsavebox{\selvestebox}
 \newenvironment{colbox}[1]

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -73,16 +73,26 @@ will let you master a given task and get along comfortably.
 Having the basics will be your multi-purpose swiss army knife.
 But if you want to have the special knowledge for a very peculiar type
 of problem set or that extra increase in skill or understanding,
-you'll have to do a detour into some of the *hidden* parts of the book:
+you'll have to do a detour into some of the "hidden" parts of the book:
 When there are command options or explanations that go beyond basics and
-best practices, we hide them in foldable book sections in order
+best practices, we hide them in special book sections in order
 to not be too distracting for anyone only interested in the basics.
 You can decide for yourself whether you want to check them out:
 
-.. findoutmore:: Click here to show/hide further commands
+.. only:: html
 
-    Sections like this contain content that goes beyond the basics
-    necessary to complete a challenge.
+   .. findoutmore:: Click here to show/hide further commands
+
+       Sections like this contain content that goes beyond the basics
+       necessary to complete a challenge.
+
+.. only:: latex
+
+   .. findoutmore:: Information on further commands
+
+       Sections like this contain content that goes beyond the basics
+       necessary to complete a challenge.
+
 
 Note further that...
 


### PR DESCRIPTION
This leaves the general structure unchanges, but all styling is done in Latex or CSS, without changing the docutil node structure anymore.

For the PDF switch to tcolorbox for more beautiful boxes that can span multiple pages. Also use "DataLad colors" more intensively.

![image](https://user-images.githubusercontent.com/136479/82752304-60678c00-9dbd-11ea-9e43-d48f9a62f58a.png)
