### PR TITLE
REF: add permalink for Git LFS section

### DIFF
--- a/docs/r.rst
+++ b/docs/r.rst
@@ -42,6 +42,8 @@ failed -- sorry about this.
 :redirect:`GIN`
   :ref:`gin`
 :redirect:`gobig`
+  :ref:`gitlfs`
+:redirect:`LFS`
   :ref:`chapter_gobig`
 :redirect:`HCP-dataset`
   :ref:`usecase_HCP_dataset`


### PR DESCRIPTION
cc @yarikoptic.
This allows you to reference http://handbook.datalad.org/en/latest/basics/101-138-sharethirdparty.html#use-github-for-sharing-content with "handbook.datalad.org/r.html?LFS". Is that what you had in mind?