### PR TITLE
MNT: Update singularity image for midterm analysis to latest version

### DIFF
--- a/docs/basics/101-133-containersrun.rst
+++ b/docs/basics/101-133-containersrun.rst
@@ -173,14 +173,14 @@ name to give to the container, and a path or url to a container Image:
    :notes: Computational reproducibility: add a software container
 
    # we are in the midterm_project subdataset
-   $ datalad containers-add midterm-software --url shub://adswa/resources:1
+   $ datalad containers-add midterm-software --url shub://adswa/resources:2
 
 .. findoutmore:: How do I add an Image from Dockerhub, or a local container?
 
    Should the Image you want to use lie on Dockerhub, specify the ``--url``
    option prefixed with ``docker://`` instead of ``shub://`` like this::
 
-      datalad containers-add midterm-software --url docker://adswa/resources:1
+      datalad containers-add midterm-software --url docker://adswa/resources:2
 
    If you want to add a container that exists locally, specify the path to it
    like this::

--- a/docs/basics/_examples/DL-101-133-101
+++ b/docs/basics/_examples/DL-101-133-101
@@ -1,5 +1,5 @@
 # we are in the midterm_project subdataset
-$ datalad containers-add midterm-software --url shub://adswa/resources:1
+$ datalad containers-add midterm-software --url shub://adswa/resources:2
 add(ok): .datalad/config (file)
 save(ok): . (dataset)
 containers_add(ok): /home/me/dl-101/DataLad-101/midterm_project/.datalad/environments/midterm-software/image (file)

--- a/docs/basics/_examples/DL-101-133-102
+++ b/docs/basics/_examples/DL-101-133-102
@@ -2,6 +2,6 @@ $ cat .datalad/config
 [datalad "dataset"]
 	id = 5f313adc-b584-11ea-90a2-3119e6b9cf19
 [datalad "containers.midterm-software"]
-	updateurl = shub://adswa/resources:1
+	updateurl = shub://adswa/resources:2
 	image = .datalad/environments/midterm-software/image
 	cmdexec = singularity exec {img} {cmd}

--- a/docs/basics/_examples/DL-101-133-103
+++ b/docs/basics/_examples/DL-101-133-103
@@ -13,7 +13,7 @@ index f0e73eb..ba9de82 100644
  [datalad "dataset"]
 	id = 5f313adc-b584-11ea-90a2-3119e6b9cf19
 +[datalad "containers.midterm-software"]
-+	updateurl = shub://adswa/resources:1
++	updateurl = shub://adswa/resources:2
 +	image = .datalad/environments/midterm-software/image
 +	cmdexec = singularity exec {img} {cmd}
 diff --git a/.datalad/environments/midterm-software/image b/.datalad/environments/midterm-software/image

--- a/docs/beyond_basics/_examples/DL-101-147-111
+++ b/docs/beyond_basics/_examples/DL-101-147-111
@@ -2,6 +2,6 @@ $ cat .datalad/config
 [datalad "dataset"]
 	id = 49864bd6-9069-11ea-96fe-833ef2c0cd3b
 [datalad "containers.midterm-software"]
-	updateurl = shub://adswa/resources:1
+	updateurl = shub://adswa/resources:2
 	image = .datalad/environments/midterm-software/image
 	cmdexec = singularity exec {img} {cmd}

--- a/docs/code_from_chapters/10_yoda_code.rst
+++ b/docs/code_from_chapters/10_yoda_code.rst
@@ -123,7 +123,7 @@ Code snippet 136::
 Code snippet 137::
 
    # we are in the midterm_project subdataset
-   datalad containers-add midterm-software --url shub://adswa/resources:1
+   datalad containers-add midterm-software --url shub://adswa/resources:2
 
 
 Code snippet 138::

--- a/docs/code_from_chapters/OHBM.rst
+++ b/docs/code_from_chapters/OHBM.rst
@@ -489,7 +489,7 @@ Here is how this works: First, I attach a software container to my dataset using
 and a url or path where to find this container, here it is singularity hub. This
 records the software in the dataset::
 
-   datalad containers-add software --url shub://adswa/resources:1
+   datalad containers-add software --url shub://adswa/resources:2
 
 Note: You need to have `singularity <https://sylabs.io/guides/3.5/user-guide/>`_
 installed to run this!


### PR DESCRIPTION
The previous container was a year old with git-annex 7.x and ran into issues in
v8 annex repositories. This change replaces code pointing to the previous image with code pointing to the new one.

This doesn't feel like the most clean way to do things, though. Is there a way to add a ``latest`` tag to the most recent image and change the code to pull the image via this tag?