### PR TITLE
Revert "Links: Remove link to old benchmarks on previous website"

### DIFF
--- a/docs/beyond_basics/101-160-gobig.rst
+++ b/docs/beyond_basics/101-160-gobig.rst
@@ -134,7 +134,7 @@ Tool-specific and smaller advice
 ================================
 
 - If you are interested in up-to-date performance benchmarks, take a look at
-  `www.datalad.org/test_fs_analysis.html <https://github.com/datalad/benchmarking/blob/master/test_fs_analysis.ipynb>`_.
+  `www.datalad.org/test_fs_analysis.html <https://www.datalad.org/test_fs_analysis.html>`_.
   This can help to set expectations and give useful comparisons of file systems
   or software versions.
 - git-annex offers a range of tricks to further improve performance in large


### PR DESCRIPTION
This reverts commit e7d99b9e4e4518ed834da0ba5c8af1180bda11ed because the link function has been restored.