### PR TITLE
BF: Fix a trailing slash in the script

### DIFF
--- a/docs/beyond_basics/101-171-enki.rst
+++ b/docs/beyond_basics/101-171-enki.rst
@@ -249,7 +249,7 @@ At this point, the workflow misses a tweak that is necessary in fMRIprep to enab
         # pybids (inside fmriprep) gets angry when it sees dangling symlinks
         # of .json files -- wipe them out, spare only those that belong to
         # the participant we want to process in this job
-        find sourcedata -mindepth 2 -name '*.json' -a ! -wholename "$1"/'*' -delete
+        find sourcedata -mindepth 2 -name '*.json' -a ! -wholename "$1"'*' -delete
 
         # next one is important to get job-reruns correct. We remove all anticipated
         # output, such that fmriprep isn't confused by the presence of stale


### PR DESCRIPTION
There was an error in the ENKI preproc workflow script that presumably was fixed in the most recent version of the workflow file. It made it into the handbook because I wrote this section when this fix wasn't yet introduced. @mih, I would consider this a hotfix.