### PR TITLE
ENH: Use Zenodo record that resolves to latest version

### DIFF
--- a/docs/basics/101-180-FAQ.rst
+++ b/docs/basics/101-180-FAQ.rst
@@ -156,7 +156,7 @@ How can I cite DataLad?
 
 There is no official paper on DataLad (yet). To cite it, please use the latest
 `zenodo <https://zenodo.org>`_ entry found here:
-`https://zenodo.org/record/3512712 <https://zenodo.org/record/3512712>`_.
+https://zenodo.org/record/808846.
 
 .. _dataset_textblock:
 


### PR DESCRIPTION
https://zenodo.org/record/3512712 resolves to 0.12.0rc6. Using record ID noted at the bottom here:
![datalad_versions](https://user-images.githubusercontent.com/83442/118978264-1e781400-b945-11eb-9a4d-80e7455f3734.png)

I assumed that you explicitly preferred the Zenodo URL over DOI, so updated the record number without switching to DOI. I'm not sure about dropping the explicit link syntax... RST should render this as a link, but possibly there's a good reason for keeping it as an explicit RST link?