### PR TITLE
Numbered, listable and referencable boxes

### DIFF
--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -38,8 +38,8 @@ def _make_toggle(admonition, docnodes, cls, classes):
 def _get_counted_boxstart(label, title):
     return \
         "\\begin{{{label}}}" \
-        "[label={{{label}counter}}]" \
-        "{{\\thetcbcounter\\ {title}}}\n".format(
+        "[label={{{label}counter}},before title={{\\thetcbcounter\\ }}]" \
+        "{{{title}}}\n".format(
             label=label,
             title=title,
         )

--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -45,6 +45,19 @@ def _get_counted_boxstart(label, title):
         )
 
 
+def _add_label(body, node):
+    """If we can construct a latex label for a node, add to body"""
+    parent_docname = node.parent.attributes.get('docname')
+    node_id = [i for i in node.attributes.get('ids') or []]
+    node_id = node_id[0] if len(node_id) else None
+    # build the same form that sphinx does
+    label = '\\detokenize{{{parent}:{id}}}'.format(
+        parent=parent_docname, id=node_id) \
+        if parent_docname and node_id else ''
+    if label:
+        body.append('\\label{{{}}}\n'.format(label))
+
+
 class gitusernote(nodes.Admonition, nodes.Element):
     """Custom "gitusernote" admonition."""
 
@@ -68,6 +81,7 @@ def visit_gitusernote_latex(self, node):
         _get_counted_boxstart(
             'gitusernote',
             node.children[0].astext()))
+    _add_label(self.body, node)
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]
@@ -102,6 +116,7 @@ def visit_findoutmore_latex(self, node):
         _get_counted_boxstart(
             'findoutmore',
             node.children[0].astext()))
+    _add_label(self.body, node)
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]
@@ -175,6 +190,7 @@ def visit_windowsworkarounds_latex(self, node):
         _get_counted_boxstart(
             'windowsworkaround',
             node.children[0].astext()))
+    _add_label(self.body, node)
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]

--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -4,6 +4,16 @@ from docutils import nodes
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 
 
+def _get_counted_boxstart(label, title):
+    return \
+        "\\begin{{{label}}}" \
+        "[label={{{label}counter}}]" \
+        "{{\\thetcbcounter\\ {title}}}\n".format(
+            label=label,
+            title=title,
+        )
+
+
 class gitusernote(nodes.Admonition, nodes.Element):
     """Custom "gitusernote" admonition."""
 
@@ -23,9 +33,10 @@ def depart_gitusernote_html(self, node):
 
 
 def visit_gitusernote_latex(self, node):
-    self.body.append("\\begin{{gitusernote}}{{{title}}}\n".format(
-        title=node.children[0].astext(),
-    ))
+    self.body.append(
+        _get_counted_boxstart(
+            'gitusernote',
+            node.children[0].astext()))
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]
@@ -56,9 +67,10 @@ def depart_findoutmore_html(self, node):
 
 
 def visit_findoutmore_latex(self, node):
-    self.body.append("\\begin{{findoutmore}}{{{title}}}\n".format(
-        title=node.children[0].astext(),
-    ))
+    self.body.append(
+        _get_counted_boxstart(
+            'findoutmore',
+            node.children[0].astext()))
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]
@@ -175,9 +187,10 @@ def depart_windowsworkarounds_html(self, node):
 
 
 def visit_windowsworkarounds_latex(self, node):
-    self.body.append("\\begin{{windowsworkaround}}{{{title}}}\n".format(
-        title=node.children[0].astext(),
-    ))
+    self.body.append(
+        _get_counted_boxstart(
+            'windowsworkaround',
+            node.children[0].astext()))
     # we have used the title for the colorbox header
     # already, do not duplicate in the body
     del node.children[0]

--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -4,6 +4,35 @@ from docutils import nodes
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 
 
+def _make_toggle(admonition, docnodes, cls, classes):
+    # throw away the title, because we want to mark
+    # it up as a 'header' further down
+    del docnodes[0][0]
+    # now put the entire admonition structure into a container
+    # that we assign the necessary class to make it 'toggle-able'
+    # in HTML
+    # outer container
+    return cls(
+        'toogle',
+        # header line with 'Find out more' prefix
+        nodes.paragraph(
+            # place actual admonition title we removed
+            # above
+            'title', admonition.arguments[0],
+            # add (CSS) class
+            classes=['header'],
+        ),
+        # place the rest of the admonition structure after the header,
+        # but still inside the container
+        *docnodes[0].children,
+        # properly identify as 'findoutmore' to enable easy custom
+        # styling, and also tag with 'toggle'. The later is actually
+        # not 100% necessary, as 'findoutmore' could get that
+        # functional assigned in CSS instead (maybe streamline later)
+        classes=['toggle'] + classes,
+    )
+
+
 def _get_counted_boxstart(label, title):
     return \
         "\\begin{{{label}}}" \
@@ -98,34 +127,9 @@ class FindOutMore(BaseAdmonition):
     required_arguments = 1
 
     def run(self):
-        # this uses the admonition code for RST parsion
-        docnodes = super(FindOutMore, self).run()
-        # but we throw away the title, because we want to mark
-        # it up as a 'header' further down
-        del docnodes[0][0]
-        # now put the entire admonition structure into a container
-        # that we assign the necessary class to make it 'toggle-able'
-        # in HTML
-        # outer container
-        toggle = findoutmore(
-            'toogle',
-            # header line with 'Find out more' prefix
-            nodes.paragraph(
-                # place actual admonition title we removed
-                # above
-                'title', self.arguments[0],
-                # add (CSS) class
-                classes=['header'],
-            ),
-            # place the rest of the admonition structure after the header,
-            # but still inside the container
-            *docnodes[0].children,
-            # properly identify as 'findoutmore' to enable easy custom
-            # styling, and also tag with 'toggle'. The later is actually
-            # not 100% necessary, as 'findoutmore' could get that
-            # functional assigned in CSS instead (maybe streamline later)
-            classes=['toggle', 'findoutmore'],
-        )
+        # this uses the admonition code for RST parsing
+        toggle = _make_toggle(
+            self, super(FindOutMore, self).run(), findoutmore, ['findoutmore'])
         return [toggle]
 
 
@@ -142,34 +146,12 @@ class WindowsWorkArounds(BaseAdmonition):
     required_arguments = 1
 
     def run(self):
-        # this uses the admonition code for RST parsion
-        docnodes = super(WindowsWorkArounds, self).run()
-        # but we throw away the title, because we want to mark
-        # it up as a 'header' further down
-        del docnodes[0][0]
-        # now put the entire admonition structure into a container
-        # that we assign the necessary class to make it 'toggle-able'
-        # in HTML
-        # outer container
-        toggle = windowsworkarounds(
-            'toogle',
-            # header line with 'Windows Workaround' prefix
-            nodes.paragraph(
-                # place actual admonition title we removed
-                # above
-                'title', self.arguments[0],
-                # add (CSS) class
-                classes=['header'],
-            ),
-            # place the rest of the admonition structure after the header,
-            # but still inside the container
-            *docnodes[0].children,
-            # properly identify as 'windowsworkarounds' to enable easy custom
-            # styling, and also tag with 'toggle'. The later is actually
-            # not 100% necessary, as 'windowsworkarounds' could get that
-            # functional assigned in CSS instead (maybe streamline later)
-            classes=['toggle', 'windowsworkarounds'],
-        )
+        # this uses the admonition code for RST parsing
+        toggle = _make_toggle(
+            self,
+            super(WindowsWorkArounds, self).run(),
+            windowsworkarounds,
+            ['windowsworkarounds'])
         return [toggle]
 
 

--- a/dataladhandbook_support/directives.py
+++ b/dataladhandbook_support/directives.py
@@ -30,6 +30,8 @@ def _make_toggle(admonition, docnodes, cls, classes):
         # not 100% necessary, as 'findoutmore' could get that
         # functional assigned in CSS instead (maybe streamline later)
         classes=['toggle'] + classes,
+        ids=docnodes[0].attributes.get('ids'),
+        names=docnodes[0].attributes.get('names'),
     )
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -358,23 +358,32 @@ ribbon more/.style={overlay={
   \end{scope}}}
 }
 
-\newtcolorbox[list inside=windowsworkarounds]{windowsworkaround}[1]{%
-  enhanced, ribbon win, title={#1},
-  coltitle=dataladgray,
-  colbacktitle=windowsgreen,
-  colframe=windowsgreen!70!black
+\newtcolorbox[%
+  auto counter,
+  number within=chapter,
+  list inside=windowsworkarounds]{windowsworkaround}[2][]{%
+    enhanced, ribbon win, title={#2},
+    coltitle=dataladgray,
+    colbacktitle=windowsgreen,
+    colframe=windowsgreen!70!black, #1
 }
-\newtcolorbox[list inside=gitusernotes]{gitusernote}[1]{%
-  enhanced, ribbon git, title={#1},
-  coltitle=dataladgray,
-  colbacktitle=dataladblue,
-  colframe=dataladblue!70!black
+\newtcolorbox[%
+  auto counter,
+  number within=chapter,
+  list inside=gitusernotes]{gitusernote}[2][]{%
+    enhanced, ribbon git, title={#2},
+    coltitle=dataladgray,
+    colbacktitle=dataladblue,
+    colframe=dataladblue!70!black, #1
 }
-\newtcolorbox[list inside=findoutmores]{findoutmore}[1]{%
-  enhanced, ribbon more, title={#1},
-  coltitle=dataladgray,
-  colbacktitle=dataladyellow,
-  colframe=dataladyellow!70!black
+\newtcolorbox[
+  auto counter,
+  number within=chapter,
+  list inside=findoutmores]{findoutmore}[2][]{%
+    enhanced, ribbon more, title={#2},
+    coltitle=dataladgray,
+    colbacktitle=dataladyellow,
+    colframe=dataladyellow!70!black, #1
 }
 
 \setcounter{tocdepth}{1}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/136479/108093436-02cb4c00-707e-11eb-9bb9-afa453adad0a.png)

![image](https://user-images.githubusercontent.com/136479/108093507-15de1c00-707e-11eb-8417-7a85b845ee2c.png)

![image](https://user-images.githubusercontent.com/136479/108093630-31492700-707e-11eb-83ea-7321588a1b88.png)

Works in HTML and Latex.

The reference a box, simply give it a name and use that one:

```rst
  .. windowsworkarounds:: Funky instructions
     :name: funky

can be referenced with :ref:`some in-text description <funky>`
```

