### PR TITLE
Add shortcut buttons to cheatsheet and summary to sidebar

### DIFF
--- a/docs/_static/cheatsheet.svg
+++ b/docs/_static/cheatsheet.svg
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="cheatsheet.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   id="svg9715"
+   version="1.1"
+   viewBox="0 0 73.860794 21.242081"
+   height="21.242081mm"
+   width="73.860794mm">
+  <defs
+     id="defs9709" />
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="27"
+     inkscape:window-x="0"
+     inkscape:window-height="1376"
+     inkscape:window-width="2560"
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="74.306065"
+     inkscape:cx="216.89832"
+     inkscape:zoom="2.8"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata9712">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-5.150774,-32.331532)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <rect
+       style="display:inline;opacity:1;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.104557;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2763"
+       width="73.832176"
+       height="19.247284"
+       x="5.150774"
+       y="32.331532" />
+    <rect
+       style="display:inline;opacity:1;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:0.0250467;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2763-3"
+       width="73.837509"
+       height="1.0776397"
+       x="5.150774"
+       y="51.578846" />
+    <rect
+       style="display:inline;opacity:1;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.0250458;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2763-3-6"
+       width="73.832176"
+       height="1.0922475"
+       x="5.150774"
+       y="32.331532" />
+    <rect
+       style="display:inline;opacity:1;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.0250508;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2763-3-6-5"
+       width="73.860794"
+       height="1.0908203"
+       x="5.150774"
+       y="52.482792" />
+    <a
+       style="display:inline;opacity:0.97"
+       id="a13079"
+       xlink:href="http://docs.datalad.org/en/latest/"
+       target="http://docs.datalad.org/en/latest/"
+       transform="translate(7.2367039,32.315784)">
+      <g
+         id="g1442"
+         transform="matrix(0.4428013,0,0,0.4428013,-3.5686857,-1.0489431)">
+        <g
+           style="display:inline"
+           id="g1395">
+          <g
+             inkscape:export-ydpi="299.96201"
+             inkscape:export-xdpi="299.96201"
+             id="flowRoot4504-8-4"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:25px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             transform="matrix(0.26458333,0,0,0.26458333,23.911751,-45.388537)"
+             aria-label="lad">
+            <path
+               sodipodi:nodetypes="cscsccscscc"
+               inkscape:connector-curvature="0"
+               id="path4584-3"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';fill:#ffa200;fill-opacity:1"
+               d="m 95.601062,269.44343 -0.0011,38.5225 c -5.7e-5,1.984 0.513084,3.552 1.537084,4.704 1.024,1.088 2.240001,1.632 3.648004,1.632 2.688,0 3.65097,0.033 6.816,0.0205 l 0.0103,12.55209 c -5.1871,0.009 -3.85034,0.003 -8.842344,0.003 -4.928,0 -9.12,-1.632 -12.576,-4.896 -3.392,-3.264 -5.088,-7.712 -5.088,-13.344 v -39.1945 z" />
+          </g>
+          <path
+             sodipodi:nodetypes="ssscscccccccsscscscsss"
+             inkscape:export-ydpi="299.96201"
+             inkscape:export-xdpi="299.96201"
+             id="path4588-1"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;line-height:25px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 75.669676,41.098735 c -1.608667,0 -3.048,-0.6858 -4.318,-2.0574 -1.27,-1.3716 -1.905,-3.0734 -1.905,-5.105399 0,-2.032 0.618067,-3.691467 1.8542,-4.9784 1.236133,-1.303867 2.683933,-1.9558 4.3434,-1.9558 1.659469,0 3.014136,0.5842 4.064003,1.7526 l 1.77e-4,-5.64119 1.905,-1.700293 1.905,1.700293 -1.77e-4,17.782389 h -3.81 v -1.8034 c -1.0668,1.337733 -2.413001,2.0066 -4.038603,2.0066 z m -2.3876,-7.010399 c 0,1.100666 0.3302,2.006599 0.9906,2.717799 0.6604,0.694267 1.430867,1.0414 2.3114,1.0414 0.880535,0 1.625603,-0.347133 2.235203,-1.0414 0.626533,-0.7112 0.9398,-1.617133 0.9398,-2.717799 0,-1.1176 -0.313267,-2.040467 -0.9398,-2.7686 -0.6096,-0.745067 -1.363134,-1.1176 -2.260603,-1.1176 -0.897467,0 -1.667933,0.372533 -2.3114,1.1176 -0.643467,0.745067 -0.9652,1.667933 -0.9652,2.7686 z"
+             inkscape:connector-curvature="0" />
+          <g
+             inkscape:export-ydpi="299.96201"
+             inkscape:export-xdpi="299.96201"
+             id="flowRoot4504-6"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:25px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             transform="matrix(0.26458333,0,0,0.26458333,-10.022048,-59.473525)"
+             aria-label="data">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4612-4"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';fill:#ffffff;fill-opacity:1"
+               d="m 171.53287,326.87793 q -9.888,0 -17.28,-7.392 -7.392,-7.392 -7.392,-19.392 0,-12.096 7.584,-19.296 7.584,-7.2 17.568,-7.2 7.776,0 13.536,5.184 v -4.32 h 14.496 v 51.648 h -14.496 v -4.224 q -6.144,4.992 -14.016,4.992 z m -10.176,-26.496 q 0,6.336 3.744,10.368 3.744,3.936 8.736,3.936 4.992,0 8.448,-3.936 3.456,-4.032 3.456,-10.272 0,-6.336 -3.456,-10.56 -3.456,-4.224 -8.544,-4.224 -5.088,0 -8.736,4.224 -3.648,4.128 -3.648,10.464 z" />
+            <path
+               sodipodi:nodetypes="sssssccccccsscscssscs"
+               inkscape:connector-curvature="0"
+               id="path4616-0"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';fill:#ffffff;fill-opacity:1"
+               d="m 264.91341,326.87793 c -6.592,0 -12.352,-2.464 -17.28,-7.392 -4.928,-4.928 -7.392,-11.392 -7.392,-19.392 0,-8.064 2.528,-14.496 7.584,-19.296 5.056,-4.8 10.912,-7.2 17.568,-7.2 5.184,0 9.696,1.728 13.536,5.184 v -4.32 h 14.496 v 52.44075 h -14.496 v -5.01675 c -4.096,3.328 -8.768,4.992 -14.016,4.992 z m -10.176,-26.496 c 0,4.224 1.248,7.68 3.744,10.368 2.496,2.624 5.408,3.936 8.736,3.936 3.328,0 6.144,-1.312 8.448,-3.936 2.304,-2.688 3.456,-6.112 3.456,-10.272 0,-4.224 -1.152,-7.744 -3.456,-10.56 -2.304,-2.816 -5.152,-4.224 -8.544,-4.224 -3.392,0 -6.304,1.408 -8.736,4.224 -2.432,2.752 -3.648,6.24 -3.648,10.464 z" />
+            <path
+               sodipodi:nodetypes="cccccccccccc"
+               inkscape:connector-curvature="0"
+               id="path4614-2"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';fill:#ffffff;fill-opacity:1"
+               d="m 209.3575,326.42845 4e-5,-17.79057 -7.6e-4,-49.632 14.49624,-10e-6 v 15.456 h 12.48 v 11.232 h -12.48 l -10e-4,22.272 -3e-5,15.24998 -7.24725,6.42519 -7.24724,-6.42519" />
+          </g>
+          <path
+             inkscape:export-ydpi="299.96201"
+             inkscape:export-xdpi="299.96201"
+             sodipodi:nodetypes="cccsccssscccccsccsc"
+             inkscape:connector-curvature="0"
+             id="path1711-6-2-1"
+             d="m 17.452682,8.7212544 -1.906485,1.9064846 1.940098,1.940098 h 0.282821 c 0.946542,0 1.789879,0.223753 2.529901,0.671209 0.740024,0.430247 1.316456,1.041043 1.729492,1.832696 0.430247,0.791651 0.645475,1.703714 0.645475,2.736304 0,1.015381 -0.197915,1.918919 -0.593741,2.710572 -0.395827,0.791653 -0.946686,1.40271 -1.652289,1.832957 -0.252626,0.154039 -0.518946,0.279256 -0.798045,0.378146 0.194754,0.207133 1.7463,1.536742 1.7463,1.536742 l -1.241054,2.325074 c 0.957959,-0.187072 1.84731,-0.490146 2.667767,-0.909914 1.497255,-0.757234 2.650383,-1.824061 3.459245,-3.200848 0.826073,-1.376788 1.239217,-2.951585 1.239217,-4.724198 0,-1.772614 -0.404618,-3.338623 -1.21348,-4.6982 C 25.479041,11.68159 24.343225,10.614499 22.880388,9.8572668 21.434762,9.1000353 19.765401,8.7212544 17.872319,8.7212544 Z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.134452px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             inkscape:export-ydpi="299.96201"
+             inkscape:export-xdpi="299.96201"
+             sodipodi:nodetypes="ssssscccccccsscscssscs"
+             id="path4586-7"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:96px;line-height:25px;font-family:'Montserrat Alternates';-inkscape-font-specification:'Montserrat Alternates Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 60.069768,41.098735 c -1.744133,0 -3.268133,-0.651933 -4.572,-1.9558 -1.303866,-1.303867 -1.9558,-3.014133 -1.9558,-5.130799 0,-2.1336 0.668867,-3.8354 2.0066,-5.1054 1.337734,-1.27 2.887134,-1.905 4.6482,-1.905 1.3716,0 2.5654,0.4572 3.5814,1.3716 l 2.88e-4,-1.35286 1.9175,-1.700476 1.9175,1.700476 1.12e-4,13.875059 h -3.8354 v -1.1176 c -1.083733,0.880531 -2.319866,1.3208 -3.7084,1.3208 z m -2.6924,-7.010399 c 0,1.117599 0.3302,2.031999 0.9906,2.743199 0.6604,0.694267 1.430867,1.0414 2.3114,1.0414 0.880534,0 1.6256,-0.347133 2.2352,-1.0414 0.6096,-0.7112 0.9144,-1.617133 0.9144,-2.717799 0,-1.1176 -0.3048,-2.048933 -0.9144,-2.794 -0.6096,-0.745067 -1.363133,-1.1176 -2.2606,-1.1176 -0.897466,0 -1.667933,0.372533 -2.3114,1.1176 -0.643466,0.728133 -0.9652,1.651 -0.9652,2.7686 z"
+             inkscape:connector-curvature="0" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="rect2037"
+             d="m 79.708456,20.517949 1.905,-1.7 1.905,1.7 V 22.218 l -1.905,-1.700015 -1.905,1.700015 z"
+             style="opacity:1;fill:#ffa200;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0" />
+          <path
+             sodipodi:nodetypes="ccccccc"
+             inkscape:connector-curvature="0"
+             id="rect2037-6"
+             d="m 79.708456,17.927898 1.905,-1.7 1.905,1.7 v 1.700051 l -1.905,-1.700015 -1.905,1.700015 z"
+             style="display:inline;opacity:1;fill:#ffa200;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0" />
+        </g>
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:0.134452px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 10.076211,8.721255 v 18.096381 c 0,0 6.723806,0.0017 7.275896,0 0.552089,-0.0017 0.786041,-0.100838 0.786041,-0.100838 l 1.26597,-1.979505 -2.025955,-1.740245 h -2.577755 v -10.42921 l -0.89967,-0.899934 -1.040165,-1.040164 -5.55e-4,-2.68e-4 c 1.3e-4,1.33e-4 0.957608,-0.957398 1.906482,-1.906223 z"
+           id="path1711-6-2-1-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cczcccccccccc"
+           inkscape:export-xdpi="299.96201"
+           inkscape:export-ydpi="299.96201" />
+      </g>
+    </a>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.67278px;line-height:80.5%;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;display:inline;opacity:0.97;fill:#ffffff;fill-opacity:0.988235;stroke:none;stroke-width:0.0526317px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:100000;stroke-opacity:1"
+       x="64.310989"
+       y="41.75211"
+       id="text5839-9-5-8"
+       inkscape:export-filename="/home/adina/repos/datalad-handbook/docs/artwork/src/local_wf_simple.png"
+       inkscape:export-xdpi="272.60767"
+       inkscape:export-ydpi="272.60767"><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5026px;line-height:80.5%;font-family:'Latin Modern Sans Demi Cond';-inkscape-font-specification:'Latin Modern Sans Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:0.988235;stroke-width:0.0526317px;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100000"
+         x="64.310989"
+         y="41.75211"
+         id="tspan8820-8-0">Cheat</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5026px;line-height:80.5%;font-family:'Latin Modern Sans Demi Cond';-inkscape-font-specification:'Latin Modern Sans Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:0.988235;stroke-width:0.0526317px;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:100000"
+         x="64.310989"
+         y="50.206703"
+         id="tspan14931">Sheet</tspan></text>
+  </g>
+</svg>

--- a/docs/_static/gist.svg
+++ b/docs/_static/gist.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)"
+   sodipodi:docname="gist.svg"
+   version="1.1"
+   viewBox="0 0 417.00197 230.27963"
+   height="230.27963"
+   width="417.00195"
+   data-name="Layer 1"
+   id="ae0ed483-2375-4630-8129-5bebfcf074ba">
+  <metadata
+     id="metadata31">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs29" />
+  <sodipodi:namedview
+     inkscape:current-layer="ae0ed483-2375-4630-8129-5bebfcf074ba"
+     inkscape:window-maximized="0"
+     inkscape:window-y="27"
+     inkscape:window-x="1280"
+     inkscape:cy="171.45549"
+     inkscape:cx="210.44236"
+     inkscape:zoom="1.014852"
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     showgrid="false"
+     id="namedview27"
+     inkscape:window-height="1376"
+     inkscape:window-width="1280"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path2"
+     fill="#e6e6e6"
+     d="M 285.09202,8.3360098e-6 A 30.28061,30.28061 0 0 0 260.9119,12.023468 19.9375,19.9375 0 0 0 233.0934,30.332538 h 82.33115 A 30.33247,30.33247 0 0 0 285.09202,8.3360098e-6 Z" />
+  <circle
+     id="circle6"
+     fill="#ffa200"
+     r="80.727303"
+     cy="92.882828"
+     cx="80.727303" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path8"
+     fill="#3f3d56"
+     d="m 417.00195,207.90053 v 22.3791 H 20.31548 v -22.48606 l 2.13847,-3.07934 125.76364,-181.096522 a 6.196,6.196 0 0 1 10.17914,0 l 84.34119,121.433112 60.03749,-85.688502 a 6.19679,6.19679 0 0 1 10.15774,0 L 414.86348,204.84253 Z" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path24"
+     fill="#cccccc"
+     d="m 220.26257,50.648018 a 37.35921,37.35921 0 0 0 -29.83262,14.83414 24.59823,24.59823 0 0 0 -34.32157,22.5891 h 101.5774 a 37.42318,37.42318 0 0 0 -37.42321,-37.42324 z" />
+  <g
+     transform="matrix(3.7795276,0,0,3.7795276,109.76456,301.94961)"
+     id="g61">
+    <g
+       transform="translate(-22.050532,-67.177558)"
+       id="g68">
+      <g
+         transform="translate(-10.076211,-8.3183922)"
+         style="display:inline"
+         inkscape:label="durr"
+         id="layer8">
+        <g
+           inkscape:export-ydpi="299.96201"
+           inkscape:export-xdpi="299.96201"
+           id="flowRoot4504-6"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;line-height:25px;font-family:Arial;-inkscape-font-specification:'Arial, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#333333;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           transform="matrix(0.26458333,0,0,0.26458333,-10.022048,-59.473525)"
+           aria-label="data" />
+        <path
+           inkscape:export-ydpi="299.96201"
+           inkscape:export-xdpi="299.96201"
+           sodipodi:nodetypes="cccsccssscccccsccsc"
+           inkscape:connector-curvature="0"
+           id="path1711-6-2-1"
+           d="m 17.981849,8.7212544 -1.906485,1.9064846 1.940098,1.940098 h 0.282821 c 0.946542,0 1.789879,0.223753 2.529901,0.671209 0.740024,0.430247 1.316456,1.041043 1.729492,1.832696 0.430247,0.791651 0.645475,1.703714 0.645475,2.736304 0,1.015381 -0.197915,1.918919 -0.593741,2.710572 -0.395827,0.791653 -0.946686,1.40271 -1.652289,1.832957 -0.252626,0.154039 -0.518946,0.279256 -0.798045,0.378146 0.194754,0.207133 1.7463,1.536742 1.7463,1.536742 l -1.241054,2.325074 c 0.957959,-0.187072 1.84731,-0.490146 2.667767,-0.909914 1.497255,-0.757234 2.650383,-1.824061 3.459245,-3.200848 0.826073,-1.376788 1.239217,-2.951585 1.239217,-4.724198 0,-1.772614 -0.404618,-3.338623 -1.21348,-4.6982 C 26.008208,11.68159 24.872392,10.614499 23.409555,9.8572668 21.963929,9.1000353 20.294568,8.7212544 18.401486,8.7212544 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.134452px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(-10.076211,-8.3183922)"
+         inkscape:label="L"
+         id="layer9"
+         style="fill:#ffffff">
+        <path
+           inkscape:export-ydpi="299.96201"
+           inkscape:export-xdpi="299.96201"
+           sodipodi:nodetypes="cczcccccccccc"
+           inkscape:connector-curvature="0"
+           id="path1711-6-2-1-9"
+           d="m 10.605378,8.721255 v 18.096381 c 0,0 6.723806,0.0017 7.275896,0 0.552089,-0.0017 0.786041,-0.100838 0.786041,-0.100838 l 1.26597,-1.979505 -2.025955,-1.740245 h -2.577755 v -10.42921 l -0.89967,-0.899934 -1.040165,-1.040164 -5.55e-4,-2.68e-4 c 1.3e-4,1.33e-4 0.957608,-0.957398 1.906482,-1.906223 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.134452px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <rect
+     transform="matrix(0.99137575,-0.13105006,0.07144928,0.99744423,0,0)"
+     y="163.96851"
+     x="116.46029"
+     height="46.041473"
+     width="247.67052"
+     id="rect85"
+     style="fill:#ffa200;fill-opacity:1;stroke:#040404;stroke-width:0.800719;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <text
+     inkscape:transform-center-y="-8.5612669"
+     inkscape:transform-center-x="82.430439"
+     transform="rotate(-7.4675606)"
+     id="text912"
+     y="198.99135"
+     x="230.0984"
+     style="font-style:normal;font-weight:normal;font-size:37.3333px;line-height:1.25;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Latin Modern Sans Demi Cond';-inkscape-font-specification:'Latin Modern Sans Demi Cond'"
+       y="198.99135"
+       x="230.0984"
+       id="tspan910"
+       sodipodi:role="line">Get the gist!</tspan></text>
+</svg>

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -25,16 +25,18 @@
   The DataLad handbook will supply you with everything you need to get started and break new grounds with DataLad.
 </p>
 
-<div style="display:block;position:relative;margin: 1em 0 1em 0;">
-  <div style="display:block;width:50%;padding-top:50%;"></div>
-  <div class="rpad" data-unit="1x1" style="position:absolute;left:0;top:0;right:0;bottom:0;overflow:hidden;"></div>
-</div>
-
 <p>
   <a href="intro/executive_summary.html" style="border:none !important;">
     <img width="500" src="{{ pathto('_static/gist.svg', 1) }}" title="One page summary"/>
   </a>
 </p>
+
+
+<div style="display:block;position:relative;margin: 1em 0 1em 0;">
+  <div style="display:block;width:10%;padding-top:10%;"></div>
+  <div class="rpad" data-unit="1x1" style="position:absolute;left:0;top:0;right:0;bottom:0;overflow:hidden;"></div>
+</div>
+
 
 <h3>Contributors</h3>
 <p>

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -30,6 +30,12 @@
   <div class="rpad" data-unit="1x1" style="position:absolute;left:0;top:0;right:0;bottom:0;overflow:hidden;"></div>
 </div>
 
+<p>
+  <a href="intro/executive_summary.html" style="border:none !important;">
+    <img width="500" src="{{ pathto('_static/gist.svg', 1) }}" title="One page summary"/>
+  </a>
+</p>
+
 <h3>Contributors</h3>
 <p>
   This guide is the result of the collaboration of

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -56,5 +56,12 @@
   <li><a href="http://handbook.datalad.org/en/latest/basics/101-136-cheatsheet.html">DataLad cheat sheet</a></li>
 </ul>
 
+<p>
+  <a href="basics/101-136-cheatsheet.html" style="border:none !important;">
+    <img width="500" src="{{ pathto('_static/cheatsheet.svg', 1) }}" title="Straight to cheatsheet"/>
+  </a>
+</p>
+
+
 <h3>Feedback</h3>
 <p>We highly appreciate your feedback on the <a href="https://github.com/datalad-handbook/book/issues/new/choose">handbook</a> and on <a href=https://forms.gle/FkNEc7HVaZU5RTYP6>DataLad</a></p>


### PR DESCRIPTION

![Screenshot from 2020-09-15 07-55-51](https://user-images.githubusercontent.com/29738718/93171207-ec187600-f728-11ea-8427-38b70ccacf2d.png)
Adds a cheatsheet button and a button "Get the gist" that links to the one-page-summary in the intro.