### PR TITLE
Update Gin as data source workflow

### DIFF
--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -261,20 +261,27 @@ You will need to have a Gin account and SSH key setup, so please take a look at 
 Then, follow these steps:
 
 - First, create a new repository on Gin (see step by step instructions above).
-- In your to-be-published dataset, add this repository as a sibling, but also as a "common data source". Make sure to configure a :term:`SSH` URL as a ``--pushurl`` but a :term:`HTTPS` URL as a ``url``, and pay close attention that the ``name <name>`` and ``--as-common-datasrc <name>`` arguments differ.
+- In your to-be-published dataset, add this repository as a sibling, this time setting `--url` and `--pushurl` arguments explicitly. Make sure to configure a :term:`SSH` URL as a ``--pushurl`` but a :term:`HTTPS` URL as a ``url``.
   Please also note that the :term:`HTTPS` URL written after ``--url`` DOES NOT have the ``.git`` suffix.
   Here is the command::
 
      $ datalad siblings add \
       -d . \
-      --name gin-update \
+      --name gin \
       --pushurl git@gin.g-node.org:/studyforrest/aggregate-fmri-timeseries.git \
       --url https://gin.g-node.org/studyforrest/aggregate-fmri-timeseries \
-      --as-common-datasrc gin
 
-- Locally, run ``git config --unset-all remote.gin-update.annex-ignore`` to prevent :term:`git-annex` from ignoring this new dataset
-- Push your data to the repository on Gin (``datalad push --to gin-update``)
-- Publish your dataset to GitHub/GitLab/..., or update and existing published dataset (``datalad push``)
+- Locally, run ``git config --unset-all remote.gin.annex-ignore`` to prevent :term:`git-annex` from ignoring this new dataset
+- Push your data to the repository on Gin (``datalad push --to gin``). This pushes the actual state of the repository, including content, but also adjusts the :term:`git-annex` configuration.
+- Configure this sibling as a "common data source". Use the same name as previously in ``--name`` (to indicate which sibling you are configuring) and give a new, different, name after ``--as-common-datasrc``::
+
+   $ datalad siblings configure \
+      --name gin \
+      --as-common-datasrc gin-src
+
+- Push to the repository on Gin again (``datalad push --to gin``) to make the configuration change known to the Gin sibling.
+
+- Publish your dataset to GitHub/GitLab/..., or update an existing published dataset (``datalad push``)
 
 Afterwards, :command:`datalad get` retrieves files from Gin, even if the dataset has been cloned from GitHub.
 


### PR DESCRIPTION
Suggested add - push - configure - push as a correct sequence. Addresses part of #779 and datalad/datalad#6269

I verified the proposed workflow with DataLad version 0.15.3.

Now the question is what to do about upcoming changes in DataLad 0.16. The new release introduces `create-sibling-gin` and shortens the workflow in question (`git config --unset-all remote.gin.annex-ignore` should be unnecessary when `create-sibling-gin` is used, see datalad/datalad#6230). I am in favour of keeping the current workflow (where the Gin repo is created manually) even after the release (as manual creation is not going away). Then, either add a separate example starting with `create-sibling-gin`, or note that the `git config` step can be skipped if the automated method was used. Should it be done in advance, or after DataLad 0.16 release?