### PR TITLE
ENH: Relative links in sidebar

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -42,7 +42,7 @@
 <p>
   This guide is the result of the collaboration of
   <a href="https://github.com/psychoinformatics-de/datalad-handbook/graphs/contributors">many people</a>, and your contributions
-  <a href="http://handbook.datalad.org/en/latest/contributing.html">are welcome</a>!
+  <a href="contributing.html">are welcome</a>!
 </p>
 
 <h3>Useful Links</h3>
@@ -51,9 +51,9 @@
   <li><a href="http://docs.datalad.org/en/latest/#">Developer Docs</a></li>
   <li><a href="https://github.com/datalad/datalad">DataLad@GitHub</a></li>
   <li><a href="https://github.com/datalad-handbook/book">Handbook@GitHub</a></li>
-  <li><a href="http://handbook.datalad.org/en/latest/basics/101-180-FAQ.html">Frequently Asked Questions</a></li>
-  <li><a href="http://handbook.datalad.org/en/latest/genindex.html">Handbook Index</a></li>
-  <li><a href="http://handbook.datalad.org/en/latest/basics/101-136-cheatsheet.html">DataLad cheat sheet</a></li>
+  <li><a href="basics/101-180-FAQ.html">Frequently Asked Questions</a></li>
+  <li><a href="genindex.html">Handbook Index</a></li>
+  <li><a href="basics/101-136-cheatsheet.html">DataLad cheat sheet</a></li>
 </ul>
 
 <p>


### PR DESCRIPTION
Found some absolute links that made it hard to find the FAQ in the rendering of #717. Feel free to close without discussion if there's a good reason to use absolute links.