### PR TITLE
Repro Paper: mention template in relevant sections

### DIFF
--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -138,6 +138,11 @@ of the flowers in centimeters. It is often used in introductory data science
 courses for statistical classification techniques in machine learning, and
 widely available -- a perfect dataset for your midterm project!
 
+.. admonition:: Turn data analysis into dynamically generated documents
+
+   Beyond the contents of this section, we have transformed the example analysis also into a template to write a reproducible paper, following the use case :ref:`usecase_reproducible_paper`.
+   If you're interested in checking that out, please head over to `github.com/datalad-handbook/repro-paper-sketch/ <https://github.com/datalad-handbook/repro-paper-sketch/>`_.
+
 Raw data as a modular, independent entity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/usecases/reproducible-paper.rst
+++ b/docs/usecases/reproducible-paper.rst
@@ -18,6 +18,7 @@ for data analysis projects [#f1]_. The resulting superdataset can be publicly
 shared, data can be obtained effortlessly on demand by anyone that has the superdataset,
 and results and paper can be generated and recomputed everywhere on demand.
 
+A template to start your own reproducible paper with the same set up can be found `on GitHub <https://github.com/datalad-handbook/repro-paper-sketch/>`__.
 
 The Challenge
 ^^^^^^^^^^^^^
@@ -88,6 +89,8 @@ itself with the new figures.
    https://github.com/psychoinformatics-de/paper-remodnav/. :command:`datalad clone`
    the repository and follow the few instructions in the README to experience the
    DataLad approach described above.
+
+   There is also a slimmed down template that uses the analysis demonstrated in :ref:`yoda_project` and packages it up into a reproducible paper using the same tools: `github.com/datalad-handbook/repro-paper-sketch/ <https://github.com/datalad-handbook/repro-paper-sketch/>`_.
 
 
 Step-by-Step


### PR DESCRIPTION
Hey @mih, I have created a template for writing a reproducible paper mirroring what we have described in the reproducible paper usecase. I did it for the Workshop next week, but its probably nice to have it mentioned in the relevant handbook sections, too. You can find the template at https://github.com/datalad-handbook/repro-paper-sketch/. @m-wierzba is also taking a look at it for feedback :)