### PR TITLE
No vertical lines in a table

### DIFF
--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -243,6 +243,7 @@ It is common for :command:`datalad get` errors to originate in :term:`git-annex`
 - Try to download the file using ``git-annex get -v -d <file_name>``. If this doesn't succeed, the DataLad command may not succeed. Options ``-d/--debug`` and ``-v`` are here to provide as much verbosity in error messages as possible
 - Read the output of :term:`git-annex`, identify the error, breathe again, and solve the issue!
 
+.. tabularcolumns:: \Y{.5}\Y{.5}
 .. list-table:: Examples of possible issues
    :header-rows: 1
 


### PR DESCRIPTION
This is a first demo of how it could be done. Essentially given sphinx a dedicated clue via `tabularcolumns` instead of having it guess.

https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-tabularcolumns

It is using the sphinx-specifc `\Y` column width specifier that should work across all table type we need (sphinx is switching type a lot, depending on table content).

### Demo

Before:

![image](https://user-images.githubusercontent.com/136479/108174589-e7a12080-70ff-11eb-83a8-16f0cb17103c.png)

Now:

![image](https://user-images.githubusercontent.com/136479/108174657-01426800-7100-11eb-89ec-58ee1edf20b9.png)

More general table beautifications are coming, but this kind must be done per each table.
