### PR TITLE
Make term references accessible in the printed handbook

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -433,6 +433,9 @@ ribbon important/.style={overlay={
 
 \newcommand{\findoutmoreiconinline}{\raisebox{-.1em}{\includegraphics[height=.9em]{more_boxicon_inline}}~}
 \newcommand{\windowswiticoninline}{\raisebox{-.3em}{\includegraphics[height=1.2em]{win_boxicon}}~}
+
+% make :term: references visually distinct in a print
+\renewcommand{\sphinxtermref}[1]{\textsc{#1}}
 """,
 }
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,8 +1,9 @@
 
+.. _glossary:
+
 ********
 Glossary
 ********
-
 
 .. glossary::
 

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -34,6 +34,12 @@ workflows to more advanced commands, and you will see your skills increase
 with each. While learning, it will be easy to
 **find use cases in your own work for the commands you come across**.
 
+.. only:: latex
+
+   Throughout the book numerous *terms* for concepts and technical components
+   are used. They are all defined in a :ref:`glossary`, and are printed
+   in small-caps, such as :term:`Git`, or :term:`commit message`.
+
 As the handbook is to be a practical guide it includes as many hands-on examples
 as we can fit into it. Code snippets look like this, and you should
 **copy them into your own terminal to try them out**, but you can also


### PR DESCRIPTION
And explain them (latex output only).

![image](https://user-images.githubusercontent.com/136479/110597593-0afc4000-8181-11eb-916d-ab501ea54d2a.png)
