### PR TITLE
Remove quotes from config file displays

### DIFF
--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -214,7 +214,7 @@ was applied.
      .. code-block:: bash
 
         [datalad "procedures.<NAME>"]
-           help = "This is a string to describe what the procedure does"
+           help = This is a string to describe what the procedure does
 
    - By default, on GNU/Linux systems, DataLad will search for system-wide procedures
      (i.e., procedures on the *system* level) in ``/etc/xdg/datalad/procedures``,
@@ -252,8 +252,8 @@ was applied.
       .. code-block:: bash
 
          [datalad "procedures.<NAME>"]
-            help = "This is a string to describe what the procedure does"
-            call-format = "python {script} {ds} {somearg1} {somearg2}"
+            help = This is a string to describe what the procedure does
+            call-format = python {script} {ds} {somearg1} {somearg2}
 
     - By convention, procedures should leave a dataset in a clean state.
 


### PR DESCRIPTION
Quotes encompassing values in git config files (including
.datalad/config), are not required and in fact inconsequential when
being read again via git-config. Showing them when displaying such
configs in the handbook may therefore be confusing and leading to the
user trying to achieve this, which is not possible via git-config or
datalad's python API. This would only be achievable by editing the raw
config file w/o a sanitizing interface.

Simply remove the depiction of such quotes, as I think debating this
aspect only makes the impression that it is somehow important, when
really these quotes have no effect at all.

(Closes #688)