### PR TITLE
Fix typos using codespell

### DIFF
--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -239,7 +239,7 @@ command as before, and check whether anything in your log changes:
 .. runrecord:: _examples/DL-101-108-107
    :language: console
    :workdir: dl-101/DataLad-101
-   :notes: A run command that does not result in changes (no modifcations, no additional files) will not produce a record in the dataset history. So what happens if we do the same again?
+   :notes: A run command that does not result in changes (no modifications, no additional files) will not produce a record in the dataset history. So what happens if we do the same again?
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Try again to create a list of podcast titles" \

--- a/docs/basics/101-117-sharelocal2.rst
+++ b/docs/basics/101-117-sharelocal2.rst
@@ -64,7 +64,7 @@ Let's see how this affects a :command:`datalad get`:
 .. runrecord:: _examples/DL-101-117-103
    :language: console
    :workdir: dl-101/mock_user/DataLad-101/recordings/longnow
-   :notes: Get a file thats present in original and one that is not
+   :notes: Get a file that is present in original and one that is not
    :cast: 04_collaboration
 
    # get the first file

--- a/docs/basics/101-123-config2.rst
+++ b/docs/basics/101-123-config2.rst
@@ -548,7 +548,7 @@ Write a note about configurations in datasets into ``notes.txt``.
 .. [#f2] Specifying annex.largefiles in your .gitattributes file will make the configuration
          "portable" -- shared copies of your dataset will retain these configurations.
          You could however also set largefiles rules in your ``.git/config`` file. Rules
-         specified in there take precendence over rules in ``.gitattributes``. You can set
+         specified in there take precedence over rules in ``.gitattributes``. You can set
          them using the :command:`git config` command::
 
             $ git config annex.largefiles 'largerthan=100kb and not (include=*.c or include=*.h)'

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -444,7 +444,7 @@ re-execution with :command:`datalad rerun` easy.
 
 .. windows-wit:: You may need to use "python", not "python3"
 
-   If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called soley ``python``.
+   If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called solely ``python``.
    Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole)::
 
       datalad run -m "analyze iris data with classification analysis" ^

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -549,7 +549,7 @@ Built-in data export
 
 Apart from flexibly configurable special remotes that allow publishing
 annexed content to a variety of third party infrastructure, DataLad also has
-some build-in support for "exporting" data to other services.
+some built-in support for "exporting" data to other services.
 
 One example is the command :command:`export-archive`. Running
 this command would produce a ``.tar.gz`` file with the content of your dataset,

--- a/docs/beyond_basics/101-170-dataladrun.rst
+++ b/docs/beyond_basics/101-170-dataladrun.rst
@@ -9,7 +9,7 @@ But there are also analyses that are so large -- either in terms of computations
 The latter type of analyses typically requires a compute cluster, a job scheduler, and parallelization.
 The question is: How can they become as reproducible and provenance tracked as the simplistic, singular analysis that were showcased in the handbook so far, and that comfortably fitted on a private computer?
 
-.. importantnote:: Reading prerequisit for distributed computing
+.. importantnote:: Reading prerequisite for distributed computing
 
    It is advised to read the previous chapter :ref:`chapter_gobig` prior to this one
 

--- a/docs/code_from_chapters/OHBM.rst
+++ b/docs/code_from_chapters/OHBM.rst
@@ -66,7 +66,7 @@ short at this point in time. Let's check it out nevertheless.
 
 This history exists thanks to Git. Therefore, you can access the history of a
 dataset with any tool that shows you git
-history. We'll stay basic and just use gits build-in ``git log`` command, but you
+history. We'll stay basic and just use gits built-in ``git log`` command, but you
 could also use tools with graphical user interfaces if you want to, for example
 :term:`tig`::
 
@@ -150,7 +150,7 @@ its the only change in the dataset, there is no need to provide a path::
 
    datalad save -m "Add notes on datalad create"
 
-Let's now add another note to modifiy this file::
+Let's now add another note to modify this file::
 
    cat << EOT >> notes.txt
    The command "datalad save [-m] PATH" saves the file
@@ -183,7 +183,7 @@ First, create a new subdirectory to be organized::
 
 Afterwards, I'll install the dataset I am interested in, either from a path or
 a URL. The dataset I want to install lives on GitHub, so in order to get it, I
-will privide its URL to the datalad clone command. I'm also attaching a path to
+will provide its URL to the datalad clone command. I'm also attaching a path to
 where I want to have it installed to this call. Importantly I am installing this
 dataset as a subdataset of DataLad-101, in other words I will nest the two
 datasets inside of each other. This is done with the --dataset flag::
@@ -322,7 +322,7 @@ contributed a fix that changed the data::
 
 But because I can link subdatasets in precise version I can
 consciously decide and openly record which version of the data I am using or
-even test how much my results change by resetting the subdataset to an ealier
+even test how much my results change by resetting the subdataset to an earlier
 state or updating the dataset to a more recent version.
 
 Reproducible analyses

--- a/docs/code_from_chapters/yale.rst
+++ b/docs/code_from_chapters/yale.rst
@@ -291,7 +291,7 @@ It is now a known sibling dataset to which you can publish data::
 
    datalad siblings
 
-Note that Gin is a particularily handy hosting service because it has annex support.
+Note that Gin is a particularly handy hosting service because it has annex support.
 This means that you can publish your complete dataset, including all data, to it in one command::
 
    datalad push --to gin

--- a/docs/intro/user_types.rst
+++ b/docs/intro/user_types.rst
@@ -126,5 +126,5 @@ handbook content, but also your pull request with your addition or use case.
 "I came here to teach!"
 
 Awesome! There are instructions in section :ref:`teach`, and the
-`companion repository at github.com/datalad-handbook/course <https://github.com/datalad-handbook/couse>`_
+`companion repository at github.com/datalad-handbook/course <https://github.com/datalad-handbook/course>`_
 contains slides, code casts, and tools for teaching.

--- a/docs/intro/windows.rst
+++ b/docs/intro/windows.rst
@@ -21,7 +21,7 @@ Windows-Deficiencies
 
 .. admonition:: Updates
 
-   We have suceeded in building git-annex with MagicMime for mimeencoding (that's a good thing).
+   We have succeeded in building git-annex with MagicMime for mimeencoding (that's a good thing).
    While we're working on packaging everything into a single, conda-based DataLad installation bundle, you can find a standalone git-annex installer at ` http://datasets.datalad.org/datalad/packages/windows/ <http://datasets.datalad.org/datalad/packages/windows/>`_.
 
 Windows works fundamentally different than macOS or Linux-based operating systems.

--- a/docs/usecases/HCP_dataset.rst
+++ b/docs/usecases/HCP_dataset.rst
@@ -412,7 +412,7 @@ retrieve data right away.
 
    In case one misenters their AWS credentials or needs to reset them,
    this can easily be done using the `Python keyring <https://keyring.readthedocs.io/en/latest/>`_
-   package. For more information on ``keyring`` and DataLad's authetication
+   package. For more information on ``keyring`` and DataLad's authentication
    process, see the *Basic process* section in :ref:`providers`.
 
    After launching Python, import the ``keyring`` package and use the 

--- a/docs/usecases/datasets.rst
+++ b/docs/usecases/datasets.rst
@@ -121,7 +121,7 @@ Dataset Nesting
 ===============
 
 Within DataLad datasets one can *nest* other DataLad
-datasets arbitralily deep. This does not seem particulary spectacular -
+datasets arbitrarily deep. This does not seem particularly spectacular -
 after all, any directory on a filesystem can have other directories inside it.
 The possibility for nested Datasets, however, is one of many advantages
 DataLad datasets have:
@@ -150,7 +150,7 @@ Creating your own dataset yourself
 Anyone can create, populate, and optionally share a *new* DataLad dataset.
 A new DataLad dataset is always created empty, even if the target
 directory already contains additional files or directories. After creation,
-arbitralily large amounts of data can be added. Once files are added and
+arbitrarily large amounts of data can be added. Once files are added and
 saved to the dataset, any changes done to these data files can be saved
 to the history.
 

--- a/docs/usecases/provenance_tracking.rst
+++ b/docs/usecases/provenance_tracking.rst
@@ -217,7 +217,7 @@ Notice that all commits are marked as equivalent (=) except the ‘random spread
 
    $ git log --oneline --left-right --cherry-mark master...replay
 
-Rob can continue processing images, and will turn in a sucessful art project.
+Rob can continue processing images, and will turn in a successful art project.
 Long after he finishes high school, he finds his dataset on his old computer
 again and remembers this small project fondly.
 

--- a/docs/usecases/reproducible-paper.rst
+++ b/docs/usecases/reproducible-paper.rst
@@ -298,7 +298,7 @@ to fill tables with unique names with minimal work, for example like this (excer
        AL versus RA        & \kappaALRAimgSac & \kappaALRAdotsSac \\
        AL versus MN        & \kappaALMNimgSac & \kappaALMNdotsSac \\
        \noalign{\smallskip}
-       % [..] more content ommitted
+       % [..] more content omitted
      \end{tabular*}
    \end{table}
 

--- a/docs/usecases/reproducible_neuroimaging_analysis_simple.rst
+++ b/docs/usecases/reproducible_neuroimaging_analysis_simple.rst
@@ -14,7 +14,7 @@ that can be automatically computationally reproduced by anyone:
 #. The final dataset can be kept as lightweight as possible by dropping input that can be easily re-obtained.
 #. A complete reproduction of the computation (including input retrieval), is possible with a single :command:`datalad rerun` command.
 
-This use case is a specialization of :ref:`usecase_reproducible_paper`, and a simpler verison of :ref:`usecase_reproduce_neuroimg`:
+This use case is a specialization of :ref:`usecase_reproducible_paper`, and a simpler version of :ref:`usecase_reproduce_neuroimg`:
 It is a data analysis that requires and creates large data files, uses specialized analysis software, and is fully automated using solely DataLad commands and tools.
 While exact data types, analysis methods, and software mentioned in this use case belong to the scientific field of neuroimaging, the basic workflow is domain-agnostic.
 
@@ -68,7 +68,7 @@ The two datasets, `ds000001 <https://legacy.openfmri.org/dataset/ds000001/>`_ an
    $ cd demo
    $ datalad clone -d . ///openfmri/ds000002 inputs/ds000002
 
-Both datasets are now registered as subdatasets, and their precise versions (e.g. in the form of the commit shasum of the lastest commit) are on record:
+Both datasets are now registered as subdatasets, and their precise versions (e.g. in the form of the commit shasum of the latest commit) are on record:
 
 .. runrecord:: _examples/repro-104
    :language: console


### PR DESCRIPTION
also contains one link fix for `https://github.com/datalad-handbook/couse` (couse -> course)