### PR TITLE
Refactor the chapter on publishing

### DIFF
--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -645,6 +645,7 @@ configuration, or interactively).
 
    GitHub `decided to deprecate user-password authentication <https://developer.github.com/changes/2020-02-14-deprecating-password-auth/>`_ and will only support authentication via personal access token from November 13th 2020 onwards.
    Upcoming changes in DataLad's API will reflect this change starting with DataLad version ``0.13.6`` by removing the ``github-passwd`` argument.
+   Starting with DataLad ``0.16.0``, a new set of commands for interactions with a variety of hosting services will be introduced (for more information, see section :ref:`share_hostingservice`).
 
    To ensure successful authentication, please create a personal access token at `github.com/settings/tokens <https://github.com/settings/tokens>`_ [#f5]_, and either
 

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -641,7 +641,7 @@ The command takes a repository name and GitHub authentication credentials
 ``github-passwd <PASSWORD>``, with an *oauth* `token <https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_ stored in the Git
 configuration, or interactively).
 
-.. importantnote:: GitHub deprecates its User Password authentication
+.. importantnote:: GitHub deprecated User Password authentication
 
    GitHub `decided to deprecate user-password authentication <https://developer.github.com/changes/2020-02-14-deprecating-password-auth/>`_ and will only support authentication via personal access token from November 13th 2020 onwards.
    Upcoming changes in DataLad's API will reflect this change starting with DataLad version ``0.13.6`` by removing the ``github-passwd`` argument.
@@ -649,12 +649,8 @@ configuration, or interactively).
 
    To ensure successful authentication, please create a personal access token at `github.com/settings/tokens <https://github.com/settings/tokens>`_ [#f5]_, and either
 
-   * configure Git's "``hub.oauthtoken``" config variable [#f7]_ with your token as in::
-
-        git config --global --add hub.oauthtoken cd2a3bd530...454f73b5a4
-
    * supply the token with the argument ``--github-login <TOKEN>`` from the command line,
-   * or supply the token from the command line when queried interactively for it
+   * or supply the token from the command line when queried for a password
 
 Based on the credentials and the
 repository name, it will create a new, empty repository on GitHub, and

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -38,7 +38,7 @@ which annexed file contents can be retrieved via :command:`datalad get`.
 
 The upcoming section :ref:`gin` shows you one of the most easy ways to publish your
 dataset publicly or for selected collaborators and friends.
-If you don't want to dive in to all the details on dataset sharing, it is save to
+If you don't want to dive in to all the details on dataset sharing, it is safe to
 directly skip ahead to this section, and have your dataset published in only a few minutes.
 
 Other sections in this chapter will showcase a variety of ways to publish datasets
@@ -51,7 +51,8 @@ The section :ref:`gitlfs` talks about using the centralized, for-pay service
 `Git LFS <https://git-lfs.github.com/>`_ for sharing dataset content on GitHub, and the
 section :ref:`figshare` shows built-in dataset export to services such as
 `figshare.com <https://figshare.com/>`__.
-
+If you want a walk-through for a different service, or if you maybe even want to share
+your own walk-through, please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_.
 
 .. importantnote:: There can never be "too much" documentation
 
@@ -124,15 +125,15 @@ The hosting services can be all kinds of private, institutional, or commercial s
    A special-remote is an extension to Git’s concept of remotes, and can
    enable :term:`git-annex` to transfer data from and possibly to places that are not Git
    repositories (e.g., cloud services or external machines such as an HPC
-   system). For example, *s3* special remote uploads and downloads content
-   to AWS S3, *web* special remote downloads files from the web, *datalad-archive*
+   system). For example, an *s3* special remote uploads and downloads content
+   to AWS S3, a *web* special remote downloads files from the web, and *datalad-archive*
    extracts files from the annexed archives, etc. Don’t envision a special-remote
    as merely a physical place or location – a special-remote is a protocol that
    defines the underlying transport of your files to and/or from a specific location.
 
 To register a special remote in your dataset and use it for file storage, you need to configure the service of your choice and *publish* the annexed contents to it. Afterwards, the published dataset (e.g., via :term:`GitHub` or :term:`GitLab`) stores the information about where to obtain annexed file contents from such that
 :command:`datalad get` works.
-Once you have configured the service of your choice, DataLad makes it easy to push different dataset contents exactly where they need to be automatically via a :term:`publication dependency`.
+Once you have configured the service of your choice, you can push your datasets Git history to the repository hosting service and the annexed contents to the special remote. But DataLad also makes it easy to push these different dataset contents exactly where they need to be automatically via a :term:`publication dependency`.
 
 Exemplary walk-throughs for `Dropbox <https://dropbox.com>`_, `Amazon S3 buckets <https://aws.amazon.com/s3/?nc1=h_ls>`_, and `Git LFS  <https://github.com/git-lfs/git-lfs>`__ can be found in the upcoming sections in this chapter.
 But the general workflow looks as follows:
@@ -214,7 +215,7 @@ The creative case: Ensuring availability using only repository hosting
 When you only want to use pure Git repository hosting services without annex support, you can still allow others to obtain (some) file contents with some creativity:
 
 For one, you can use commands such as :command:`datalad download-url` (:manpage:`datalad-download` manual) or :command:`datalad addurls` (:manpage:`datalad-addurls` manual) to retrieve files from web sources and register their location automatically.
-The first Chapter :ref:`chapter_datasets` demonstrates :command:`download-url`, and the usecase :ref:`usecase_HCP_dataset` demonstrates `addurls` on a large scale.
+The first Chapter :ref:`chapter_datasets` demonstrates :command:`download-url`, and the usecase :ref:`usecase_HCP_dataset` demonstrates ``addurls`` on a large scale.
 
 Other than this, you can rely on digital provenance in the form of :term:`run record`\s that allow consumers of your dataset to recompute a result instead of :command:`datalad get`\ing it.
 The midterm-project example in section :ref:`yoda_project` has been an example for this.

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -3,8 +3,24 @@
 Beyond shared infrastructure
 ----------------------------
 
+Data sharing potentially involves a number of different elements:
+
+.. figure:: ../artwork/src/publishing/startingpoint.svg
+   :width: 60%
+
+   An overview of all elements potentially included in a publication workflow.
+
 Users on a common, shared computational infrastructure such as an :term:`SSH server`
-can share datasets via simple installations with paths.
+can share datasets via simple installations with paths, without any involvement of third party storage providers or repository hosting services:
+
+|pic1|  |pic2|
+
+.. |pic1| image:: ../artwork/src/publishing/clone_local.svg
+   :width: 45%
+
+.. |pic2| image:: ../artwork/src/publishing/clone_server.svg
+   :width: 45%
+
 But at some point in a dataset's life, you may want to share it with people that
 can't access the computer or server your dataset lives on, store it on other infrastructure
 to save diskspace, or create a backup.
@@ -36,12 +52,6 @@ The section :ref:`gitlfs` talks about using the centralized, for-pay service
 section :ref:`figshare` shows built-in dataset export to services such as
 `figshare.com <https://figshare.com/>`__.
 
-
-
-.. figure:: ../artwork/src/publishing/startingpoint.svg
-   :width: 70%
-
-   An overview of all elements potentially included in a publication workflow.
 
 .. importantnote:: There can never be "too much" documentation
 
@@ -153,6 +163,10 @@ data is as easy as with any public DataLad dataset.
 While you have to invest some setup effort in the beginning, once this
 is done, the workflows of yours and others are the same that you are already
 very familiar with.
+
+.. figure:: ../artwork/src/publishing/clone_url.svg
+   :width: 60%
+
 
 If you are interested in learning how to set up different services as special remotes, you can take a look at the sections :ref:`s3`, :ref:`dropbox` or :ref:`gitlfs` for concrete examples with DataLad datasets, and the general section :ref:`share_hostingservice` on setting up dataset siblings.
 In addition, there are step-by-step walk-throughs in the documentation of git-annex for services such as `S3 <https://git-annex.branchable.com/tips/public_Amazon_S3_remote/>`_, `Google Cloud Storage <https://git-annex.branchable.com/tips/using_Google_Cloud_Storage/>`_,

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -3,6 +3,46 @@
 Beyond shared infrastructure
 ----------------------------
 
+Users on a common, shared computational infrastructure such as an :term:`SSH server`
+can share datasets via simple installations with paths.
+But at some point in a dataset's life, you may want to share it with people that
+can't access the computer or server your dataset lives on, store it on other infrastructure
+to save diskspace, or create a backup.
+When this happens, you will want to publish your dataset to repository hosting
+services (for example :term:`GitHub`, :term:`GitLab`, or :term:`Gin`)
+and/or third party storage providers (such as `Dropbox <https://dropbox.com>`_,
+`Google <https://google.com>`_,
+`Amazon S3 buckets <https://aws.amazon.com/s3/?nc1=h_ls>`_,
+the `Open Science Framework (OSF) <https://osf.io/>`__, and many others).
+
+This chapter tackles different aspects of dataset publishing.
+The remainder of this section talks about general aspects of dataset publishing, and
+illustrates the idea of using third party services as :term:`special remote`\s from
+which annexed file contents can be retrieved via :command:`datalad get`.
+
+The upcoming section :ref:`gin` shows you one of the most easy ways to publish your
+dataset publicly or for selected collaborators and friends.
+If you don't want to dive in to all the details on dataset sharing, it is save to
+directly skip ahead to this section, and have your dataset published in only a few minutes.
+
+Other sections in this chapter will showcase a variety of ways to publish datasets
+and their contents to different services:
+The section :ref:`share_hostingservice` demonstrates how to publish datasets to any
+kind of Git repository hosting service.
+The sections :ref:`s3` and :ref:`dropbox` are concrete examples of sharing datasets
+publicly or with selected others via different cloud services.
+The section :ref:`gitlfs` talks about using the centralized, for-pay service
+`Git LFS <https://git-lfs.github.com/>`_ for sharing dataset content on GitHub, and the
+section :ref:`figshare` shows built-in dataset export to services such as
+`figshare.com <https://figshare.com/>`__.
+
+
+
+.. figure:: ../artwork/src/publishing/startingpoint.svg
+   :width: 70%
+
+   An overview of all elements potentially included in a publication workflow.
+
 .. importantnote:: There can never be "too much" documentation
 
    If you plan to share your own datasets with people that are unfamiliar with
@@ -11,140 +51,63 @@ Beyond shared infrastructure
    block that the handbook provides. To find this textblock, go to
    :ref:`dataset_textblock`
 
-From the sections :ref:`sharelocal1` and :ref:`yoda_project` you already
-know about two common setups for sharing datasets:
 
-Users on a common, shared computational infrastructure such as an :term:`SSH server`
-can share datasets via simple installations with paths.
-
-Without access to the same computer, it is possible to :command:`push` datasets
-to :term:`GitHub` or :term:`GitLab` to publish them.
-You have already done this when you shared
-your ``midterm_project`` dataset via :term:`GitHub`. However, this section
-demonstrated that the files stored in :term:`git-annex` (such as the results of
-your analysis, ``pairwise_comparisons.png`` and ``prediction_report.csv``) are not
-published to GitHub: There was meta data about their file availability, but a
-:command:`datalad get` command on these files failed, because storing (large)
-annexed content is currently not supported by :term:`GitHub` [#f1]_.
-In the case of the ``midterm_project``, this was not a problem: The
-computations that you ran were captured with :command:`datalad run`, and
-others can just recompute your results instead of :command:`datalad get`\ting them.
-
-However, not always do two or more parties share the same server, have access to
-the same systems, or share something that can be recomputed quickly, but need to
-actually share datasets with data, including the annexed contents.
-
-.. figure:: ../artwork/src/publishing/startingpoint.svg
-   :width: 70%
-
-   An overview of all elements potentially included in a publication workflow.
 
 Leveraging third party infrastructure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Let's say you'd like to share your complete ``DataLad-101`` dataset with
-a friend overseas. After all you know about DataLad, you'd like to let more people
-know about its capabilities. You and your friend, however, do not have access
-to the same computational infrastructure, and there are also many annexed files, e.g.,
-the PDFs in your dataset, that you'd like your friend to have but that can't be
-simply computed or automatically obtained from web sources.
+There are several ways to make datasets available for others:
 
-In these cases, the two previous approaches to share data do not suffice.
-What you would like to do is to provide your friend with a GitHub URL to
-install a dataset from *and* successfully run :command:`datalad get`, just as with
-the many publicly available DataLad datasets such as the ``longnow`` podcasts.
+- You can **publish your dataset to a repository with annex support** such as :term:`gin` or the `Open Science Framework (OSF) <https://osf.io/>`__ [#f1]_. This is the easiest way to share datasets and all their contents. Read on in the section :ref:`gin` or consult the tutorials of the `datalad-osf extension <http://docs.datalad.org/projects/osf/en/latest/index.html>`_ to learn how to do this.
 
-To share all dataset contents with your friend, you need to configure an external
-resource that stores your annexed data contents and that can be accessed by the
-person you want to share your data with. Such a resource can be a private
-web server, but also a third party services cloud storage such as
-`Dropbox <https://dropbox.com>`_,
-`Google <https://google.com>`_,
-`Amazon S3 buckets <https://aws.amazon.com/s3/?nc1=h_ls>`_,
-`Box.com <https://www.box.com/en-gb/home>`_,
-`Figshare <https://figshare.com/>`__,
-`owncloud <https://owncloud.com>`_,
-`sciebo <https://hochschulcloud.nrw>`_,
-the `Open Science Framework (OSF) <https://osf.io/>`__  (requires the `datalad-osf extension <http://docs.datalad.org/projects/osf/en/latest/index.html>`_),
-or many more. The key to achieve this lies within :term:`git-annex`.
+- You can **publish your dataset to a repository hosting service**, and **configure an external resource that stores your annexed data**. Such a resource can be a private web server, but also a third party services cloud storage such as `Dropbox <https://dropbox.com>`_, `Google <https://google.com>`_, `Amazon S3 buckets <https://aws.amazon.com/s3/?nc1=h_ls>`_, `Box.com <https://www.box.com/en-gb/home>`_, `owncloud <https://owncloud.com>`_, `sciebo <https://hochschulcloud.nrw>`_, or many more.
 
-In order to use third party services for file storage, you need to configure the
-service of your choice and *publish* the annexed contents to it. Afterwards,
-the published dataset (e.g., via :term:`GitHub` or :term:`GitLab`) stores the
-information about where to obtain annexed file contents from such that
-:command:`datalad get` works.
+- You can **export your dataset statically** as a snapshot to a service such as  `Figshare <https://figshare.com/>`__ or the `Open Science Framework (OSF) <https://osf.io/>`__ [#f1]_.
+
+- You can **publish your dataset to a repository hosting service** and ensure that
+  all dataset contents are either available from pre-existing public sources or can be recomputed from a :term:`run record`.
+
+Dataset contents and third party services influence sharing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because DataLad datasets are :term:`Git` repositories, it is possible to
+:command:`push` datasets to any Git repository hosting service, such as
+:term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_,
+or `Gitea <https://gitea.io/en-us/>`_.
+You have already done this in section :ref:`yoda_project` when you shared your ``midterm_project`` dataset via :term:`GitHub`.
+
+However, most Git repository hosting services do not support hosting the file content
+of the files managed by :term:`git-annex`.
+For example, the the results of the analysis in section :ref:`yoda_project`,
+``pairwise_comparisons.png`` and ``prediction_report.csv``, were not published to
+GitHub: There was meta data about their file availability, but if a friend cloned
+this dataset and ran a :command:`datalad get` command, content retrieval would fail
+because their only known location is your private computer to which only you have access.
+Instead, they would need to be recomputed from the :term:`run record` in the dataset.
+
+When you are sharing DataLad datasets with other people or third party services,
+an important distinction thus lies in *annexed* versus *not-annexed* content, i.e.,
+files that stored in your dataset's :term:`annex` versus files that are committed
+into :term:`Git`.
+The third-party service of your choice may have support for both annexed and non-annexed files, or only one them.
 
 .. figure:: ../artwork/src/publishing/publishing_network_publishparts2.svg
    :width: 80%
 
    Schematic difference between the Git and git-annex aspect of your dataset, and where each part *usually* gets published to.
 
-This tutorial showcases how this can be done, and shows the basics of how
-datasets can be shared via a third party infrastructure.
 
-.. importantnote:: Free publication service alternatives
+The common case: Repository hosting without annex support and special remotes
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-   There are two easier and free alternatives to what is outlined in this section:
+Because DataLad datasets are :term:`Git` repositories, it is possible to
+:command:`push` datasets to any Git repository hosting service, such as
+:term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_,
+or `Gitea <https://gitea.io/en-us/>`_.
+But while anything that is managed by Git is accessible in repository hosting services, they usually don't support storing annexed data [#f2]_.
 
-   - Using the free G-Node Infrastructure :term:`Gin`, a repository hosting service with support for dataset annexes.
-     The :ref:`next section <gin>` introduces how to use this third party infrastructure, and you can skip ahead if you prefer an easier start.
-
-   - Using the ``datalad-osf`` extension to publish datasets and their file contents to the free `Open Science Framework (OSF) <https://osf.io/>`__.
-     This alternative differs from what is outlined in this chapter, but its `documentation <http://docs.datalad.org/projects/osf/en/latest/index.html>`_ provides detailed tutorials and use cases.
-
-   If you are interested in learning how to set up a special remote, or are bound to a different third party provider than :term:`Gin` or the OSF, please read on in this section.
-
-From your perspective (as someone who wants to share data), you will
-need to
-
-- (potentially) install/setup the relevant *special-remote*,
-- find a place that large file content can be stored in & set up a
-  *publication dependency* on this location,
-- publish your dataset
-
-This gives you the freedom to decide where your data lives and
-who can have access to it. Once this set up is complete, updating and
-accessing a published dataset and its data is almost as easy as if it would
-lie on your own machine.
-
-From the perspective of your friend (as someone who wants to obtain a dataset),
-they will need to
-
-- (potentially) install the relevant *special-remote* and
-- perform the standard :command:`datalad clone` and :command:`datalad get` commands
-  as necessary.
-
-Thus, from a collaborator's perspective, with the exception of potentially
-installing/setting up the relevant *special-remote*, obtaining your dataset and its
-data is as easy as with any public DataLad dataset.
-While you have to invest some setup effort in the beginning, once this
-is done, the workflows of yours and others are the same that you are already
-very familiar with.
-
-Setting up 3rd party services to host your data
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. importantnote:: There is work in progress
-
-   The tutorial below is functional, but there is work towards a wrapper
-   function to ease creating and working with rclone-based special remotes:
-   https://github.com/datalad/datalad/pull/4162.
-   Once finished, this section will be updated accordingly.
-
-In this paragraph you will see how a third party service can be configured
-to host your data. Note that the *exact* procedures are different from service
-to service -- this is inconvenient, but inevitable given the
-differences between the various third party infrastructures.
-The general workflow, however, is the same:
-
-#. Initialize the appropriate Git-annex *special-remote* (different
-   from service to service).
-#. Push annexed file content to the third-party service to use it as a storage provider
-#. Share the dataset (repository) via GitHub/GitLab/... for others to install from
-
-If the above steps are implemented, others can :command:`install` or
-:command:`clone` your shared dataset, and :command:`get` or :command:`pull` large
-file content from the remote, third party storage.
+When you want to publish a dataset to a Git repository hosting service to allow others to easily find and clone it, but you also want others to be able to retrieve annexed files in this dataset via :command:`datalad get`, annexed contents need to be pushed to additional storage hosting services.
+The hosting services can be all kinds of private, institutional, or commercial services, and their location will be registered in the dataset under the concept of a :term:`special remote`.
 
 .. find-out-more:: What is a special remote
 
@@ -157,420 +120,119 @@ file content from the remote, third party storage.
    as merely a physical place or location – a special-remote is a protocol that
    defines the underlying transport of your files to and/or from a specific location.
 
-As an example, let's walk through all necessary steps to publish ``DataLad-101``
-to **Dropbox**. If you instead are interested in learning how to set up a public
-`Amazon S3 bucket <https://aws.amazon.com/s3/?nc1=h_ls>`_, there is a single-page, step-by-step
-walk-through `in the documentation of git-annex <https://git-annex.branchable.com/tips/public_Amazon_S3_remote/>`_
-that shows how you can create an S3 special remote and share data with anyone who
-gets a clone of your dataset, without them needing Amazon AWS credentials. Likewise,
-the documentation provides step-by-step walk-throughs for many other services,
-such as `Google Cloud Storage <https://git-annex.branchable.com/tips/using_Google_Cloud_Storage/>`_,
+To register a special remote in your dataset and use it for file storage, you need to configure the service of your choice and *publish* the annexed contents to it. Afterwards, the published dataset (e.g., via :term:`GitHub` or :term:`GitLab`) stores the information about where to obtain annexed file contents from such that
+:command:`datalad get` works.
+Once you have configured the service of your choice, DataLad makes it easy to push different dataset contents exactly where they need to be automatically via a :term:`publication dependency`.
+
+Exemplary walk-throughs for `Dropbox <https://dropbox.com>`_, `Amazon S3 buckets <https://aws.amazon.com/s3/?nc1=h_ls>`_, and `Git LFS  <https://github.com/git-lfs/git-lfs>`__ can be found in the upcoming sections in this chapter.
+But the general workflow looks as follows:
+
+From your perspective (as someone who wants to share data), you will
+need to
+
+- (potentially) install/setup the relevant *special-remote*,
+- create a dataset sibling on GitHub/GitLab/... for others to install from
+- set up a *publication dependency* between repository hosting and special remote , so that annexed contents are automatically pushed to the special remote when ever you update the sibling on the Git repository hosting site
+- publish your dataset
+
+This gives you the freedom to decide where your data lives and
+who can have access to it. Once this set up is complete, updating and
+accessing a published dataset and its data is almost as easy as if it would
+lie on your own machine.
+
+From the perspective of a consumer (as someone who wants to obtain your dataset),
+they will need to
+
+- (potentially) install the relevant *special-remote* (dependent on the third-party service you chose) and
+- perform the standard :command:`datalad clone` and :command:`datalad get` commands
+  as necessary.
+
+Thus, from a collaborator's perspective, with the exception of potentially
+installing/setting up the relevant *special-remote*, obtaining your dataset and its
+data is as easy as with any public DataLad dataset.
+While you have to invest some setup effort in the beginning, once this
+is done, the workflows of yours and others are the same that you are already
+very familiar with.
+
+If you are interested in learning how to set up different services as special remotes, you can take a look at the sections :ref:`s3`, :ref:`dropbox` or :ref:`gitlfs` for concrete examples with DataLad datasets, and the general section :ref:`share_hostingservice` on setting up dataset siblings.
+In addition, there are step-by-step walk-throughs in the documentation of git-annex for services such as `S3 <https://git-annex.branchable.com/tips/public_Amazon_S3_remote/>`_, `Google Cloud Storage <https://git-annex.branchable.com/tips/using_Google_Cloud_Storage/>`_,
 `Box.com <https://git-annex.branchable.com/tips/using_box.com_as_a_special_remote/>`__,
 `Amazon Glacier <https://git-annex.branchable.com/tips/using_Amazon_Glacier/>`_,
 `OwnCloud <https://git-annex.branchable.com/tips/owncloudannex/>`__, and many more.
-Here is the complete list: `git-annex.branchable.com/special_remotes/ <https://git-annex.branchable.com/special_remotes/>`_.
-
-For Dropbox, the relevant special-remote to configures is
-`rclone <https://github.com/DanielDent/git-annex-remote-rclone>`__.
-It is a command line program to sync files and directories to and
-from a large number of commercial providers [#f2]_ (Amazon Cloud Drive, Microsoft
-One Drive, ...). By enabling it as a special remote, :term:`git-annex` gets the
-ability to do the same, and can thus take care of publishing large file content
-to such sources conveniently under the hood.
-
-
-- The first step is to `install <https://rclone.org/install/>`_
-  ``rclone`` on your computer. The installation instructions are straightforward
-  and the installation is quick if you are on a Unix-based system (macOS or any
-  Linux distribution).
-
-- Afterwards, run ``rclone config`` from the command line to configure ``rclone`` to
-  work with Dropbox. Running this command will a guide you with an interactive
-  prompt through a ~2 minute configuration of the remote (here we will name the
-  remote "dropbox-for-friends" -- the name will be used to refer to it later during the
-  configuration of the dataset we want to publish). The interactive dialog is
-  outlined below, and all parts that require user input are highlighted.
-
-.. code-block::
-   :emphasize-lines: 7-8, 22, 26, 30, 36
-
-   $ rclone config
-    2019/09/06 13:43:58 NOTICE: Config file "/home/me/.config/rclone/rclone.conf" not found - using defaults
-    No remotes found - make a new one
-    n) New remote
-    s) Set configuration password
-    q) Quit config
-    n/s/q> n
-    name> dropbox-for-friends
-    Type of storage to configure.
-    Enter a string value. Press Enter for the default ("").
-    Choose a number from below, or type in your own value
-     1 / 1Fichier
-       \ "fichier"
-     2 / Alias for an existing remote
-       \ "alias"
-    [...]
-     8 / Dropbox
-       \ "dropbox"
-    [...]
-    31 / premiumize.me
-       \ "premiumizeme"
-    Storage> dropbox
-    ** See help for dropbox backend at: https://rclone.org/dropbox/ **
-
-    Dropbox App Client Id
-    Leave blank normally.
-    Enter a string value. Press Enter for the default ("").
-    client_id>
-    Dropbox App Client Secret
-    Leave blank normally.
-    Enter a string value. Press Enter for the default ("").
-    client_secret>
-    Edit advanced config? (y/n)
-    y) Yes
-    n) No
-    y/n> n
-    If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth
-    Log in and authorize rclone for access
-    Waiting for code...
-
-- At this point, this will open a browser and ask you to authorize ``rclone`` to
-  manage your Dropbox, or any other third-party service you have selected
-  in the interactive prompt. Accepting will bring you back into the terminal
-  to the final configuration prompts:
-
-.. code-block:: bash
-   :emphasize-lines: 12, 26
-
-   Got code
-   --------------------
-   [dropbox-for-friends]
-   type = dropbox
-   token = {"access_token":"meVHyc[...]",
-            "token_type":"bearer",
-            "expiry":"0001-01-01T00:00:00Z"}
-   --------------------
-   y) Yes this is OK
-   e) Edit this remote
-   d) Delete this remote
-   y/e/d> y
-   Current remotes:
-
-   Name                 Type
-   ====                 ====
-   dropbox-for-friends  dropbox
-
-   e) Edit existing remote
-   n) New remote
-   d) Delete remote
-   r) Rename remote
-   c) Copy remote
-   s) Set configuration password
-   q) Quit config
-   e/n/d/r/c/s/q> q
-
-- Once this is done, install ``git-annex-remote-rclone``.
-  It is a wrapper around `rclone <https://rclone.org>`__ that makes any   destination supported by rclone usable with :term:`git-annex`.
-  If you are on a recent version of Debian or Ubuntu (or enable `NeuroDebian <https://neuro.debian.net>`_ repository), you can get it conveniently via your package manager, e.g., with ``sudo apt-get install git-annex-remote-rclone``.
-  Alternatively, ``git clone`` the `git-annex-remote-rclone <https://github.com/DanielDent/git-annex-remote-rclone>`_ repository to your machine (do not clone it into ``DataLad-101`` but somewhere else on your computer)::
-
-     $ git clone https://github.com/DanielDent/git-annex-remote-rclone.git
-
-- Copy the path to this repository into your ``$PATH`` variable. If the
-  clone is in ``/home/user-bob/repos``, the command would look like this [#f3]_::
-
-   $ export PATH="/home/user-bob/repos/git-annex-remote-rclone:$PATH"
+Here is the complete list: `git-annex.branchable.com/special_remotes <https://git-annex.branchable.com/special_remotes>`_.
 
-- Finally, in the dataset you want to share, run the :command:`git annex initremote` command.
-  Give the remote a name (it is ``dropbox-for-friends`` here), and specify the name of  the remote you configured with ``rclone`` with the ``target`` parameters:
-
-.. code-block:: bash
-
-   $ git annex initremote dropbox-for-friends type=external externaltype=rclone chunk=50MiB encryption=none target=dropbox-for-friends prefix=my_awesome_dataset
-
-   initremote dropbox-for-friends ok
-   (recording state in git...)
-
-What has happened up to this point is that we have configured Dropbox
-as a third-party storage service for the annexed contents in the dataset.
-On a conceptual, dataset level, your Dropbox folder is now a :term:`sibling` -- the sibling name is the first positional argument after ``initremote``, i.e., "dropbox-for-friends":
-
-.. code-block:: bash
-
-   $ datalad siblings
-    .: here(+) [git]
-    .: dropbox-for-friends(+) [rclone]
-    .: roommate(+) [../mock_user/DataLad-101 (git)]
-
-On Dropbox, a new folder will be created for your annexed files.
-By default, this folder will be called ``git-annex``, but it can be configured using the ``--prefix=<whatitshouldbecalled>`` option, as done above.
-However, this directory on Dropbox is not the location you would refer your friend or a collaborator to.
-The representation of the files in the special-remote is not human-readable --
-it is a tree of annex objects, and thus looks like a bunch of very weirdly named
-folders and files to anyone.
-Through this design it becomes possible to chunk files into smaller units (see
-`the git-annex documentation <https://git-annex.branchable.com/chunking/>`_ for more on this),
-optionally encrypt content on its way from a local machine to a storage service
-(see `the git-annex documentation <https://git-annex.branchable.com/encryption/>`__ for more on this),
-and avoid leakage of information via file names. Therefore, the Dropbox remote is
-not a places a real person would take a look at, instead they are only meant to
-be managed and accessed via DataLad/git-annex.
-
-To actually share your dataset with someone, you need to *publish* it to Github,
-Gitlab, or a similar hosting service.
-
-.. index:: ! datalad command; create-sibling-github
-
-You could, for example, create a sibling of the ``DataLad-101`` dataset
-on GitHub with the command :command:`create-sibling-github`.
-This will create a new GitHub repository called "DataLad-101" under your account,
-and configure this repository as a :term:`sibling` of your dataset
-called ``github`` (exactly like you have done in :ref:`yoda_project`
-with the ``midterm_project`` subdataset).
-However, in order to be able to link the contents stored in Dropbox, you also need to
-configure a *publication dependency* to the ``dropbox-for-friends`` sibling -- this is
-done with the ``publish-depends <sibling>`` option.
-
-.. code-block:: bash
-
-   $ datalad create-sibling-github -d . DataLad-101 \
-     --publish-depends dropbox-for-friends
-     [INFO   ] Configure additional publication dependency on "dropbox-for-friends"
-     .: github(-) [https://github.com/<user-name>/DataLad-101.git (git)]
-     'https://github.com/<user-name>/DataLad-101.git' configured as sibling 'github' for <Dataset path=/home/me/dl-101/DataLad-101>
-
-:command:`datalad siblings` will again list all available siblings:
-
-.. code-block:: bash
-
-   $ datalad siblings
-    .: here(+) [git]
-    .: dropbox-for-friends(+) [rclone]
-    .: roommate(+) [../mock_user/DataLad-101 (git)]
-    .: github(-) [https://github.com/<user-name>/DataLad-101.git (git)]
-
-Note that each sibling has either a ``+`` or ``-`` attached to its name. This
-indicates the presence (``+``) or absence (``-``) of a remote data annex at this
-remote. You can see that your ``github`` sibling indeed does not have a remote
-data annex.
-Therefore, instead of "only" publishing to this GitHub repository (as done in section
-:ref:`yoda_project`), in order to also publish annex contents, we made
-publishing to GitHub dependent on the ``dropbox-for-friends`` sibling
-(that has a remote data annex), so that annexed contents are published
-there first.
-
-.. importantnote:: Publication dependencies are strictly local configuration
-
-   Note that the publication dependency is only established for your own dataset,
-   it is not shared with clones of the dataset. Internally, this configuration
-   is a key value pair in the section of your remote in ``.git/config``:
-
-   .. code-block:: bash
-
-      [remote "github"]
-         annex-ignore = true
-         url = https://github.com/<user-name>/DataLad-101.git
-         fetch = +refs/heads/*:refs/remotes/github/*
-         datalad-publish-depends = dropbox-for-friends
-
-With this setup, we can publish the dataset to GitHub. Note how the publication
-dependency is served first:
-
-.. code-block:: bash
-   :emphasize-lines: 2
-
-   $ datalad push --to github
-   [INFO   ] Transferring data to configured publication dependency: 'dropbox-for-friends'
-   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> data to dropbox-for-friends
-   publish(ok): books/TLCL.pdf (file)
-   publish(ok): books/byte-of-python.pdf (file)
-   publish(ok): books/progit.pdf (file)
-   publish(ok): recordings/interval_logo_small.jpg (file)
-   publish(ok): recordings/salt_logo_small.jpg (file)
-   [INFO   ] Publishing to configured dependency: 'dropbox-for-friends'
-   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> data to dropbox-for-friends
-   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> to github
-   Username for 'https://github.com': <user-name>
-   Password for 'https://<user-name>@github.com':
-   publish(ok): . (dataset) [pushed to github: ['[new branch]', '[new branch]']]
-   action summary:
-     publish (ok: 6)
-
-
-Afterwards, your dataset can be found on GitHub, and ``cloned`` or ``installed``.
-
-
-.. find-out-more:: What if I do not want to share a dataset with everyone, or only some files of it?
-
-   There are a number of ways to restrict access to your dataset or individual
-   files of your dataset. One is via choice of (third party) hosting service
-   for annexed file contents.
-   If you chose a service only selected people have access to, and publish annexed
-   contents exclusively there, then only those selected people can perform a
-   successful :command:`datalad get`. On shared file systems you may achieve
-   this via :term:`permissions` for certain groups or users, and for third party
-   infrastructure you may achieve this by invitations/permissions/... options
-   of the respective service.
-
-   If it is individual files that you do not want to share, you can selectively
-   publish the contents of all files you want others to have, and withhold the data
-   of the files you do not want to share. This can be done by providing paths
-   to the data that should be published, or a `git-annex-wanted <https://git-annex.branchable.com/git-annex-wanted/>`_ configuration and the ``--data auto`` option.
-
-   Let's say you have a dataset with three files:
-
-   - ``experiment.txt``
-   - ``subject_1.dat``
-   - ``subject_2.data``
-
-   Consider that all of these files are annexed. While the information in
-   ``experiment.txt`` is fine for everyone to see, ``subject_1.dat`` and
-   ``subject_2.dat`` contain personal and potentially identifying data that
-   can not be shared. Nevertheless, you want collaborators to know that these
-   files exist.
-   By publishing only the file contents of ``experiment.txt`` with
-
-   .. code-block:: bash
-
-      $ datalad push --to github experiment.txt
-
-   only meta data about file availability of ``subject_1.dat`` and ``subject_2.dat``
-   exists, but as these files' annexed data is not published, a :command:`datalad get`
-   will fail. Note, though, that :command:`push` will publish the complete
-   dataset history (unless you specify a commit range with the ``--since`` option
-   -- see the `manual <http://docs.datalad.org/en/latest/generated/man/datalad-push.html>`_
-   for more information).
 
-
-From the perspective of whom you share your dataset with...
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If your friend would now want to get your dataset including the annexed
-contents, and you made sure that they can access the Dropbox folder with
-the annexed files (e.g., by sharing an access link), here is what they would
-have to do:
+The easy case: Repository hosting with annex support
+""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-If the repository is on GitHub, a :command:`datalad clone` with the URL
-will install the dataset::
+There are a few Git repository hosting services with support for annexed contents.
+One of them is :term:`Gin`.
+What makes them extremely convenient is that there is no need to configure a special remote -- creating a :term:`sibling` and running :command:`datalad push` is enough.
 
-   $ datalad clone https://github.com/<user-name>/DataLad-101.git
-   [INFO   ] Cloning https://github.com/<user-name>/DataLad-101.git [1 other candidates] into '/Users/awagner/Documents/DataLad-101'
-   [INFO   ]   Remote origin not usable by git-annex; setting annex-ignore
-   [INFO   ] access to 1 dataset sibling dropbox-for-friends not auto-enabled, enable with:
-   |         datalad siblings -d "/Users/awagner/Documents/DataLad-101" enable -s dropbox-for-friends
-   install(ok): /Users/awagner/Documents/DataLad-101 (dataset)
-
-Pay attention to one crucial information in this output::
-
-   [INFO   ] access to 1 dataset sibling dropbox-for-friends not auto-enabled, enable with:
-   |         datalad siblings -d "/Users/<user-name>/Documents/DataLad-101" enable -s dropbox-for-friends
-
-This means that someone who wants to access the data from dropbox needs to
-enable the special remote.
-For this,  this person first needs to install and configure ``rclone``
-as well: Since ``rclone`` is the protocol with which
-annexed data can be transferred from and to Dropbox, anyone who needs annexed
-data from Dropbox needs *this* special remote. Therefore, the first steps are
-the same as before:
-
-- `Install <https://rclone.org/install/>`__ ``rclone`` (as described above).
-- Run ``rclone config`` to configure ``rclone`` to work with Dropbox (as described above). **It is important to name the remote identically** - in the example above, it would need to be "dropbox-for-friends".
-  This means: You need to communicate the name of your special remote to your friend, and they have to give it the same name as the one configured in the dataset).
-  (There are efforts towards extracting this information automatically from datasets, but for the time being, this is an important detail to keep in mind).
-- install `git-annex-remote-rclone <https://github.com/DanielDent/git-annex-remote-rclone>`_ (as described above).
-
-After this is done, you can execute what DataLad's output message suggests
-to "enable" this special remote (inside of the installed ``DataLad-101``)::
-
-   $ datalad siblings -d "/Users/awagner/Documents/DataLad-101" \
-     enable -s dropbox-for-friends
-   .: dropbox-for-friends(?) [git]
-
-And once this is done, you can get any annexed file contents, for example the
-books, or the cropped logos from chapter :ref:`chapter_run`::
-
-   $ datalad get books/TLCL.pdf
-   get(ok): /home/some/other/user/DataLad-101/books/TLCL.pdf (file) [from dropbox-for-friends]
-
-.. index:: ! datalad command; create-sibling-github
-.. _gitlfs:
-
-Use GitHub for sharing content
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-GitHub supports `Git Large File Storage <https://github.com/git-lfs/git-lfs>`_
-(Git LFS) for managing data files using Git.  Free GitHub subscription allows up
-to `1GB of free storage and up to 1GB of bandwidth monthly <https://docs.github.com/en/github/managing-large-files/versioning-large-files/about-storage-and-bandwidth-usage>`_.
-As such, it might be sufficient for some use cases, and could be configured
-quite easily.  Similarly to the steps above, we need first to create a repository
-on GitHub if it does not already exist::
-
-    $ datalad create-sibling-github test-github-lfs
-    .: github(-) [https://github.com/yarikoptic/test-github-lfs.git (git)]
-    'https://github.com/yarikoptic/test-github-lfs.git' configured as sibling 'github' for <Dataset path=/tmp/test-github-lfs>
-
-and then initialize special remote of type ``git-lfs``, pointing to the same GitHub
-repository::
-
-    $ git annex initremote github-lfs type=git-lfs url=https://github.com/yarikoptic/test-github-lfs encryption=none embedcreds=no
-
-If you would like to compress data in Git LFS, you need to take a detour via
-encryption during :command:`git annex initremote` -- this has compression as a
-convenient side effect. Here is an example initialization::
-
-   $ git annex initremote --force github-lfs type=git-lfs url=https://github.com/yarikoptic/test-github-lfs encryption=shared
-
-With this single step it becomes possible to transfer contents to GitHub::
-
-    $ git annex copy --to=github-lfs file.dat
-    copy file.dat (to github-lfs...)
-    ok
-    (recording state in git...)
-
-and the entire dataset to the same GitHub repository::
-
-    $ datalad push --to=github
-    [INFO   ] Publishing <Dataset path=/tmp/test-github-lfs> to github
-    publish(ok): . (dataset) [pushed to github: ['[new branch]', '[new branch]']]
-
-Because the special remote URL coincides with the regular remote URL on GitHub,
-``siblings enable`` will not even be necessary when datalad is installed
-from GitHub.
-
-.. importantnote:: No drop from LFS
-
-   Unfortunately, it is impossible to :command:`drop` contents from Git LFS:
-   `help.github.com/en/github/managing-large-files <https://docs.github.com/en/github/managing-large-files/versioning-large-files/removing-files-from-git-large-file-storage#git-lfs-objects-in-your-repository>`_
-
-.. _figshare:
-
-Built-in data export
-^^^^^^^^^^^^^^^^^^^^
-
-Apart from flexibly configurable special remotes that allow publishing
-annexed content to a variety of third party infrastructure, DataLad also has
-some built-in support for "exporting" data to other services.
-
-One example is the command :command:`export-archive`. Running
-this command would produce a ``.tar.gz`` file with the content of your dataset,
-which you could later upload to any data hosting portal manually. This moves
-data out of version control and decentralized tracking,
-and essentially "throws it over the wall". This means, while your data (also
-the annexed data) will be available for download from where you share it, none of the
-special features a DataLad dataset provides will be available, such as its
-history or configurations.
-
-Another example is :command:`export-to-figshare`. Running this command allows
-you to publish the dataset to `Figshare <https://figshare.com/>`__.  As the command
-:command:`export-archive` is used by it to prepare content for upload to
-Figshare, annexed files also will be annotated as available from the archive on
-Figshare using ``datalad-archive`` special remote.  As a result, if you publish
-your Figshare dataset and share your DataLad dataset on GitHub, users will still
-be able to fetch content from the tarball shared on Figshare via DataLad.
+.. figure:: ../artwork/src/publishing/publishing_network_publishgin.svg
+   :width: 80%
+
+Read the section :ref:`gin` for a walk-through.
+
+The uncommon case: Special remotes with repository hosting support
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Typically, storage hosting services such as cloud storage providers do not provide
+the ability to host Git repositories.
+Therefore, it is typically not possible to :command:`clone` from a cloud storage.
+However, a number of :term:`datalad extension`\s have been created that equip cloud storage providers with the ability to also host Git repositories.
+While they do not get the ability to display repositories the same way that pure
+Git repository hosting services like GitHub do, they do get the super power of becoming clonable.
+
+One example for this is the Open Science Framework, which can become the home of datasets by using the `datalad-osf extension <http://docs.datalad.org/projects/osf/en/latest/index.html>`_.
+As long as you and your collaborators have the extension installed, annexed dataset
+contents and the Git repository part of your dataset can be pushed or cloned in one go.
+
+.. figure:: ../artwork/src/publishing/publishing_network_publishosf.svg
+   :width: 80%
+
+Please take a look at the `documentation and tutorials of datalad-osf extension <http://docs.datalad.org/projects/osf/en/latest/index.html>`_ for examples and more information.
+
+The creative case: Ensuring availability using only repository hosting
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+When you only want to use pure Git repository hosting services without annex support, you can still allow others to obtain (some) file contents with some creativity:
+
+For one, you can use commands such as :command:`datalad download-url` (:manpage:`datalad-download` manual) or :command:`datalad addurls` (:manpage:`datalad-addurls` manual) to retrieve files from web sources and register their location automatically.
+The first Chapter :ref:`chapter_datasets` demonstrates :command:`download-url`, and the usecase :ref:`usecase_HCP_dataset` demonstrates `addurls` on a large scale.
+
+Other than this, you can rely on digital provenance in the form of :term:`run record`\s that allow consumers of your dataset to recompute a result instead of :command:`datalad get`\ing it.
+The midterm-project example in section :ref:`yoda_project` has been an example for this.
+
+
+The static case: Exporting dataset snapshots
+""""""""""""""""""""""""""""""""""""""""""""
+
+While DataLad datasets have the great advantage that they carry a history with all kinds of useful digital provenance and previous versions of files, it may not in all cases be necessary to make use of this advantage.
+Sometimes, you may just want to share or archive the most recent state of the dataset as a snapshot.
+
+DataLad provides the ability to do this out of the box to arbitrary locations, and support for specific services such as `Figshare <https://figshare.com/>`__.
+Find out more information on this in the section :ref:`figshare`.
+Other than that, some :term:`datalad extension`\s allow an export to additional services such as the Open Science Framework [#f1]_.
+
+General information on publishing datasets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Beyond concrete examples of publishing datasets, some general information may be useful in addition:
+The section :ref:`push` illustrates the DataLad command :command:`datalad push`, a command that handles every publication operation, regardless of the type of published content or its destination.
+In addition to this, the section :ref:`privacy` contains tips and strategies on publishing datasets without leaking potentially private contents or information.
+Finally, you may be interested in publishing datasets into centrally managed locations for backup, archival, or central data management.
+In this case, take a look at the advanced section :ref:`riastore`.
+
 
 .. rubric:: Footnotes
 
-.. [#f1] Older versions of :term:`GitLab`, on the other hand, provide a git-annex configuration. It
+.. [#f1] Requires the `datalad-osf extension <http://docs.datalad.org/projects/osf/en/latest/index.html>`_.
+
+.. [#f2] In addition to not storing annexed data, most Git repository hosting services also have a size limit for files kept in Git. So while you could *theoretically* commit a sizable file into Git, this would not only negatively impact the performance of your dataset as Git doesn't handle large files well, but it would also `prevent your dataset to be published to a Git repository hosting service like GitHub <https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github>`_.
+
+.. [#f5] Older versions of :term:`GitLab`, on the other hand, provide a git-annex configuration. It
          is disabled by default, and to enable it you would need to have administrative
          access to the server and client side of your GitLab instance. Find out more
          `here <https://docs.gitlab.com/12.10/ee/administration/git_annex.html>`_.
@@ -578,16 +240,3 @@ be able to fetch content from the tarball shared on Figshare via DataLad.
          `GitLFS <https://git-lfs.github.com/>`__, a non-free, centralized service
          that allows to store large file contents. The last paragraph in this
          section shows an example on how to use their free trial version.
-
-.. [#f2] ``rclone`` is a useful special-remote for this example, because
-         you can not only use it for Dropbox, but also for many other
-         third-party hosting services.
-         For a complete overview of which third-party services are
-         available and which special-remote they need, please see this
-         `list <http://git-annex.branchable.com/special_remotes/>`_.
-
-.. [#f3] Note that ``export`` will extend your ``$PATH`` *for your current shell*.
-         This means you will have to repeat this command if you open a new shell.
-         Alternatively, you can insert this line into your shells configuration file
-         (e.g., ``~/.bashrc``) to make this path available to all future shells of
-         your user account.

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -252,5 +252,4 @@ In this case, take a look at the advanced section :ref:`riastore`.
          `here <https://docs.gitlab.com/12.10/ee/administration/git_annex.html>`_.
          Alternatively, GitHub can integrate with
          `GitLFS <https://git-lfs.github.com/>`__, a non-free, centralized service
-         that allows to store large file contents. The last paragraph in this
-         section shows an example on how to use their free trial version.
+         that allows to store large file contents. :ref:`gitlfs` shows an example on how to use their free trial version.

--- a/docs/basics/101-138-sharethirdparty.rst
+++ b/docs/basics/101-138-sharethirdparty.rst
@@ -59,7 +59,7 @@ section :ref:`figshare` shows built-in dataset export to services such as
    DataLad, it may be helpful to give a short explanation of what a DataLad
    dataset is and what it can do. For this, you can use a ready-made text
    block that the handbook provides. To find this textblock, go to
-   :ref:`dataset_textblock`
+   :ref:`dataset_textblock`. Alternative, run :command:`datalad add-readme`.
 
 
 

--- a/docs/basics/101-139-dropbox.rst
+++ b/docs/basics/101-139-dropbox.rst
@@ -13,7 +13,7 @@ the many publicly available DataLad datasets such as the ``longnow`` podcasts.
 
 
 As an example, let's walk through all necessary steps to publish the ``DataLad-101`` dataset to GitHub, and its file contents to **Dropbox**.
-To make this as convenient as possible, we will also set up a publication dependency between the two.
+To make this as convenient as possible, we will also set up a :term:`publication dependency` between the two.
 
 To set up Dropbox as a third party storage provide you need to configure a special-remote called
 `rclone <https://github.com/DanielDent/git-annex-remote-rclone>`__.

--- a/docs/basics/101-139-dropbox.rst
+++ b/docs/basics/101-139-dropbox.rst
@@ -1,0 +1,305 @@
+.. _dropbox:
+
+Walk-through: Dropbox as a special remote
+-----------------------------------------
+
+Let's say you'd like to share your complete ``DataLad-101`` dataset with
+a friend overseas. After all you know about DataLad, you'd like to let more people
+know about its capabilities. You and your friend, however, do not have access
+to the same computational infrastructure, and there are also many annexed files, e.g., the PDFs in your dataset, that you'd like your friend to have but that can't be simply computed or automatically obtained from web sources.
+What you would like to do is to provide your friend with a URL to
+install a dataset from *and* successfully run :command:`datalad get`, just as with
+the many publicly available DataLad datasets such as the ``longnow`` podcasts.
+
+
+As an example, let's walk through all necessary steps to publish the ``DataLad-101`` dataset to GitHub, and its file contents to **Dropbox**.
+To make this as convenient as possible, we will also set up a publication dependency between the two.
+
+To set up Dropbox as a third party storage provide you need to configure a special-remote called
+`rclone <https://github.com/DanielDent/git-annex-remote-rclone>`__.
+It is a command line program to sync files and directories to and
+from a large number of commercial providers [#f2]_.
+
+- The first step is to `install <https://rclone.org/install/>`_
+  ``rclone`` on your computer. The installation instructions are straightforward
+  and the installation is quick if you are on a Unix-based system (macOS or any
+  Linux distribution).
+
+- Afterwards, run ``rclone config`` from the command line to configure ``rclone`` to
+  work with Dropbox. Running this command will a guide you with an interactive
+  prompt through a ~2 minute configuration of the remote (here we will name the
+  remote "dropbox-for-friends" -- the name will be used to refer to it later during the
+  configuration of the dataset we want to publish). The interactive dialog is
+  outlined below, and all parts that require user input are highlighted.
+
+.. code-block::
+   :emphasize-lines: 7-8, 22, 26, 30, 36
+
+   $ rclone config
+    2019/09/06 13:43:58 NOTICE: Config file "/home/me/.config/rclone/rclone.conf" not found - using defaults
+    No remotes found - make a new one
+    n) New remote
+    s) Set configuration password
+    q) Quit config
+    n/s/q> n
+    name> dropbox-for-friends
+    Type of storage to configure.
+    Enter a string value. Press Enter for the default ("").
+    Choose a number from below, or type in your own value
+     1 / 1Fichier
+       \ "fichier"
+     2 / Alias for an existing remote
+       \ "alias"
+    [...]
+     8 / Dropbox
+       \ "dropbox"
+    [...]
+    31 / premiumize.me
+       \ "premiumizeme"
+    Storage> dropbox
+    ** See help for dropbox backend at: https://rclone.org/dropbox/ **
+
+    Dropbox App Client Id
+    Leave blank normally.
+    Enter a string value. Press Enter for the default ("").
+    client_id>
+    Dropbox App Client Secret
+    Leave blank normally.
+    Enter a string value. Press Enter for the default ("").
+    client_secret>
+    Edit advanced config? (y/n)
+    y) Yes
+    n) No
+    y/n> n
+    If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth
+    Log in and authorize rclone for access
+    Waiting for code...
+
+- At this point, this will open a browser and ask you to authorize ``rclone`` to
+  manage your Dropbox, or any other third-party service you have selected
+  in the interactive prompt. Accepting will bring you back into the terminal
+  to the final configuration prompts:
+
+.. code-block:: bash
+   :emphasize-lines: 12, 26
+
+   Got code
+   --------------------
+   [dropbox-for-friends]
+   type = dropbox
+   token = {"access_token":"meVHyc[...]",
+            "token_type":"bearer",
+            "expiry":"0001-01-01T00:00:00Z"}
+   --------------------
+   y) Yes this is OK
+   e) Edit this remote
+   d) Delete this remote
+   y/e/d> y
+   Current remotes:
+
+   Name                 Type
+   ====                 ====
+   dropbox-for-friends  dropbox
+
+   e) Edit existing remote
+   n) New remote
+   d) Delete remote
+   r) Rename remote
+   c) Copy remote
+   s) Set configuration password
+   q) Quit config
+   e/n/d/r/c/s/q> q
+
+- Once this is done, install ``git-annex-remote-rclone``.
+  It is a wrapper around `rclone <https://rclone.org>`__ that makes any   destination supported by rclone usable with :term:`git-annex`.
+  If you are on a recent version of Debian or Ubuntu (or have enabled the `NeuroDebian <https://neuro.debian.net>`_ repository), you can get it conveniently via your package manager, e.g., with ``sudo apt-get install git-annex-remote-rclone``.
+  Alternatively, ``git clone`` the `git-annex-remote-rclone <https://github.com/DanielDent/git-annex-remote-rclone>`_ repository to your machine (do not clone it into ``DataLad-101`` but somewhere else on your computer), and copy the path to this repository into your ``$PATH`` variable. If you
+  clone into ``/home/user-bob/repos``, the command would look like this [#f3]_::
+
+     $ git clone https://github.com/DanielDent/git-annex-remote-rclone.git
+     $ export PATH="/home/user-bob/repos/git-annex-remote-rclone:$PATH"
+
+- Finally, in the dataset you want to share, run the :command:`git annex initremote` command.
+  Give the remote a name (it is ``dropbox-for-friends`` here), and specify the name of  the remote you configured with ``rclone`` with the ``target`` parameters:
+
+.. code-block:: bash
+
+   $ git annex initremote dropbox-for-friends type=external externaltype=rclone chunk=50MiB encryption=none target=dropbox-for-friends prefix=my_awesome_dataset
+
+   initremote dropbox-for-friends ok
+   (recording state in git...)
+
+What has happened up to this point is that we have configured Dropbox
+as a third-party storage service for the annexed contents in the dataset.
+On a conceptual, dataset level, your Dropbox folder is now a :term:`sibling` -- the sibling name is the first positional argument after ``initremote``, i.e., "dropbox-for-friends":
+
+.. code-block:: bash
+
+   $ datalad siblings
+    .: here(+) [git]
+    .: dropbox-for-friends(+) [rclone]
+    .: roommate(+) [../mock_user/DataLad-101 (git)]
+
+On Dropbox, a new folder will be created for your annexed files.
+By default, this folder will be called ``git-annex``, but it can be configured using the ``--prefix=<whatitshouldbecalled>`` option, as done above.
+However, this directory on Dropbox is not the location you would refer your friend or a collaborator to.
+The representation of the files in the special-remote is not human-readable --
+it is a tree of annex objects, and thus looks like a bunch of very weirdly named
+folders and files to anyone.
+Through this design it becomes possible to chunk files into smaller units (see
+`the git-annex documentation <https://git-annex.branchable.com/chunking/>`_ for more on this),
+optionally encrypt content on its way from a local machine to a storage service
+(see `the git-annex documentation <https://git-annex.branchable.com/encryption/>`__ for more on this),
+and avoid leakage of information via file names. Therefore, the Dropbox remote is
+not a places a real person would take a look at, instead they are only meant to
+be managed and accessed via DataLad/git-annex.
+
+To actually share your dataset with someone, you need to *publish* it to Github,
+Gitlab, or a similar hosting service.
+
+.. index:: ! datalad command; create-sibling-github
+
+You could, for example, create a sibling of the ``DataLad-101`` dataset
+on GitHub with the command :command:`create-sibling-github`.
+This will create a new GitHub repository called "DataLad-101" under your account,
+and configure this repository as a :term:`sibling` of your dataset
+called ``github`` (exactly like you have done in :ref:`yoda_project`
+with the ``midterm_project`` subdataset).
+However, in order to be able to link the contents stored in Dropbox, you also need to
+configure a *publication dependency* to the ``dropbox-for-friends`` sibling -- this is
+done with the ``publish-depends <sibling>`` option.
+
+.. code-block:: bash
+
+   $ datalad create-sibling-github -d . DataLad-101 \
+     --publish-depends dropbox-for-friends
+     [INFO   ] Configure additional publication dependency on "dropbox-for-friends"
+     .: github(-) [https://github.com/<user-name>/DataLad-101.git (git)]
+     'https://github.com/<user-name>/DataLad-101.git' configured as sibling 'github' for <Dataset path=/home/me/dl-101/DataLad-101>
+
+:command:`datalad siblings` will again list all available siblings:
+
+.. code-block:: bash
+
+   $ datalad siblings
+    .: here(+) [git]
+    .: dropbox-for-friends(+) [rclone]
+    .: roommate(+) [../mock_user/DataLad-101 (git)]
+    .: github(-) [https://github.com/<user-name>/DataLad-101.git (git)]
+
+Note that each sibling has either a ``+`` or ``-`` attached to its name. This
+indicates the presence (``+``) or absence (``-``) of a remote data annex at this
+remote. You can see that your ``github`` sibling indeed does not have a remote
+data annex.
+Therefore, instead of "only" publishing to this GitHub repository (as done in section
+:ref:`yoda_project`), in order to also publish annex contents, we made
+publishing to GitHub dependent on the ``dropbox-for-friends`` sibling
+(that has a remote data annex), so that annexed contents are published
+there first.
+
+.. importantnote:: Publication dependencies are strictly local configuration
+
+   Note that the publication dependency is only established for your own dataset,
+   it is not shared with clones of the dataset. Internally, this configuration
+   is a key value pair in the section of your remote in ``.git/config``:
+
+   .. code-block:: bash
+
+      [remote "github"]
+         annex-ignore = true
+         url = https://github.com/<user-name>/DataLad-101.git
+         fetch = +refs/heads/*:refs/remotes/github/*
+         datalad-publish-depends = dropbox-for-friends
+
+With this setup, we can publish the dataset to GitHub. Note how the publication
+dependency is served first:
+
+.. code-block:: bash
+   :emphasize-lines: 2
+
+   $ datalad push --to github
+   [INFO   ] Transferring data to configured publication dependency: 'dropbox-for-friends'
+   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> data to dropbox-for-friends
+   publish(ok): books/TLCL.pdf (file)
+   publish(ok): books/byte-of-python.pdf (file)
+   publish(ok): books/progit.pdf (file)
+   publish(ok): recordings/interval_logo_small.jpg (file)
+   publish(ok): recordings/salt_logo_small.jpg (file)
+   [INFO   ] Publishing to configured dependency: 'dropbox-for-friends'
+   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> data to dropbox-for-friends
+   [INFO   ] Publishing <Dataset path=/home/me/dl-101/DataLad-101> to github
+   Username for 'https://github.com': <user-name>
+   Password for 'https://<user-name>@github.com':
+   publish(ok): . (dataset) [pushed to github: ['[new branch]', '[new branch]']]
+   action summary:
+     publish (ok: 6)
+
+
+Afterwards, your dataset can be found on GitHub, and ``cloned`` or ``installed``.
+
+
+From the perspective of whom you share your dataset with...
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your friend would now want to get your dataset including the annexed
+contents, and you made sure that they can access the Dropbox folder with
+the annexed files (e.g., by sharing an access link), here is what they would
+have to do:
+
+If the repository is on GitHub, a :command:`datalad clone` with the URL
+will install the dataset::
+
+   $ datalad clone https://github.com/<user-name>/DataLad-101.git
+   [INFO   ] Cloning https://github.com/<user-name>/DataLad-101.git [1 other candidates] into '/Users/awagner/Documents/DataLad-101'
+   [INFO   ]   Remote origin not usable by git-annex; setting annex-ignore
+   [INFO   ] access to 1 dataset sibling dropbox-for-friends not auto-enabled, enable with:
+   |         datalad siblings -d "/Users/awagner/Documents/DataLad-101" enable -s dropbox-for-friends
+   install(ok): /Users/awagner/Documents/DataLad-101 (dataset)
+
+Pay attention to one crucial information in this output::
+
+   [INFO   ] access to 1 dataset sibling dropbox-for-friends not auto-enabled, enable with:
+   |         datalad siblings -d "/Users/<user-name>/Documents/DataLad-101" enable -s dropbox-for-friends
+
+This means that someone who wants to access the data from dropbox needs to
+enable the special remote.
+For this,  this person first needs to install and configure ``rclone``
+as well: Since ``rclone`` is the protocol with which
+annexed data can be transferred from and to Dropbox, anyone who needs annexed
+data from Dropbox needs *this* special remote. Therefore, the first steps are
+the same as before:
+
+- `Install <https://rclone.org/install/>`__ ``rclone`` (as described above).
+- Run ``rclone config`` to configure ``rclone`` to work with Dropbox (as described above). **It is important to name the remote identically** - in the example above, it would need to be "dropbox-for-friends".
+  This means: You need to communicate the name of your special remote to your friend, and they have to give it the same name as the one configured in the dataset).
+  (There are efforts towards extracting this information automatically from datasets, but for the time being, this is an important detail to keep in mind).
+- install `git-annex-remote-rclone <https://github.com/DanielDent/git-annex-remote-rclone>`_ (as described above).
+
+After this is done, you can execute what DataLad's output message suggests
+to "enable" this special remote (inside of the installed ``DataLad-101``)::
+
+   $ datalad siblings -d "/Users/awagner/Documents/DataLad-101" \
+     enable -s dropbox-for-friends
+   .: dropbox-for-friends(?) [git]
+
+And once this is done, you can get any annexed file contents, for example the
+books, or the cropped logos from chapter :ref:`chapter_run`::
+
+   $ datalad get books/TLCL.pdf
+   get(ok): /home/some/other/user/DataLad-101/books/TLCL.pdf (file) [from dropbox-for-friends]
+
+.. rubric:: Footnotes
+
+.. [#f2] ``rclone`` is a useful special-remote for this example, because
+         you can not only use it for Dropbox, but also for many other
+         third-party hosting services.
+         For a complete overview of which third-party services are
+         available and which special-remote they need, please see this
+         `list <http://git-annex.branchable.com/special_remotes/>`_.
+
+.. [#f3] Note that ``export`` will extend your ``$PATH`` *for your current shell*.
+         This means you will have to repeat this command if you open a new shell.
+         Alternatively, you can insert this line into your shells configuration file
+         (e.g., ``~/.bashrc``) to make this path available to all future shells of
+         your user account.
+         If you are unsure what any of this means, take a look at :ref:`this additional information on environment variables <envvars>`

--- a/docs/basics/101-139-figshare.rst
+++ b/docs/basics/101-139-figshare.rst
@@ -1,0 +1,61 @@
+.. _figshare:
+
+Built-in data export
+^^^^^^^^^^^^^^^^^^^^
+
+Apart from flexibly configurable special remotes that allow publishing
+annexed content to a variety of third party infrastructure, DataLad also has
+some built-in support for "exporting" data to other services.
+This usually means that a static snapshot of your dataset and its files are shared
+in archives or collections of files.
+While an export of a dataset looses some of the advantages that a DataLad dataset has, for example a transparent version history, it can be a fast and simple way to make the most recent version of your dataset available or archived.
+
+One example is the command :command:`export-archive`.
+Running this command creates a ``.tar.gz`` file with the content of your dataset.
+This compressed archive can be uploaded to any data hosting portal manually.
+This moves data out of version control and decentralized tracking, and essentially "throws it over the wall" - while your data (also the annexed data) will be available for download from where you share it, none of the special features a DataLad dataset provides will be available, such as its history or configurations.
+
+Another example is :command:`export-to-figshare`.
+`Figshare <https://figshare.com/>`__ is an online open access repository where researchers can preserve and share their research outputs, including figures, datasets, or images - and thus everything that could potentially be managed in a Datalad dataset.
+Running :command:`datalad export-to-figshare` allows you to publish the dataset as a snapshot.
+Note that this requires a free account on Figshare, and the generation of an `access token <https://figshare.com/account/applications>`_ for authentication.
+An interactive prompt will ask you to supply authentication credentials, and guide you through the process of creating a new article.
+
+.. code-block:: bash
+   :emphasize-lines: 5
+
+   $ datalad export-to-figshare
+	[INFO   ] Exporting current tree as an archive under /home/me/DataLad-101 since figshare does not support directories
+	[INFO   ] Uploading /home/me/datalad_b1cbbaa9-dd5c-473e-8092-e911021f33cb.zip to figshare
+	Article
+	Would you like to create a new article to upload to?  If not - we will list existing articles (choices: yes, no): yes
+
+	New article
+	Please enter the title (must be at least 3 characters long). [abcd#b1cbbaa9-dd5c-473e-8092-e911021f33cb]: my-cool-dataset
+
+	[INFO   ] Created a new (private) article 16676764 at https://figshare.com/account/articles/16676764. Please visit it, enter additional meta-data and make public
+	[INFO   ] 'Registering' /home/me/datalad_b1cbbaa9-dd5c-473e-8092-e911021f33cb.zip within annex
+	[INFO   ] Adding URL https://ndownloader.figshare.com/files/30876682 for it
+	[INFO   ] Registering links back for the content of the archive
+	[INFO   ] Adding content of the archive /home/me/datalad_b1cbbaa9-dd5c-473e-8092-e911021f33cb.zip into annex AnnexRepo(/home/me/DataLad-101)
+	[INFO   ] Initiating special remote datalad-archives
+	[INFO   ] Finished adding /home/me/datalad_b1cbbaa9-dd5c-473e-8092-e911021f33cb.zip: Files processed: 4, removed: 4, +git: 2, +annex: 2
+	[INFO   ] Removing generated and now registered in annex archive
+	export_to_figshare(ok): Dataset(/home/me/DataLad-101) [Published archive https://ndownloader.figshare.com/files/30876682]
+
+
+
+The screenshot below shows how the ``DataLad-101`` dataset looks like in exported form:
+
+.. figure:: ../artwork/src/figshare_screenshot.png
+
+You could then extend the dataset with metadata, obtain a `DOI <https://www.doi.org/driven_by_DOI.html>`_ for it and make it citable, and point others to it in order to download it as an archive of files.
+
+Beyond this, as the command :command:`export-archive` is used by it to prepare content for upload to Figshare, annexed files also will be annotated as available from the archive on Figshare using ``datalad-archive`` special remote.
+As a result, if you publish your Figshare dataset and share your DataLad dataset on a repository hosting service without support for annexed files, users will still be able to fetch content from the tarball shared on Figshare.
+
+.. code-block:: bash
+
+   $ datalad siblings
+    .: here(+) [git]
+    .: datalad-archives(+) [datalad-archives]

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -1,7 +1,7 @@
 .. _gin:
 
-Dataset hosting on GIN
-----------------------
+Walk-through: Dataset hosting on GIN
+------------------------------------
 
 `GIN <https://gin.g-node.org/G-Node/Info/wiki>`__ (G-Node infrastructure) is a
 free data management system designed for comprehensive and reproducible management

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -40,40 +40,8 @@ In order to use GIN for hosting and sharing your datasets, you need to
 Once you have `registered <https://gin.g-node.org/user/sign_up>`_
 an account on the GIN server by providing your e-mail address, affiliation,
 and name, and selecting a user name and password, you should upload your
-:term:`SSH key` to allow SSH access.
-
-.. find-out-more:: What is an SSH key and how can I create one?
-
-   An SSH key is an access credential in the :term:`SSH` protocol that can be used
-   to login from one system to remote servers and services, such as from your private
-   computer to an :term:`SSH server`. For repository hosting services such as :term:`GIN`,
-   :term:`GitHub`, or :term:`GitLab`, it can be used to connect and authenticate
-   without supplying your username or password for each action.
-
-   This `tutorial by GitHub <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent>`_
-   is a detailed step-by-step instruction to generate and use SSH keys for authentication,
-   and it also shows you how to add your public SSH key to your GitHub account
-   so that you can install or clone datasets or Git repositories via ``SSH`` (in addition
-   to the ``http`` protocol), and the same procedure applies to GitLab and Gin.
-
-   Don't be intimidated if you have never done this before -- it is fast and easy:
-   First, you need to create a private and a public key (an SSH key pair).
-   All this takes is a single command in the terminal. The resulting files are
-   text files that look like someone spilled alphabet soup in them, but constitute
-   a secure password procedure.
-   You keep the private key on your own machine (the system you are connecting from,
-   and that **only you have access to**),
-   and copy the public key to the system or service you are connecting to.
-   On the remote system or service, you make the public key an *authorized key* to
-   allow authentication via the SSH key pair instead of your password. This
-   either takes a single command in the terminal, or a few clicks in a web interface
-   to achieve.
-   You should protect your SSH keys on your machine with a passphrase to prevent
-   others -- e.g., in case of theft -- to log in to servers or services with
-   SSH authentication [#f2]_, and configure an ``ssh agent``
-   to handle this passphrase for you with a single command. How to do all of this
-   is detailed in the above tutorial.
-
+:term:`SSH key` to allow SSH access
+(you can find an explanation of what SSH keys are and how you can create one in :ref:`this Findoutmore <fom-sshkey>` in the general section :ref:`share_hostingservice`).
 To do this, visit the settings of your user account. On the left hand side, select
 the tab "SSH Keys", and click the button "Add Key":
 
@@ -321,12 +289,6 @@ Afterwards, :command:`datalad get` retrieves files from Gin, even if the dataset
          `web interface <https://gin.g-node.org/G-Node/Info/wiki/WebInterface>`_
          and `client <https://gin.g-node.org/G-Node/Info/wiki/GinUsageTutorial>`_ are
          useful tools with a variety of features that are worthwhile to check out, as well.
-
-.. [#f2] Your private SSH key is incredibly valuable, and it is important to keep
-         it secret!
-         Anyone who gets your private key has access to anything that the public key
-         is protecting. If the private key does not have a passphrase, simply copying
-         this file grants a person access!
 
 .. [#f3] Alternatively, you can configure the siblings url with :command:`git config`::
 

--- a/docs/basics/101-139-gitlfs.rst
+++ b/docs/basics/101-139-gitlfs.rst
@@ -1,0 +1,48 @@
+.. _gitlfs:
+
+Walk-through: Git LFS as a special remote on GitHub
+---------------------------------------------------
+
+Some repository hosting services provide for-pay support for large files, and can thus be used as special remotes as well.
+GitHub and GitLab for example support `Git Large File Storage <https://github.com/git-lfs/git-lfs>`_ (Git LFS) for managing data files using Git.
+A free GitHub subscription allows up to `1GB of free storage and up to 1GB of bandwidth monthly <https://docs.github.com/en/github/managing-large-files/versioning-large-files/about-storage-and-bandwidth-usage>`_.
+As such, it might be sufficient for some use cases, and could be configured
+quite easily.
+
+In order to store annexed dataset contents on GitHub, we need first to create a repository on GitHub::
+
+    $ datalad create-sibling-github test-github-lfs
+    .: github(-) [https://github.com/yarikoptic/test-github-lfs.git (git)]
+    'https://github.com/yarikoptic/test-github-lfs.git' configured as sibling 'github' for <Dataset path=/tmp/test-github-lfs>
+
+and then initialize a :term:`special remote` of type ``git-lfs``, pointing to the same GitHub repository::
+
+    $ git annex initremote github-lfs type=git-lfs url=https://github.com/yarikoptic/test-github-lfs encryption=none embedcreds=no
+
+If you would like to compress data in Git LFS, you need to take a detour via
+encryption during :command:`git annex initremote` -- this has compression as a
+convenient side effect. Here is an example initialization::
+
+   $ git annex initremote --force github-lfs type=git-lfs url=https://github.com/yarikoptic/test-github-lfs encryption=shared
+
+With this single step it becomes possible to transfer contents to GitHub::
+
+    $ git annex copy --to=github-lfs file.dat
+    copy file.dat (to github-lfs...)
+    ok
+    (recording state in git...)
+
+and the entire dataset to the same GitHub repository::
+
+    $ datalad push --to=github
+    [INFO   ] Publishing <Dataset path=/tmp/test-github-lfs> to github
+    publish(ok): . (dataset) [pushed to github: ['[new branch]', '[new branch]']]
+
+Because the special remote URL coincides with the regular remote URL on GitHub,
+``siblings enable`` (as shown in the section :ref:`dropbox`) will not even be necessary when datalad is installed
+from GitHub.
+
+.. importantnote:: No drop from LFS
+
+   Unfortunately, it is impossible to :command:`drop` contents from Git LFS:
+   `help.github.com/en/github/managing-large-files <https://docs.github.com/en/github/managing-large-files/versioning-large-files/removing-files-from-git-large-file-storage#git-lfs-objects-in-your-repository>`_

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -8,4 +8,66 @@ Because DataLad datasets are :term:`Git` repositories, it is possible to
 :term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_,
 or `Gitea <https://gitea.io/en-us/>`_.
 
-These published datasets are ordinary :term:`sibling`\s of your dataset, and can be cloned by others depending on whether you make the repository public or private.
+
+How to add a sibling on a Git repository hosting site
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are multiple ways to create a dataset sibling on a repository hosting site to push your dataset to.
+
+
+The manual way
+""""""""""""""
+
+#. Create a new repository via the webinterface of the hosting service of your choice.
+   It does not need to have the same name as your local dataset, but it helps to associate local dataset and remote siblings.
+
+.. figure:: ../artwork/src/GIN_newrepo.png
+
+   Webinterface of :term:`gin` during the creation of a new repository.
+
+#. Afterwards, copy the :term:`SSH` URL of the repository. Usually, repository hosting services will provide you with a convenient way to copy it to your clipboard. An SSH URL takes the following form: ``git@<hosting-service>:/<user>/<repo-name>.git``. Note that almost all services will require you to use the SSH URL to your repository in order to do :command:`push` operations, so make sure to take the :term:`SSH` and not the :term:`HTTPS` URL.
+
+#. Make sure to have an :term:`SSH key` set up. This usually requires generating an SSH key pair if you do not have one yet, and uploading the public key to the repository hosting service.
+
+.. _sshkey:
+
+.. find-out-more:: What is an SSH key and how can I create one?
+   :name: fom-sshkey
+
+   An SSH key is an access credential in the :term:`SSH` protocol that can be used
+   to login from one system to remote servers and services, such as from your private
+   computer to an :term:`SSH server`. For repository hosting services such as :term:`GIN`,
+   :term:`GitHub`, or :term:`GitLab`, it can be used to connect and authenticate
+   without supplying your username or password for each action.
+
+   This `tutorial by GitHub <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent>`_
+   is a detailed step-by-step instruction to generate and use SSH keys for authentication,
+   and it also shows you how to add your public SSH key to your GitHub account
+   so that you can install or clone datasets or Git repositories via ``SSH`` (in addition
+   to the ``http`` protocol), and the same procedure applies to GitLab and Gin.
+
+   Don't be intimidated if you have never done this before -- it is fast and easy:
+   First, you need to create a private and a public key (an SSH key pair).
+   All this takes is a single command in the terminal. The resulting files are
+   text files that look like someone spilled alphabet soup in them, but constitute
+   a secure password procedure.
+   You keep the private key on your own machine (the system you are connecting from,
+   and that **only you have access to**),
+   and copy the public key to the system or service you are connecting to.
+   On the remote system or service, you make the public key an *authorized key* to
+   allow authentication via the SSH key pair instead of your password. This
+   either takes a single command in the terminal, or a few clicks in a web interface
+   to achieve.
+   You should protect your SSH keys on your machine with a passphrase to prevent
+   others -- e.g., in case of theft -- to log in to servers or services with
+   SSH authentication [#f2]_, and configure an ``ssh agent``
+   to handle this passphrase for you with a single command. How to do all of this
+   is detailed in the above tutorial.
+
+
+#. Use the SSH URL to add the repository as a sibling. There are two commands that allow you to do that; both require you give the sibling a name of your choice:
+
+   #. ``git remote add <name> <ssh-url>``
+   #. ``datalad siblings-add --dataset . --name <name> --url <ssh-url>``
+
+#. Push your dataset to the new sibling.

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -25,7 +25,7 @@ Even though the dataset sibling on GitHub does not serve the data, it constitute
     $ datalad siblings
     .: here(+) [git]
     .: mddatasrc(+) [http://psydata.ovgu.de/studyforrest/phase2/.git (git)]
-    .: upstream(-) [git@github.com:psychoinformatics-de/studyforrest-data-phase2.git (git)]
+    .: origin(-) [git@github.com:psychoinformatics-de/studyforrest-data-phase2.git (git)]
 
 
 There are multiple ways to create a dataset sibling on a repository hosting site to push your dataset to.

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -16,7 +16,7 @@ As outlined in a number of sections before, Git repository hosting sites typical
 Depending on whether or not an annex is supported, you can push either only your Git history to the sibling, or the complete dataset including annexed file contents.
 You can find out whether a sibling on a remote hosting services carries an annex or not by running the :command:`datalad siblings` command.
 A ``+``, ``-``, or ``?`` sign in parenthesis indicates whether the sibling carries an annex, does not carry an annex, or whether this information isn't yet known.
-In the example below you can see that a public GitHub repository `<https://github/psychoinformatics/studyforrest-data-phase2>`_ does not carry an annex on ``github``, but that the annexed data are served from an additional sibling ``mddatasrc`` (a :term:`special remote`).
+In the example below you can see that a public GitHub repository `<https://github/psychoinformatics/studyforrest-data-phase2>`_ does not carry an annex on ``github`` (the sibling ``origin``), but that the annexed data are served from an additional sibling ``mddatasrc`` (a :term:`special remote` with annex support).
 Even though the dataset sibling on GitHub does not serve the data, it constitutes a simple, findable access point to retrieve the dataset, and can be used to provide updates and fixes via :term:`pull request`\s, issues, etc.
 
 .. code-block:: bash
@@ -157,7 +157,9 @@ If you have an :term:`SSH key` configured, it is useful to specify ``--access`` 
 The command :command:`datalad create-sibling-github` requires a personal access token from GitHub (see the :ref:`paragraph on authentication tokens below for more information <token>`).
 When you are using it for the first time, you should be queried interactively for it.
 Subsequently, your token should be stored internally.
-If you have an :term:`SSH key` configured, it is useful to specify ``--access-protocol`` as ``ssh`` -- this saves you the need to authenticate with every ``push``.
+
+By default, the URL that is set up for you is an :term:`HTTPS` URL.
+If you have an :term:`SSH key` configured, it is useful to specify ``--access-protocol`` as ``ssh`` -- with this the :term:`SSH` URL is configured, saving you the need to authenticate with every ``push``.
 
 .. code-block:: bash
 
@@ -207,7 +209,11 @@ Each command is slightly tuned towards the peculiarities of each particular plat
 Other streamlined arguments, such as ``--recursive`` or ``--publish-depends`` allow you to perform more complex configurations, for example publication of dataset hierarchies or connections to :term:`special remote`\s. Upcoming walk-throughs will demonstrate them.
 
 Self-hosted repository services, e.g., Gogs or Gitea instances, have an additional required argument, the ``--api`` flag.
-It needs to point to the URL of the instance, for example ``datalad create-sibling-gogs my_repo_on_gogs  --api "https://try.gogs.io"``
+It needs to point to the URL of the instance, for example
+
+.. code-block:: bash
+
+   $ datalad create-sibling-gogs my_repo_on_gogs  --api "https://try.gogs.io"
 
 
 .. _token:
@@ -258,7 +264,7 @@ Should you employ GitHub workflows, for example, a token without "workflow" scop
 
 
 .. [#f1] Many repository hosting services have useful features to make your work citeable.
-         For example, :term:`gin` is able to assign a :term:`DOI` to your dataset, and GitHub allows ``CITATION.cff`` files.
+         For example, :term:`gin` is able to assign a :term:`DOI` to your dataset, and GitHub allows ``CITATION.cff`` files. At the same time, archival services such as `Zenodo <https://zenodo.org/>`_ often integrate with published repositories, allowing you to preserve your dataset with them.
 
 .. [#f2] Your private SSH key is incredibly valuable, and it is important to keep
          it secret!

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -117,25 +117,25 @@ Please consult the ``python-gitlab`` `documentation <https://python-gitlab.readt
 .. code-block::
 
 	[global]
-	default = jugit
+	default = gitlab
 	ssl_verify = true
 	timeout = 5
 
-	[jugit]
-	url = https://jugit.fz-juelich.de
+	[gitlab]
+	url = https://gitlab.myinstance.com
 	private_token = <super-secret-token>
 	api_version = 4
 
-This configures the default GitLab instance (here, we have called it ``jugit``) with a specific base URL and the user's personal access token for authentication.
+This configures the default GitLab instance (here, we have called it ``gitlab``) with a specific base URL and the user's personal access token for authentication.
 Note that you will need to generate and retrieve your own personal access token under the profile settings of the gitlab instance of your choice (see the :ref:`paragraph on authentication tokens below for more information <token>`).
-With this configuration, the ``--site`` parameter can identify the GitLab instance by its name ``jugit``.
+With this configuration, the ``--site`` parameter can identify the GitLab instance by its name ``gitlab``.
 If you have an :term:`SSH key` configured, it is useful to specify ``--access`` as ``ssh`` -- this saves you the need to authenticate with every ``push``:
 
 .. code-block:: bash
 
    $ datalad create-sibling-gitlab \
      -d . \              	# current dataset
-     --site jugit \      	# to the configured GitLab instance
+     --site gitlab \      	# to the configured GitLab instance
      --project DataLad-101 \	# repository name
      --layout flat \
      --access ssh 		# optional, but useful
@@ -146,8 +146,8 @@ If you have an :term:`SSH key` configured, it is useful to specify ``--access`` 
 	  create_sibling_gitlab (ok: 1)
    $ datalad siblings
      here(+) [git]
-	 jugit(-) [git@jugit.fz-juelich.de:adswa/DataLad-101.git (git)]
-   $ datalad push --to jugit
+	 jugit(-) [git@gitlab.myinstance.com:<user>/<repo>.git (git)]
+   $ datalad push --to gitlab
 	publish(ok): . (dataset)
 	action summary:
 	  publish (ok: 1)

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -1,0 +1,11 @@
+.. _share_hostingservice:
+
+Publishing datasets to Git repository hosting
+---------------------------------------------
+
+Because DataLad datasets are :term:`Git` repositories, it is possible to
+:command:`push` datasets to any Git repository hosting service, such as
+:term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_,
+or `Gitea <https://gitea.io/en-us/>`_.
+
+These published datasets are ordinary :term:`sibling`\s of your dataset, and can be cloned by others depending on whether you make the repository public or private.

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -5,18 +5,34 @@ Publishing datasets to Git repository hosting
 
 Because DataLad datasets are :term:`Git` repositories, it is possible to
 :command:`push` datasets to any Git repository hosting service, such as
-:term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_,
-or `Gitea <https://gitea.io/en-us/>`_.
+:term:`GitHub`, :term:`GitLab`, :term:`Gin`, :term:`Bitbucket`, `Gogs <https://gogs.io/>`_, or `Gitea <https://gitea.io/en-us/>`_.
+These published datasets are ordinary :term:`sibling`\s of your dataset, and among other advantages, they can constitute a back-up, an entry-point to retrieve your dataset for others or yourself, the backbone for collaboration on datasets, or the means to enhance visibility, findability and citeability of your work [#f1]_.
+This section contains a brief overview on how to publish your dataset to different services.
 
+Git repository hosting and annexed data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-How to add a sibling on a Git repository hosting site
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+As outlined in a number of sections before, Git repository hosting sites typically do not support dataset annexes - some, like :term:`gin` however, do.
+Depending on whether or not an annex is supported, you can push either only your Git history to the sibling, or the complete dataset including annexed file contents.
+You can find out whether a sibling on a remote hosting services carries an annex or not by running the :command:`datalad siblings` command.
+A ``+``, ``-``, or ``?`` sign in parenthesis indicates whether the sibling carries an annex, does not carry an annex, or whether this information isn't yet known.
+In the example below you can see that a public GitHub repository `<https://github/psychoinformatics/studyforrest-data-phase2>`_ does not carry an annex on ``github``, but that the annexed data are served from an additional sibling ``mddatasrc`` (a :term:`special remote`).
+Even though the dataset sibling on GitHub does not serve the data, it constitutes a simple, findable access point to retrieve the dataset, and can be used to provide updates and fixes via :term:`pull request`\s, issues, etc.
+
+.. code-block:: bash
+
+    # a clone of github/psychoinformatics/studyforrest-data-phase2 has the following siblings:
+    $ datalad siblings
+    .: here(+) [git]
+    .: mddatasrc(+) [http://psydata.ovgu.de/studyforrest/phase2/.git (git)]
+    .: upstream(-) [git@github.com:psychoinformatics-de/studyforrest-data-phase2.git (git)]
+
 
 There are multiple ways to create a dataset sibling on a repository hosting site to push your dataset to.
 
+How to add a sibling on a Git repository hosting site: The manual way
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The manual way
-""""""""""""""
 
 #. Create a new repository via the webinterface of the hosting service of your choice.
    It does not need to have the same name as your local dataset, but it helps to associate local dataset and remote siblings.
@@ -71,3 +87,175 @@ The manual way
    #. ``datalad siblings-add --dataset . --name <name> --url <ssh-url>``
 
 #. Push your dataset to the new sibling.
+
+
+How to add a sibling on a Git repository hosting site: The automated way
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+DataLad provides ``create-sibling-*`` commands to automatically create datasets on certain hosting sites.
+DataLad versions ``0.16.0`` and higher contain more of these commands, and provide a more streamlined parametrization.
+Please read the paragraph that matches your version of DataLad below, and be mindful of a change in command arguments between DataLad versions ``0.15.x`` and ``0.16.x``.
+
+Using DataLad version < 0.16.0
+""""""""""""""""""""""""""""""
+
+If you are using DataLad version below ``0.16.0``, you can automatically create new repositories from the command line for :term:`GitHub` and :term:`GitLab` using the commands :command:`datalad create-sibling-github` and :command:`datalad create-sibling-gitlab`.
+Due to the different representation of repositories on the two sites, the two commands are parametrized differently, and it is worth to consult each command's :term:`manpage` or ``--help``, but below are basic usage examples for the two commands:
+
+**GitLab:**
+Using :command:`datalad create-sibling-gitlab` is easiest with a ``python-gitlab`` configuration.
+Please consult the ``python-gitlab`` `documentation <https://python-gitlab.readthedocs.io/en/stable/cli-usage.html#configuration>`_ for details, but a basic configuration in the file ``~/.python-gitlab.cfg`` can look like this:
+
+.. code-block::
+
+	[global]
+	default = jugit
+	ssl_verify = true
+	timeout = 5
+
+	[jugit]
+	url = https://jugit.fz-juelich.de
+	private_token = <super-secret-token>
+	api_version = 4
+
+This configures the default GitLab instance (here, we have called it ``jugit``) with a specific base URL and the user's personal access token for authentication.
+Note that you will need to generate and retrieve your own personal access token under the profile settings of the gitlab instance of your choice (see the :ref:`paragraph on authentication tokens below for more information <token>`).
+With this configuration, the ``--site`` parameter can identify the GitLab instance by its name ``jugit``.
+If you have an :term:`SSH key` configured, it is useful to specify ``--access`` as ``ssh`` -- this saves you the need to authenticate with every ``push``:
+
+.. code-block:: bash
+
+   $ datalad create-sibling-gitlab \
+     -d . \              	# current dataset
+     --site jugit \      	# to the configured GitLab instance
+     --project DataLad-101 \	# repository name
+     --layout flat \
+     --access ssh 		# optional, but useful
+	create_sibling_gitlab(ok): . (dataset)
+	configure-sibling(ok): . (sibling)
+	action summary:
+	  configure-sibling (ok: 1)
+	  create_sibling_gitlab (ok: 1)
+   $ datalad siblings
+     here(+) [git]
+	 jugit(-) [git@jugit.fz-juelich.de:adswa/DataLad-101.git (git)]
+   $ datalad push --to jugit
+	publish(ok): . (dataset)
+	action summary:
+	  publish (ok: 1)
+
+
+**GitHub:**
+The command :command:`datalad create-sibling-github` requires a personal access token from GitHub (see the :ref:`paragraph on authentication tokens below for more information <token>`).
+When you are using it for the first time, you should be queried interactively for it.
+Subsequently, your token should be stored internally.
+If you have an :term:`SSH key` configured, it is useful to specify ``--access-protocol`` as ``ssh`` -- this saves you the need to authenticate with every ``push``.
+
+.. code-block:: bash
+
+    $ datalad create-sibling-github \
+      -d . \ 				# current dataset
+      DataLad-101 \     		# repository name
+      --access-protocol ssh 		# optional, but useful
+    You need to authenticate with 'github' credentials. https://github.com/settings/tokens provides information on how to gain access
+    token: <my-super-secret-token>
+    create_sibling_github(ok): . (dataset) [Dataset sibling 'github', project at https://github.com/adswa/DataLad-101.git]
+    configure-sibling(ok): . (sibling)
+    action summary:
+      configure-sibling (ok: 1)
+      create_sibling_github (ok: 1)
+    $ datalad push --to github
+    publish(ok): . (dataset)
+    action summary:
+      publish (ok: 1)
+
+
+Using DataLad version 0.16.0 and higher
+"""""""""""""""""""""""""""""""""""""""
+
+Starting with DataLad version ``0.16.0`` or higher, you can automatically create new repositories from the command line for :term:`GitHub`, :term:`GitLab`, :term:`gin`, `Gogs <https://gogs.io/>`__, or `Gitea <https://gitea.io/en-us/>`__.
+This is implemented with a new set of commands called :command:`create-sibling-github`, :command:`create-sibling-gitlab`, :command:`create-sibling-gin`, :command:`create-sibling-gogs`, and :command:`create-sibling-gitea`.
+
+.. gitusernote:: Get DataLad features ahead of time by installing from a commit
+
+   If you want to get this feature ahead of the ``0.16.0`` release, you can install the most recent version of the :term:`master` :term:`branch` or a specific :term:`commit` hash from GitHub, for example with
+
+   .. code-block::
+
+      $ pip install git+git://github.com/datalad/datalad.git@master
+
+   When getting features ahead of time, your feedback is especially valuable. If you find that something
+   does not work, or if you have an idea for improvements, please `get in touch <https://github.com/datalad/datalad/issues/new>`_.
+
+Each command is slightly tuned towards the peculiarities of each particular platform, but the most important common parameters are streamlined across commands as follows:
+
+- ``[REPONAME]`` (required): The name of the repository on the hosting site. It will be created under a user's namespace, unless this argument includes an organization name prefix. For example, ``datalad create-sibling-github my-awesome-repo`` will create a new repository under ``github.com/<user>/my-awesome-repo``, while ``datalad create-sibling-github <orgname>/my-awesome-repo`` will create a new repository of this name under the GitHub organization ``<orgname>`` (given appropriate permissions).
+- ``-s/--name <name>`` (required): A name under which the sibling is identified. By default, it will be based on or similar to the hosting site. For example, the sibling created with ``datalad create-sibling-github`` will  be called ``github`` by default.
+- ``--credential <name>`` (optional): Credentials used for authentication are stored internally by DataLad under specific names. These names allow you to have multiple credentials, and flexibly decide which one to use. When ``--credential <name>`` is the name of an existing credential, DataLad tries to authenticate with the specified credential; when it does not yet exist DataLad will prompt interactively for a credential, such as an access token, and store it under the given ``<name>`` for future authentications. By default, DataLad will name a credential according to the hosting service URL it used for, for example ``datalad-api.github.com`` as the default for credentials used to authenticate against GitHub.
+- ``--access-protocol {https|ssh|https-ssh}`` (default ``https``): Whether to use :term:`SSH` or :term:`HTTPS` URLs, or a hybrid version in which HTTPS is used to *pull* and SSH is used to *push*. Using :term:`SSH` URLs requires an :term:`SSH key` setup, but is a very convenient authentication method, especially when pushing updates -- which would need manual input on user name and token with every ``push`` over HTTPS.
+- ``--dry-run`` (optional): With this flag set, the command will not actually create the target repository, but only perform tests for name collisions and report repository name(s).
+- ``--private`` (optional): A switch that, if set, makes sure that the created repository is private.
+
+Other streamlined arguments, such as ``--recursive`` or ``--publish-depends`` allow you to perform more complex configurations, for example publication of dataset hierarchies or connections to :term:`special remote`\s. Upcoming walk-throughs will demonstrate them.
+
+Self-hosted repository services, e.g., Gogs or Gitea instances, have an additional required argument, the ``--api`` flag.
+It needs to point to the URL of the instance, for example ``datalad create-sibling-gogs my_repo_on_gogs  --api "https://try.gogs.io"``
+
+
+.. _token:
+
+Authentication by token
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To create or update repositories on remote hosting services you will need to set up appropriate authentication and permissions.
+In most cases, this will be in the form of an authorization token with a specific permission scope.
+
+What is a token?
+""""""""""""""""
+
+Personal access tokens are an alternative to authenticating via your password, and take the form of a long character string, associated with a human-readable name or description.
+If you are prompted for ``username`` and ``password`` in the command line, you would enter your token in place of the ``password`` [#f3]_.
+Note that you do not have to type your token at every authentication -- your token will be stored on your system the first time you have used it and automatically reused whenever relevant.
+
+.. find-out-more:: How does the authentication storage work?
+
+   Passwords, user names, tokens, or any other login information is stored in
+   your system's (encrypted) `keyring <https://en.wikipedia.org/wiki/GNOME_Keyring>`_.
+   It is a built-in credential store, used in all major operating systems, and
+   can store credentials securely.
+
+You can have multiple tokens, and each of them can get a different scope of permissions, but it is important to treat your tokens like passwords and keep them secret.
+
+Which permissions do they need?
+"""""""""""""""""""""""""""""""
+
+The most convenient way to generate tokens is typically via the webinterface of the hosting service of your choice.
+Often, you can specifically select which set of permissions a specific token has in a drop-down menu similar (but likely not identical) to this screenshot from GitHub:
+
+.. figure:: ../artwork/src/github-token.png
+
+   Webinterface to generate an authentication token on GitHub. One typically has to set a name and
+   permission set, and potentially an expiration date.
+
+For creating and updating repositories with DataLad commands it is usually sufficient to grant only repository-related permissions.
+However, broader permission sets may also make sense.
+Should you employ GitHub workflows, for example, a token without "workflow" scope could not push changes to workflow files, resulting in errors like this one::
+
+    [remote rejected] (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/benchmarks.yml` without `workflow` scope)]
+
+
+
+
+.. rubric:: Footnotes
+
+
+.. [#f1] Many repository hosting services have useful features to make your work citeable.
+         For example, :term:`gin` is able to assign a :term:`DOI` to your dataset, and GitHub allows ``CITATION.cff`` files.
+
+.. [#f2] Your private SSH key is incredibly valuable, and it is important to keep
+         it secret!
+         Anyone who gets your private key has access to anything that the public key
+         is protecting. If the private key does not have a passphrase, simply copying
+         this file grants a person access!
+
+.. [#f3]  GitHub `deprecated user-password authentication <https://developer.github.com/changes/2020-02-14-deprecating-password-auth/>`_ and only supports authentication via personal access token from November 13th 2020 onwards. Supplying a password instead of a token will fail to authenticate.

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -49,6 +49,9 @@ How to add a sibling on a Git repository hosting site: The manual way
 
 		Webinterface of :term:`github` during the creation of a new repository.
 
+#. Afterwards, copy the :term:`SSH` or :term:`HTTPS` URL of the repository. Usually, repository hosting services will provide you with a convenient way to copy it to your clipboard. An SSH URL takes the form ``git@<hosting-service>:/<user>/<repo-name>.git`` and an HTTPS URL takes the form ``https://<hosting-service>/<user>/<repo-name>.git``. The type of URL you choose determines whether and how you will be able to ``push`` to your repository. Note that many services will require you to use the SSH URL to your repository in order to do :command:`push` operations, so make sure to take the :term:`SSH` and not the :term:`HTTPS` URL if this is the case.
+
+#. If you pick the :term:`SSH` URL, make sure to have an :term:`SSH key` set up. This usually requires generating an SSH key pair if you do not have one yet, and uploading the public key to the repository hosting service.
 
 .. _sshkey:
 
@@ -86,12 +89,12 @@ How to add a sibling on a Git repository hosting site: The manual way
    is detailed in the above tutorial.
 
 
-#. Use the SSH URL to add the repository as a sibling. There are two commands that allow you to do that; both require you give the sibling a name of your choice:
+#. Use the URL to add the repository as a sibling. There are two commands that allow you to do that; both require you give the sibling a name of your choice (common name choices are ``upstream``, or a short-cut for your user name or the hosting platform, but its completely up to you to decide):
 
-   #. ``git remote add <name> <ssh-url>``
-   #. ``datalad siblings-add --dataset . --name <name> --url <ssh-url>``
+   #. ``git remote add <name> <url>``
+   #. ``datalad siblings-add --dataset . --name <name> --url <url>``
 
-#. Push your dataset to the new sibling.
+#. Push your dataset to the new sibling: ``datalad push --to <name>``
 
 
 How to add a sibling on a Git repository hosting site: The automated way

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -37,13 +37,18 @@ How to add a sibling on a Git repository hosting site: The manual way
 #. Create a new repository via the webinterface of the hosting service of your choice.
    It does not need to have the same name as your local dataset, but it helps to associate local dataset and remote siblings.
 
-.. figure:: ../artwork/src/GIN_newrepo.png
+.. find-out-more:: The webinterface for Gin
 
-   Webinterface of :term:`gin` during the creation of a new repository.
+	.. figure:: ../artwork/src/GIN_newrepo.png
 
-#. Afterwards, copy the :term:`SSH` URL of the repository. Usually, repository hosting services will provide you with a convenient way to copy it to your clipboard. An SSH URL takes the following form: ``git@<hosting-service>:/<user>/<repo-name>.git``. Note that almost all services will require you to use the SSH URL to your repository in order to do :command:`push` operations, so make sure to take the :term:`SSH` and not the :term:`HTTPS` URL.
+	   Webinterface of :term:`gin` during the creation of a new repository.
 
-#. Make sure to have an :term:`SSH key` set up. This usually requires generating an SSH key pair if you do not have one yet, and uploading the public key to the repository hosting service.
+.. find-out-more:: The webinterface of GitHub
+
+	.. figure:: ../artwork/src/newrepo-github.png
+
+		Webinterface of :term:`github` during the creation of a new repository.
+
 
 .. _sshkey:
 

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -37,17 +37,13 @@ How to add a sibling on a Git repository hosting site: The manual way
 #. Create a new repository via the webinterface of the hosting service of your choice.
    It does not need to have the same name as your local dataset, but it helps to associate local dataset and remote siblings.
 
-.. find-out-more:: The webinterface for Gin
+.. figure:: ../artwork/src/GIN_newrepo.png
 
-	.. figure:: ../artwork/src/GIN_newrepo.png
+   Webinterface of :term:`gin` during the creation of a new repository.
 
-	   Webinterface of :term:`gin` during the creation of a new repository.
+.. figure:: ../artwork/src/newrepo-github.png
 
-.. find-out-more:: The webinterface of GitHub
-
-	.. figure:: ../artwork/src/newrepo-github.png
-
-		Webinterface of :term:`github` during the creation of a new repository.
+	Webinterface of :term:`github` during the creation of a new repository.
 
 #. Afterwards, copy the :term:`SSH` or :term:`HTTPS` URL of the repository. Usually, repository hosting services will provide you with a convenient way to copy it to your clipboard. An SSH URL takes the form ``git@<hosting-service>:/<user>/<repo-name>.git`` and an HTTPS URL takes the form ``https://<hosting-service>/<user>/<repo-name>.git``. The type of URL you choose determines whether and how you will be able to ``push`` to your repository. Note that many services will require you to use the SSH URL to your repository in order to do :command:`push` operations, so make sure to take the :term:`SSH` and not the :term:`HTTPS` URL if this is the case.
 

--- a/docs/basics/101-139-privacy.rst
+++ b/docs/basics/101-139-privacy.rst
@@ -21,6 +21,7 @@ Thus, make sure to always manage sensitive files with :term:`git-annex`, even if
 Having the file annexed allows you to specifically not share its contents, even when you make your dataset publicly available.
 However, it is highly important to realize that while annexed file's *contents* are not saved into Git, annex file's *names* are.
 If private information such as a medical patients non-anonymized ID or other potentially identifying information becomes a part of the file name, this information is exposed in the Git history of the dataset.
+Keep in mind that this applies even if you renamed the file.
 
 .. find-out-more:: Help! I accidentally saved sensitive information to Git!
 

--- a/docs/basics/101-139-privacy.rst
+++ b/docs/basics/101-139-privacy.rst
@@ -1,0 +1,71 @@
+.. _privacy:
+
+Keeping (some) dataset contents private
+---------------------------------------
+
+Datasets can contain information that you don't want to share with others.
+Maybe the collection of pictures from your team-building event also contains those after-hour photos where you drunkenly kidnapped a tram.
+Or you are handling data with strict privacy requirements, such as patient data or
+medical imaging files.
+Whatever it may be, this short section summarizes strategies that help you to ensure
+to private information is not leaked, even when you publicly share datasets that contain it.
+
+Strategy 1: Never save private information to Git
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The most important strategy to keep in mind in handling datasets with potentially sensitive information is to **never save sensitive information into Git**. **NEVER**.
+Saving sensitive information into a dataset or Git repository that you intend to share is the equivalent of including your account password as an attachment to every email you write -- you don't necessarily point out that there is private information, but it lies around for everyone to accidentally find.
+Once a file with sensitive contents has been saved in the version history, sharing this dataset may accidentally expose the sensitive information even if it has been removed in the most recent version -- the transparent revision history of a dataset allows to simply restore the file.
+
+Thus, make sure to always manage sensitive files with :term:`git-annex`, even if the file is just a small text file.
+Having the file annexed allows you to specifically not share its contents, even when you make your dataset publicly available.
+However, it is highly important to realize that while annexed file's *contents* are not saved into Git, annex file's *names* are.
+If private information such as a medical patients non-anonymized ID or other potentially identifying information becomes a part of the file name, this information is exposed in the Git history of the dataset.
+
+.. find-out-more:: Help! I accidentally saved sensitive information to Git!
+
+	The only lasting way to remove contents from the dataset history completely is to substantially rewrite the dataset's history via tools such as ``git-filter-repo`` or ``git filter-branch``, two very dangerous and potentially destructive operations.
+	If you ever need to go there, the advanced section :ref:`cleanup` contains a paragraph on "Getting contents out of Git".
+
+Strategy 2: Restrict access via third party service or file system permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you have a dataset and only authorized actors should be allowed to access it,
+it is possible to set access restrictions simply via choice of (third party) storage permissions.
+When it is an access restricted dataset on shared infrastructure, for example a scientific dataset that only researchers who signed a data usage agreement should have access to, it could suffice to create specific `Unix groups <https://en.wikipedia.org/wiki/Group_identifier>`_ with authorized users, and give only those groups the necessary permissions.
+Depending on what permissions are set, unauthorized actors would not be able to retrieve file contents, or be able to clone the dataset at all.
+
+The ability of repository hosting services to make datasets private and only allow select collaborators access is yet another method of keeping complete datasets as private as necessary, even though you should think twice on whether or not you should host sensitive repositories at all on these services.
+
+One method to exert potentially fine-grained access control over file contents is via choice of (third party) hosting service for some or all annexed file contents.
+If you chose a service only selected people have access to, and publish annexed contents exclusively there, then only those selected people can perform a successful :command:`datalad get`.
+For example, when it is a dataset with content hosted on third party cloud storage such as S3 buckets, permission settings in the storage locations would allow data providers to specify or limit who is able to retrieve the file contents.
+An example for this is the usecase :ref:`usecase_hcp_dataset`, where file contents from the human connectome project can only be retrieved when a user has obtained the necessary credentials first.
+
+
+Strategy 3: Selective publishing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If it is individual files that you do not want to share, you can selectively publish the contents of all files you want others to have, and withhold the data of the files you do not want to share.
+This can be done by providing paths to the data that should be published, or a `git-annex-wanted <https://git-annex.branchable.com/git-annex-wanted/>`_ configuration and the ``--data auto`` option.
+
+Let's say you have a dataset with three files:
+
+- ``experiment.txt``
+- ``subject_1.dat``
+- ``subject_2.data``
+
+Consider that all of these files are annexed. While the information in ``experiment.txt`` is fine for everyone to see, ``subject_1.dat`` and ``subject_2.dat`` contain personal and potentially identifying data that can not be shared.
+Nevertheless, you want collaborators to know that these files exist.
+By publishing only the file contents of ``experiment.txt`` with
+
+.. code-block:: bash
+
+  $ datalad push --to github experiment.txt
+
+only meta data about file availability of ``subject_1.dat`` and ``subject_2.dat`` exists, but as these files' annexed data is not published, a :command:`datalad get`
+will fail.
+Note, though, that :command:`push` will publish the complete dataset history (unless you specify a commit range with the ``--since`` option -- see the `manual <http://docs.datalad.org/en/latest/generated/man/datalad-push.html>`_ for more information).
+
+
+

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -357,6 +357,73 @@ and :command:`get` all annexed file content successfully from the ``public-s3`` 
 Congrats!
 
 
+Advanced examples
+^^^^^^^^^^^^^^^^^
+
+When there is a lot to upload, automation is your friend.
+Below, we try to collect a few real world examples that go beyond toy examples.
+Do you have one and want to share it with the world as well? Please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_!
+
+Automated uploads of dataset hierarchies
+""""""""""""""""""""""""""""""""""""""""
+
+The script below is a quick-and-dirty solution to the task of exporting a hierarchy of datasets to an S3 bucket.
+I needs to be invoked with three positional arguments, the path to the :term:`DataLad superdataset`, the S3 bucket name, and a prefix.
+
+.. code-block:: bash
+
+	#!/bin/bash
+
+	set -eu
+
+	export PS4='> '
+	set -x
+
+	topds="$1"
+	bucket="$2"
+	prefix="$3"
+
+	# TEMP
+	srname="${bucket}5"
+
+	topdsfull=$PWD/$topds/
+
+	if ! git annex version | grep 8.2021 ; then
+		echo "E: need recent git annex. check what you have"
+		exit 1
+	fi
+
+	{ echo "$topdsfull"; datalad -f '{path}' subdatasets -r -d "$topds"; } | \
+	while read ds; do
+		relds=$(relpath "$ds" "$topdsfull")
+		fileprefix="$prefix/$relds/"
+		fileprefix=$(python -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$fileprefix")
+		echo $relds;
+		(
+			cd "$ds";
+			# TODO: make sure that there is no ./ or // in fileprefix
+			if ! git remote | grep -q "$srname"; then
+				git annex initremote --debug "$srname" \
+					type=S3 \
+					autoenable=true \
+					bucket=$bucket \
+					encryption=none \
+					exporttree=yes \
+					"fileprefix=$fileprefix/" \
+					host=s3.amazonaws.com \
+					partsize=1GiB \
+					port=80 \
+					"publicurl=https://s3.amazonaws.com/$bucket" \
+					public=yes \
+					versioning=yes
+			fi
+			git annex export --to "$srname" --jobs 6 master
+
+		)
+	done
+
+
+
 .. [#f5] Instead of using GitHub's WebUI you could also obtain a token using the command line GitHub interface (https://github.com/sociomantic-tsunami/git-hub) by running ``git hub setup`` (if no 2FA is used).
    If you decide to use the command line interface, here is help on how to use it:
    Clone the `GitHub repository <https://github.com/sociomantic-tsunami/git-hub>`_ to your local computer.

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -274,12 +274,8 @@ on GitHub, which required preconfigured GitHub authentication details.
 
    To ensure successful authentication, please create a personal access token at `github.com/settings/tokens <https://github.com/settings/tokens>`_ [#f5]_, and either
 
-   * configure Git's "``hub.oauthtoken``" config variable [#f7]_ with your token as in::
-
-        git config --global --add hub.oauthtoken cd2a3bd530...454f73b5a4
-
    * supply the token with the argument ``--github-login <TOKEN>`` from the command line,
-   * or supply the token from the command line when queried interactively for it
+   * or supply the token from the command line when queried for a password
 
 
 The creation of the sibling (named ``github``) can also be confirmed with :command:`datalad siblings`:
@@ -430,5 +426,3 @@ I needs to be invoked with three positional arguments, the path to the :term:`Da
    Clone the `GitHub repository <https://github.com/sociomantic-tsunami/git-hub>`_ to your local computer.
    Decide whether you want to build a Debian package to install, or install the single-file Python script distributed in the repository.
    Make sure that all `requirements <https://github.com/sociomantic-tsunami/git-hub>`_ for your preferred version are installed , and run either ``make deb`` followed by ``sudo dpkg -i deb/git-hub*all.deb``, or ``make install``.
-
-.. [#f7] To re-read about Git's configurations and the ``git config`` command, please take a look at the section :ref:`config`.

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -1,7 +1,7 @@
 .. _s3:
 
-Amazon S3 as a special remote
------------------------------
+Walk-through: Amazon S3 as a special remote
+-------------------------------------------
 
 `Amazon S3 <https://aws.amazon.com/s3/>`_ (or Amazon Simple Storage Service) is a
 popular service by `Amazon Web Services <https://aws.amazon.com/>`_ (AWS) that

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -270,6 +270,7 @@ on GitHub, which required preconfigured GitHub authentication details.
    GitHub `decided to deprecate user-password authentication <https://developer.github.com/changes/2020-02-14-deprecating-password-auth/>`_ and
    only supports authentication via personal access token from November 13th 2020 onwards. Changes in DataLad's API reflect this change starting
    with DataLad version ``0.13.6`` by removing the ``github-passwd`` argument.
+   Starting with DataLad ``0.16.0``, a new set of commands for interactions with a variety of hosting services will be introduced (for more information, see section :ref:`share_hostingservice`).
 
    To ensure successful authentication, please create a personal access token at `github.com/settings/tokens <https://github.com/settings/tokens>`_ [#f5]_, and either
 

--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -169,54 +169,6 @@ Publishing fails with the error message ``[remote rejected] (branch is currently
 This can be prevented with  `configuration settings <https://github.blog/2015-02-06-git-2-3-has-been-released/>`_ in Git versions 2.3 or higher, or by pushing to a branch of the sibling that is currently not checked-out.
 For more information on this, and other error messages during push, please checkout the section :ref:`help`.
 
-Setting access control via publishing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-There are a number of ways to restrict access to your dataset or individual
-files of your dataset. One is via choice of (third party) hosting service
-for annexed file contents.
-If you chose a service only selected people have access to, and publish annexed
-contents exclusively there, then only those selected people can perform a
-successful :command:`datalad get`. On shared file systems you may achieve
-this via :term:`permissions` for certain groups or users, and for third party
-infrastructure you may achieve this by invitations/permissions/... options
-of the respective service.
-
-If it is individual files that you do not want to share, you can selectively
-publish the contents of all files you want others to have, and withhold the data
-of the files you do not want to share. This can be done by publishing only
-selected files by providing paths, or overriding default push behavior with
-the ``--data`` option and git-annex ``wanted`` configurations.
-Specifying ``--data nothing`` would for example not push any annexed contents.
-
-Let's say you have a dataset with three files:
-
-- ``experiment.txt``
-- ``subject_1.dat``
-- ``subject_2.dat``
-
-Consider that all of these files are annexed. While the information in
-``experiment.txt`` is fine for everyone to see, ``subject_1.dat`` and
-``subject_2.dat`` contain personal and potentially identifying data that
-can not be shared. Nevertheless, you want collaborators (with whom data
-can not be shared) to know that these files exist, for example such that
-they can develop scripts against the directory structure and
-file names of a dataset, submit those scripts to the data owners,
-and thus still perform an analysis despite not having access to the data.
-
-By publishing only the file contents of ``experiment.txt`` with
-
-.. code-block:: bash
-
-  $ datalad push --to github experiment.txt
-
-only meta data about file availability of ``subject_1.dat`` and ``subject_2.dat``
-exists, but as these files' annexed data is not published, a :command:`datalad get`
-will fail. Note, though, that :command:`push` will publish the complete
-dataset history (unless you specify a commit range with the ``--since`` option
--- see the `manual <http://docs.datalad.org/en/latest/generated/man/datalad-push.html>`_
-for more information).
-
 .. find-out-more:: On the datalad publish command
    :float:
    :name: fom-publish

--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -1,9 +1,9 @@
 .. _push:
 
-Overview: Publishing datasets
------------------------------
+Overview: The datalad push command
+----------------------------------
 
-The sections :ref:`yoda_project`, :ref:`sharethirdparty`, and :ref:`gin` have each
+Previous sections on publishing DataLad datasets  have each
 shown you crucial aspects of the functions of dataset publishing with
 :command:`datalad push`. This section wraps them all together.
 

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -13,6 +13,7 @@ Third party infrastructure
    :caption: Leverage third party services to share datasets
 
    101-138-sharethirdparty
+   101-139-hostingservices
    101-139-dropbox
    101-139-s3
    101-139-gitlfs

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -13,7 +13,7 @@ Third party infrastructure
    :caption: Leverage third party services to share datasets
 
    101-138-sharethirdparty
-   101-139-gin
+   101-139-dropbox
    101-139-s3
    101-141-push
    101-140-summary

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -15,6 +15,8 @@ Third party infrastructure
    101-138-sharethirdparty
    101-139-dropbox
    101-139-s3
+   101-139-gitlfs
+   101-139-gin
    101-141-push
    101-140-summary
 

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -18,6 +18,7 @@ Third party infrastructure
    101-139-gitlfs
    101-139-gin
    101-139-figshare
+   101-139-privacy
    101-141-push
    101-140-summary
 

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -17,6 +17,7 @@ Third party infrastructure
    101-139-s3
    101-139-gitlfs
    101-139-gin
+   101-139-figshare
    101-141-push
    101-140-summary
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -233,6 +233,9 @@ Glossary
       Git concept: to integrate the changes of one :term:`branch`/:term:`sibling`/ ... into
       a different branch.
 
+   merge request
+     See :term:`pull request`.
+
    metadata
       "Data about data": Information about one or more aspects of data used to summarize
       basic information, for example means of create of the data, creator or author, size,
@@ -280,6 +283,10 @@ Glossary
       set with the option ``publish-depends`` in the commands
       :command:`datalad siblings`, :command:`datalad create-sibling`, and
       :command:`datalad create-sibling-github/gitlab`.
+
+
+   pull request
+      Also known as :term:`merge request`. Contributions to Git repositories/DataLad datasets can be proposed to be :term:`merge`\d into the dataset by "requesting a pull/update" from the dataset maintainer to obtain a proposed change from a dataset clone or sibling. It is implemented as a feature in repository hosting sites such as :term:`GitHub`, :term:`Gin`, or :term:`GitLab`.
 
    relative path
       A path related to the present working directory. Relative paths never start with ``/``.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -223,6 +223,9 @@ Glossary
       They are used to build programs, but also to manage projects where some files must be automatically updated from others whenever the others change.
       An example of a Makefile is shown in the usecase :ref:`usecase_reproducible_paper`.
 
+   manpage
+      Abbreviation of "manual page". For most Unix programs, the command ``man <program-name>`` will open a :term:`pager` with this commands documentation. If you have installed DataLad as a Debian package, ``man`` will allow you to open DataLad manpages in your terminal.
+
    master
       Git concept: For the longest time, ``master`` was the name of the default :term:`branch` in a dataset. More recently, the name ``main`` is used. If you are not sure, you can find out if your default branch is ``main`` or ``master`` by running ``git branch``.
 
@@ -243,6 +246,9 @@ Glossary
    object-tree
       git-annex concept: The place where :term:`git-annex` stores available file contents. Files that are annexed get
       a :term:`symlink` added to :term:`Git` that points to the file content. A different word for :term:`annex`.
+
+   pager
+      A `terminal paper <https://en.wikipedia.org/wiki/Terminal_pager>`_ is a program to view file contents in the :term:`terminal`. Popular examples are the programs ``less`` and ``more``. Some terminal output can be opened automatically in a pager, for example the output of a :command:`git log` command. You can use the arrow keys to navigate and scroll in the pager, and the letter ``q`` to exit it.
 
    permissions
       Access rights assigned by most file systems that determine whether a user can view (``read permission``),


### PR DESCRIPTION
[Duplicate of #761 in hopes to trigger a readthedocs preview that was somehow lost on the way]

This work-in-progress PR starts a larger effort on restructuring and extending the handbooks content on publishing datasets to third party services.

In particular, it
- separated service-specific walk-throughs into standalone sections. This affected the "intro" section in particular, from which content on configuring dropbox as a special remote, exporting dataset contents to figshare, and using Git-lfs have each been transformed into standalone sections in the chapter. At the moment, there are walk-throughts for dropbox, s3, figshare, git lfs and gin. This new structure may also make it easier to add new services as walk-throughs.
- improved the introduction into the topic of dataset publication. I have split it into different usecases depending on the capabilities of the employed third party services. The intro lists them, and links to the relevant walk-throughs later in the chapter.
- added a standalone section on data privacy
- extended the example on exporting datasets to figshare with screenshots and code


There is still missing content and room for improvement:

- [x] The placeholder section on publishing datasets to git repository hosting services needs to be filled with the current commands and procedures to do this
- [x] The placeholder section on publishing datasets to git repository hosting services needs to document the new ``create-sibling-{github/gogs/gitlab...}`` command that will come in ``0.16.0``
- [ ] The walkthroughs might benefit from a more generic setup, such as the one that @jsheunis has created in the S3 workflow, where the section is a complete stand-alone piece including the generation of a dataset to publish. If we adopt this approach for the other walk-throughs, too, their content can become more accessible and would not require readers to e.g., have a "DataLad-101" dataset from the previous chapters to publish.
- [x] the section on data privacy could be extended with more strategies and ideas or examples - at the moment, its a lose and hastily collected set of ideas. @mslw maybe has more content based on his work on the RDM module on this topic