### PR TITLE
Ginupdate

### DIFF
--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -139,6 +139,16 @@ If it is a **public** repository, retrieving the dataset and getting access to
 all published data contents (in a read-only fashion) is done by cloning the
 repository's ``https`` url. This does not require a user account on Gin.
 
+.. admonition:: Important: Take the URL in the browser, not the copy-paste URL
+
+   Please note that you need to use the browser URL of the repository, not the copy-paste URL on the upper right hand side of the repository if you want to get anonymous HTTPS access!
+   The two URLs differ only by a ``.git`` extension:
+
+   * Brower bar: ``https://gin.g-node.org/<user>/<repo>``
+   * Copy-paste "HTTPS clone": ``https://gin.g-node.org/<user>/<repo>.git``
+
+   A dataset cloned from ``https://gin.g-node.org/<user>/<repoy>.git``, however, can not retrieve annexed files!
+
 .. runrecord:: _examples/DL-101-139-107
    :language: console
    :workdir: dl-101/clone_of_dl-101

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -265,9 +265,9 @@ Expandable notes, "``Windows-Workaround``\s", contain important information, alt
 - **Step 4**: Install git-annex (temporarily necessary)
   One of DataLad's core dependencies is :term:`git-annex`.
   For the longest time, git-annex installers for Windows lacked support for `mimeencoding <https://en.wikipedia.org/wiki/MIME>`_.
-   Without mimeencoding, a standard DataLad procedure, the ``text2git`` configuration (it will be introduced in the very first section of the Basics), is not functional, and you will find "Windowsworkarounds" to deal with this.
-   We recently started to build git-annex with support for mimeencoding ourselves, though.
-   At the moment, we are working on packaging up Windows-specific DataLad distributions with this version of :term:`git-annex`, but for the time being, you can find the standalone git-annex installer for Windows with mimeencoding at `http://datasets.datalad.org/datalad/packages/windows/ <http://datasets.datalad.org/datalad/packages/windows/>`_.
+  Without mimeencoding, a standard DataLad procedure, the ``text2git`` configuration (it will be introduced in the very first section of the Basics), is not functional, and you will find "Windowsworkarounds" to deal with this.
+  We recently started to build git-annex with support for mimeencoding ourselves, though.
+  At the moment, we are working on packaging up Windows-specific DataLad distributions with this version of :term:`git-annex`, but for the time being, you can find the standalone git-annex installer for Windows with mimeencoding at `http://datasets.datalad.org/datalad/packages/windows/ <http://datasets.datalad.org/datalad/packages/windows/>`_.
 
 - Optional - Install Unix tools
 


### PR DESCRIPTION
Added an explicit note on cloning via HTTPS from Gin in response to https://github.com/datalad/datalad/issues/5144.