### PR TITLE
MNT: Fix link to git-annex docs on GitLab, mention deprecation

### DIFF
--- a/docs/basics/101-140-summary.rst
+++ b/docs/basics/101-140-summary.rst
@@ -49,7 +49,7 @@ costs will likely influence your choice of service.
 
 .. rubric:: Footnotes
 
-.. [#f1] :term:`GitLab` does provide a git-annex configuration, but it is disabled
+.. [#f1] Older versions of :term:`GitLab` provide a git-annex configuration, but it is disabled
          by default, and to enable it you would need to have administrative
          access to the server and client side of your GitLab instance. Find out more
-         `here <https://docs.gitlab.com/ee/administration/git_annex.html>`_.
+         `here <https://docs.gitlab.com/12.10/ee/administration/git_annex.html>`_.


### PR DESCRIPTION
The monthly linkchecker found that this link 404'ed. Closer inspection revealed that the feature was deprecated.