### PR TITLE
Workflowtest adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ clean-examples:
 	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
 	@find docs -name _examples -type d | sed 's/docs\/usecases\/_examples//' |xargs rm -vrf
 	# also wipe the workdirs, otherwise a rebuild will lead to chaos
-	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq | sed 's/usecases//'); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
+	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq | sed 's/usecases//' | sed 's/DVCvsDL//'); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
     # wipe out bare push repos
-	@chmod +w -R /home/me/pushes; rm -vrf /home/me/pushes
+	@chmod +w -R /home/me/pushes/{DataLad-101,midterm_project}; rm -vrf /home/me/pushes/{DataLad-101,midterm_project}
 	@rm -vrf /home/me/makepushtarget.py
 	# wipe out the RIA store
 	@rm -vrf /home/me/myriastore
@@ -24,6 +24,7 @@ clean-DVC:
 	# wipe out the DVC comparison
 	@find docs/beyond_basics/_examples -name DL-101-168* -type f | xargs rm -vrf
 	@chmod +w -R /home/me/DVCvsDL; rm -vrf /home/me/DVCvsDL
+	@chmod +w -R /home/me/pushes/data-version-control; rm -vrf /home/me/pushes/data-version-control
 
 # wipe out usecases
 clean-usecases:

--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -342,7 +342,7 @@ was applied.
       $ cat example2  && echo '' && cat somedir/example
 
    .. runrecord:: _examples/DL-101-124-109
-      :workdir:  procs/somedataset
+      :workdir: procs/somedataset
       :language: console
 
       $ git config -f .datalad/config datalad.procedures.example.help "A toy example"

--- a/docs/beyond_basics/101-168-dvc.rst
+++ b/docs/beyond_basics/101-168-dvc.rst
@@ -54,6 +54,24 @@ The `DVC tutorial <https://realpython.com/python-data-version-control/>`_ comes 
    # please clone this repository from your own fork when coding along
    $ git clone https://github.com/datalad-handbook/data-version-control DVC
 
+.. only:: adminmode
+
+    We need to reconfigure the remote origin to a local push target to simulate pushing back.
+    First, rename origin:
+
+    .. runrecord:: _examples/DL-101-168-102a
+       :language: console
+       :workdir: DVCvsDL/DVC
+
+       $ git remote rename origin github
+
+    Then, create a local pushtarget under the remote name origin
+
+    .. runrecord:: _examples/DL-101-168-102b
+       :language: console
+
+       $ python3 /home/me/makepushtarget.py '/home/me/DVCvsDL/DVC' 'origin' '/home/me/pushes/data-version-control' True True
+
 The resulting Git repository is already pre-structured in a way that aids DVC ML analyses: It has the directories ``model`` and ``metrics``, and a set of Python scripts for a machine learning analysis in ``src/``.
 
 .. runrecord:: _examples/DL-101-168-102
@@ -994,16 +1012,18 @@ Even though there is no one-to-one correspondence between a DVC and a DataLad wo
 
    We need to clean up -- reset the state of the "data version control" repo to its original state, force push
 
+   DISABLED, NOT NECESSARY WITH A CHANGE TO A LOCAL PUSH TARGET
+
    .. runrecord:: _examples/DL-101-168-190
       :workdir: DVCvsDL/DVC
       :language: console
 
-      $ git checkout master
-      $ git reset --hard b796ba195447268ebc51e20a778fb2db9f11e341
-      $ git push --force origin master
-      # delete the branches and tags
-      $ git push origin :random_forrest :sgd-pipeline
-      $ git tag -d random-forrest sgd-pipeline
+      #$ git checkout master
+      #$ git reset --hard b796ba195447268ebc51e20a778fb2db9f11e341
+      #$ git push --force origin master
+      ## delete the branches and tags
+      #$ git push origin :random_forrest :sgd-pipeline
+      #$ git tag -d random-forrest sgd-pipeline
 
 Summary
 ^^^^^^^

--- a/docs/beyond_basics/101-168-dvc.rst
+++ b/docs/beyond_basics/101-168-dvc.rst
@@ -52,7 +52,7 @@ The `DVC tutorial <https://realpython.com/python-data-version-control/>`_ comes 
 
    ### DVC
    # please clone this repository from your own fork when coding along
-   $ git clone git@github.com:datalad-handbook/data-version-control.git DVC
+   $ git clone https://github.com/datalad-handbook/data-version-control DVC
 
 The resulting Git repository is already pre-structured in a way that aids DVC ML analyses: It has the directories ``model`` and ``metrics``, and a set of Python scripts for a machine learning analysis in ``src/``.
 
@@ -439,7 +439,7 @@ To demonstrate this, let's look at a repository with an empty cache by cloning t
    ### DVC
    # clone the repo into a new location for demonstration purposes:
    $ cd ../
-   $ git clone git@github.com:datalad-handbook/data-version-control.git DVC-2
+   $ git clone https://github.com/datalad-handbook/data-version-control DVC-2
 
 Retrieving the data from the data remote to repopulate the cache is done with the :command:`dvc fetch` command:
 
@@ -494,7 +494,7 @@ Currently, the dataset can thus be shared via :term:`GitHub` or similar hosting 
 
       ### DVC-DataLad
       # outside of a dataset
-      $ datalad clone git@github.com:datalad-handbook/DVC-DataLad.git DVC-DataLad-2
+      $ datalad clone https://github.com/datalad-handbook/DVC-DataLad.git DVC-DataLad-2
       $ cd DVC-DataLad-2
 
    .. runrecord:: _examples/DL-101-168-132

--- a/docs/beyond_basics/101-168-dvc.rst
+++ b/docs/beyond_basics/101-168-dvc.rst
@@ -257,6 +257,7 @@ Here, we stick to the project organization of DVC though.
 
 At this point, the data is already version controlled [#f6]_, but the directory structure doesn't resemble that of the DVC dataset yet -- the extracted directory adds one unnecessary directory layer::
 
+    $ tree
     .
     ├── code
     │   └── [...]

--- a/docs/beyond_basics/_examples/DL-101-168-102a
+++ b/docs/beyond_basics/_examples/DL-101-168-102a
@@ -1,0 +1,1 @@
+$ git remote rename origin github

--- a/docs/beyond_basics/_examples/DL-101-168-102b
+++ b/docs/beyond_basics/_examples/DL-101-168-102b
@@ -1,0 +1,1 @@
+$ python3 /home/me/makepushtarget.py '/home/me/DVCvsDL/DVC' 'origin' '/home/me/pushes/data-version-control' True True


### PR DESCRIPTION
A first set of adjustments that are necessary for convincing the CI setup to work.
This set of changes mainly deals with the DVC chapter.

First off all, I remove it from the clean-examples target. clean-examples thus wipes out everything in Basics and Advances but the DVC chapter. This is because it takes very long to build, and it already has its own target (clean-DVC).

Secondly, it uses a local push target instead of a GitHub remote. This is necessary so that building locally on remote CI machines succeeds. For a similar reason, cloning within the DVC chapter uses now https instead of SSH.