### PR TITLE
Build two-sided PDF

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -303,7 +303,7 @@ latex_elements = {
         release,
         ', '.join('\\mbox{%s}' % a for a in authors[1:-1]),
     ),
-    'extraclassoptions': 'openany,oneside',
+    'extraclassoptions': 'openany,twoside',
     'fncychap': r'\usepackage[Bjarne]{fncychap}',
     'passoptionstopackages': r'\PassOptionsToPackage{svgnames}{xcolor}',
     'preamble': r"""


### PR DESCRIPTION
First, it makes sense to targeted two-sided printing at 400+ pages, and
second it removed tons of warnings from the PDF build, because it
removes a conflict between sphinx's fancyhdr setup, and our previous
explicit 'oneside' configuration.