### PR TITLE
Pin docutils to < 0.18 to fix handbook build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alabaster >= 0.7.11
 Babel
 certifi
 chardet
-docutils
+docutils < 0.18
 idna
 imagesize
 Jinja2


### PR DESCRIPTION
Recent handbook build failures point to pinning docutils to ``<=0.18``:
```
Running Sphinx v2.1.2
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
make[1]: Leaving directory '/home/runner/work/book/book/docs'
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/application.py", line 231, in __init__
    self.setup_extension(extension)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/application.py", line 394, in setup_extension
    self.registry.load_extension(self, extname)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/registry.py", line 484, in load_extension
    metadata = mod.setup(app)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/addnodes.py", line 394, in setup
    app.add_node(meta)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/application.py", line 565, in add_node
    logger.warning(__('node class %r is already registered, '
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1838, in warning
    self.log(WARNING, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/util/logging.py", line 126, in log
    super().log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1870, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1538, in log
    self._log(level, msg, args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1615, in _log
    self.handle(record)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1625, in handle
    self.callHandlers(record)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 1687, in callHandlers
    hdlr.handle(record)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 963, in handle
    rv = self.filter(record)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/logging/__init__.py", line 821, in filter
    result = f.filter(record)
  File "/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/sphinx/util/logging.py", line 428, in filter
    raise SphinxWarning(message)
sphinx.errors.SphinxWarning: node class 'meta' is already registered, its visitors will be overridden

Warning, treated as error:
node class 'meta' is already registered, its visitors will be overridden
make[1]: *** [Makefile:168: doctest] Error 2
make: *** [Makefile:8: doctest] Error 2
Error: Process completed with exit code 2.
```