### PR TITLE
Mention --assume-ready of datalad-run

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,5 +1,5 @@
 name: Handbook build
-on: [push, pull_request]
+on: [push]
 jobs:
   bookbuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,0 +1,23 @@
+name: Handbook build
+on: [push, pull_request]
+jobs:
+  bookbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up environment
+        uses: actions/setup-python@v1
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+          sudo apt-get install texlive-latex-recommended texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra latexmk librsvg2-bin
+      - name: Build docs
+        run: |
+          make doctest
+          make html
+          make latexpdf
+

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -384,10 +384,24 @@ Make a note of this behavior in your ``notes.txt`` file.
    EOT
 
 
+Save yourself the preparation time
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. importantnote:: version requirement for --assume-ready
+
+   The option ``--assume-ready`` was introduced with DataLad version 0.14.1.
+
+Its generally good practice to specify ``--input`` and ``--output`` even if your input files are already retrieved and your output files unlocked -- it makes sure that a recomputation can succeed, even if inputs are not yet retrieved, or if output needs to be unlocked.
+However, the internal preparation steps of checking that inputs exist or that outputs are unlocked can take a bit of time, especially if it involves checking a large number of files.
+
+Starting with **datalad version 0.14.1**, you can make use of the ``--assume-ready`` argument of :command:`datalad run` if you want to avoid the expense of unnecessary preparation steps.
+Depending on whether your inputs are already retrieved, your outputs already unlocked (or not needed to be unlocked), or both, specify ``--assume-ready`` with the argument ``inputs``, ``outputs`` or ``both`` and save yourself a few seconds, without sacrificing the ability to rerun your command under conditions in which the preparation would be necessary.
+
+
 Placeholders
 ^^^^^^^^^^^^
 
-Just after writing this note, you have to relax your fingers a bit. "Man, this was
+Just after writing the note, you had to relax your fingers a bit. "Man, this was
 so much typing. Not only did I need to specify the inputs and outputs, I also had
 to repeat all of these lengthy paths in the command line call..." you think.
 

--- a/docs/basics/101-113-summary.rst
+++ b/docs/basics/101-113-summary.rst
@@ -27,6 +27,9 @@ command, and discovered the concept of *locked* content.
 * Anything specified as ``input`` will be retrieved if necessary with a :command:`datalad get` prior to command
   execution. Anything specified as ``output`` will be ``unlocked`` prior to modifications.
 
+* It is good practice to specify ``input`` and ``output`` to ensure that a :command:`datalad rerun` works, and to capture the relevant elements of a computation in a machine-readable record.
+  If you want to spare yourself preparation time in case everything is already retrieved and unlocked, you can use ``--assume-ready {input|output|both}`` to skip a check on whether inputs are already present or outputs already unlocked (requires DataLad version ``0.14.1`` or later).
+
 .. figure:: ../artwork/src/run.svg
    :alt: Schematic illustration of datalad run.
    :width: 80%


### PR DESCRIPTION
This adds a short paragraph in the chapter on datalad run's input and output options,
and adds a bullet point in the summary of datalad run, on the recently introduced
--assume-ready flag that skips the preparation of --inputs and --outputs if a user
has retrieved/unlocked them already
Fixes #697.

ping @mih