### PR TITLE
Further streamlining boxes

### DIFF
--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -23,15 +23,7 @@ def depart_gitusernote_html(self, node):
 
 
 def visit_gitusernote_latex(self, node):
-    self.body.append("""
-    \\begin{{tcolorbox}}[
-        enhanced,
-        ribbon git,
-        title={{{title}}},
-        coltitle=dataladgray,
-        colbacktitle=dataladblue,
-        colframe=dataladblue!70!black]
-    """.format(
+    self.body.append("\\begin{{gitusernote}}{{{title}}}\n".format(
         title=node.children[0].astext(),
     ))
     # we have used the title for the colorbox header
@@ -40,7 +32,7 @@ def visit_gitusernote_latex(self, node):
 
 
 def depart_gitusernote_latex(self, node):
-    self.body.append('\n\n\\end{tcolorbox}\n')
+    self.body.append('\n\n\\end{gitusernote}\n')
 
 
 class GitUserNote(BaseAdmonition):
@@ -64,15 +56,7 @@ def depart_findoutmore_html(self, node):
 
 
 def visit_findoutmore_latex(self, node):
-    self.body.append("""
-    \\begin{{tcolorbox}}[
-        enhanced,
-        ribbon more,
-        title={{{title}}},
-        coltitle=dataladgray,
-        colbacktitle=dataladyellow,
-        colframe=dataladyellow!70!black]
-    """.format(
+    self.body.append("\\begin{{findoutmore}}{{{title}}}\n".format(
         title=node.children[0].astext(),
     ))
     # we have used the title for the colorbox header
@@ -81,7 +65,7 @@ def visit_findoutmore_latex(self, node):
 
 
 def depart_findoutmore_latex(self, node):
-    self.body.append('\n\n\\end{tcolorbox}\n')
+    self.body.append('\n\n\\end{findoutmore}\n')
 
 
 class FindOutMore(BaseAdmonition):
@@ -191,15 +175,7 @@ def depart_windowsworkarounds_html(self, node):
 
 
 def visit_windowsworkarounds_latex(self, node):
-    self.body.append("""
-    \\begin{{tcolorbox}}[
-        enhanced,
-        ribbon win,
-        title={{{title}}},
-        coltitle=dataladgray,
-        colbacktitle=windowsgreen,
-        colframe=windowsgreen!70!black]
-    """.format(
+    self.body.append("\\begin{{windowsworkaround}}{{{title}}}\n".format(
         title=node.children[0].astext(),
     ))
     # we have used the title for the colorbox header
@@ -207,10 +183,8 @@ def visit_windowsworkarounds_latex(self, node):
     del node.children[0]
 
 
-
 def depart_windowsworkarounds_latex(self, node):
-    self.body.append('\n\n\\end{tcolorbox}\n')
-
+    self.body.append('\n\n\\end{windowsworkaround}\n')
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -343,19 +343,38 @@ cautionBgColor={named}{LightCyan}%
 ribbon win/.style={overlay={
   \begin{scope}[shift={([xshift=-5mm,yshift=-3mm]frame.north west)}]
     \path(0,0) node[inner sep=0] {\includegraphics{win_boxicon}};
-  \end{scope}}]}
+  \end{scope}}}
 }
 \tcbset{%
 ribbon git/.style={overlay={
   \begin{scope}[shift={([xshift=-5mm,yshift=-3mm]frame.north west)}]
     \path(0,0) node[inner sep=0] {\includegraphics{git_boxicon}};
-  \end{scope}}]}
+  \end{scope}}}
 }
 \tcbset{%
 ribbon more/.style={overlay={
   \begin{scope}[shift={([xshift=-5mm,yshift=-3mm]frame.north west)}]
     \path(0,0) node[inner sep=0] {\includegraphics{more_boxicon}};
-  \end{scope}}]}
+  \end{scope}}}
+}
+
+\newtcolorbox[list inside=windowsworkarounds]{windowsworkaround}[1]{%
+  enhanced, ribbon win, title={#1},
+  coltitle=dataladgray,
+  colbacktitle=windowsgreen,
+  colframe=windowsgreen!70!black
+}
+\newtcolorbox[list inside=gitusernotes]{gitusernote}[1]{%
+  enhanced, ribbon git, title={#1},
+  coltitle=dataladgray,
+  colbacktitle=dataladblue,
+  colframe=dataladblue!70!black
+}
+\newtcolorbox[list inside=findoutmores]{findoutmore}[1]{%
+  enhanced, ribbon more, title={#1},
+  coltitle=dataladgray,
+  colbacktitle=dataladyellow,
+  colframe=dataladyellow!70!black
 }
 
 \setcounter{tocdepth}{1}


### PR DESCRIPTION
- enable future display of box listings (by type)

![image](https://user-images.githubusercontent.com/136479/108027910-36c95180-702b-11eb-85fc-9aed94f02e40.png)

Note that such a listing is not actually generated in this PR, only the prerequisites are established. A related, but unaddressed, topic is the numbering of boxes and their in-text referencing. This would be most helpful in the PDF to make box positioning more flexible.