### PR TITLE
Minor typo and other feedback on the INM7 version

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -150,6 +150,11 @@
       "name": "Hanke, Michael",
       "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
       "orcid": "0000-0001-6398-6370"
+    },
+    {
+      "name": "Wu, Jianxiao",
+      "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
+      "orcid": "0000-0002-4866-272X"
     }
   ],
   "keywords": [

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -10,7 +10,7 @@ large and small files, modifying content and saving the changes to history, inst
 datasets, even as subdatasets within datasets, recording the impact of commands
 on a dataset with the run and re-run commands, and capturing plenty of
 :term:`provenance` on the way.
-We further noticed that when we modified content in ``notes.txt`` or ``list_files.py``,
+We further noticed that when we modified content in ``notes.txt`` or ``list_titles.sh``,
 the modified content was in a *text file*. We learned that
 this precise type of file, in conjunction with the initial configuration template
 ``text2git`` we gave to :command:`datalad create`, is meaningful: As the textfile is

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -249,6 +249,7 @@ to manage the file system in a DataLad dataset (:ref:`filesystem`).
       :cast: 03_git_annex_basics
 
       # compare it to the checksum (here of type md5sum) of the PDF file and the subdirectory name
+      # for macOS/OSX user, use md5 instead of md5sum
       $ md5sum TLCL.pdf
 
    There are different hash functions available. Depending on which is used,

--- a/docs/basics/101-133-containersrun.rst
+++ b/docs/basics/101-133-containersrun.rst
@@ -41,6 +41,12 @@ This section will give a quick overview on what containers are and
 demonstrate how ``datalad-containers`` helps to capture full provenance of an
 analysis by linking containers to datasets and analyses.
 
+.. note::
+
+   In order to run the commands in this section, the `datalad-containers`
+   extension needs to be installed separately, simply with 
+   `pip install datalad-container`.
+
 Containers
 ^^^^^^^^^^
 

--- a/docs/beyond_basics/101-161-biganalyses.rst
+++ b/docs/beyond_basics/101-161-biganalyses.rst
@@ -6,7 +6,7 @@ Calculate in greater numbers
 When creating and populating datasets yourself it may be easy to monitor the
 overall size of the dataset and its file number, and introduce
 subdatasets whenever and where ever necessary. It may not be as straightforward
-when you are not population datasets yourself, but when *software* or
+when you are not populating datasets yourself, but when *software* or
 analyses scripts suddenly dump vast amounts of output.
 Certain analysis software can create myriads of files. A standard
 `FEAT analysis <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT/UserGuide>`_ [#f1]_


### PR DESCRIPTION
Fix issue #593 

- Fix 2 typos
- Add a comment in Chapter 3.2 for md5 checksum in macOS
- Add a note in Chapter 7.2 to remind user to install `datalad-container` first

