### PR TITLE
Tune footnotes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -335,6 +335,7 @@ cautionBgColor={named}{LightCyan}%
 \usepackage{charter}
 \usepackage[defaultsans]{lato}
 \usepackage{inconsolata}
+\usepackage[hang,flushmargin,multiple]{footmisc}
 
 % make sure all float stay in their respective chapter
 %\usepackage[chapter]{placeins}


### PR DESCRIPTION
No indent on first line, to save some space for URL-type footnotes