### PR TITLE
[ENH] Fix various typos

### DIFF
--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -13,7 +13,7 @@ As the text file is stored in Git and not git-annex, no content unlocking is nec
 As we saw within the demonstrations of :command:`datalad run`, modifying content of non-text files, such as ``.jpg``\s, typically requires the additional step of *unlocking* file content, either by hand with the :command:`datalad unlock` command, or within :command:`datalad run` using the ``-o``/``--output`` flag.
 
 There is one detail about DataLad datasets that we have not covered yet.
-Its both a crucial aspect to understanding certain aspects of a dataset, but it is also a potential source of confusion that we want to eradicate.
+It's both a crucial aspect to understanding certain aspects of a dataset, but it is also a potential source of confusion that we want to eradicate.
 
 You might have noticed already that an ``ls -l`` or ``tree`` command in your dataset shows small arrows and quite cryptic paths following each non-text file.
 Maybe your shell also displays these files in a different color than text files when listing them.
@@ -187,7 +187,7 @@ This leads to a few conclusions:
 The first is that you should not be worried
 to see cryptic looking symlinks in your repository -- this is how it should look.
 You can read the :ref:`find-out-more on why these paths look so weird <fom-objecttree>` and what all of this has to do with data integrity, if you want to.
-Its additional information that can help to establish trust in that your data are safely stored and tracked, and understanding more about the object tree and knowing bits of the git-annex basics can make you more confident in working with your datasets.
+It's additional information that can help to establish trust in that your data are safely stored and tracked, and understanding more about the object tree and knowing bits of the git-annex basics can make you more confident in working with your datasets.
 
 The second is that it should now be clear to you why the ``.git`` directory
 should not be deleted or in any way modified by hand. This place is where
@@ -294,7 +294,7 @@ Nevertheless, it may be important to know that some tools that you would expect 
 Some **file managers** (e.g., OSX's Finder) may not display broken symlinks.
 In these cases, it will be impossible to browse and explore the file hierarchy of not-yet-retrieved files with the file manager.
 You can make sure to always be able to see the file hierarchy in two separate ways:
-Upgrade your file manager to display file types in a DataLad datasets (e.g., the `git-annex-turtle extension <https://github.com/andrewringler/git-annex-turtle>`_ for Finder).
+Upgrade your file manager to display file types in DataLad datasets (e.g., the `git-annex-turtle extension <https://github.com/andrewringler/git-annex-turtle>`_ for Finder).
 Alternatively, use the :command:`ls` command in a terminal instead of a file manager GUI.
 Other tools may be more more specialized, smaller, or domain-specific, and may fail to correctly work with broken symlinks, or display unhelpful error messages when handling them, or require additional flags to modify their behavior (such as the :ref:`BIDS Validator <bidsvalidator>`, used in the neuroimaging community).
 When encountering unexpected behavior or failures, try to keep in mind that a dataset without retrieved content appears to be a pile of broken symlinks to a range of tools, consult a tools documentation with regard to symlinks, and check whether data retrieval fixes persisting problems.

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -13,7 +13,7 @@ As the text file is stored in Git and not git-annex, no content unlocking is nec
 As we saw within the demonstrations of :command:`datalad run`, modifying content of non-text files, such as ``.jpg``\s, typically requires the additional step of *unlocking* file content, either by hand with the :command:`datalad unlock` command, or within :command:`datalad run` using the ``-o``/``--output`` flag.
 
 There is one detail about DataLad datasets that we have not covered yet.
-It's both a crucial aspect to understanding certain aspects of a dataset, but it is also a potential source of confusion that we want to eradicate.
+It is a crucial component to understanding certain aspects of a dataset, but it is also a potential source of confusion that we want to eradicate.
 
 You might have noticed already that an ``ls -l`` or ``tree`` command in your dataset shows small arrows and quite cryptic paths following each non-text file.
 Maybe your shell also displays these files in a different color than text files when listing them.

--- a/docs/basics/101-122-config.rst
+++ b/docs/basics/101-122-config.rst
@@ -244,9 +244,9 @@ or values in there are irrelevant for understanding the book, your dataset,
 or DataLad, and can just be left as they are. The previous section merely served
 to de-mystify the :command:`git config` command and the configuration files.
 Nevertheless, it might be helpful to get an overview about the meaning of the
-remaining sections in that file, and the :ref:`that disects this config file further <fom_gitconfig>`  can give you a glimpse of this.
+remaining sections in that file, and the :ref:`that dissects this config file further <fom_gitconfig>`  can give you a glimpse of this.
 
-.. find-out-more:: Disecting a Git config file further
+.. find-out-more:: Dissecting a Git config file further
    :name: fom_gitconfig
    :float:
 

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -990,7 +990,7 @@ dropped automatically, but for content in sub-*datasets* to be dropped, the
 By default, DataLad will not drop any content that does not have at least
 one verified remote copy that the content could be retrieved from again.
 It is possible to drop the downloaded image, because thanks to
-:command:`datalad download-url` its original location in the web in known:
+:command:`datalad download-url` its original location in the web is known:
 
 .. runrecord:: _examples/DL-101-136-175
    :language: console
@@ -1079,9 +1079,9 @@ private :term:`SSH key`\s or passwords, or too many or too large files are
 accidentally saved into Git, and *need* to get out of the dataset history.
 The command ``git-filter-repo <path-specification> --force`` will "filter-out",
 i.e., remove all files **but the ones specified** in ``<path-specification>``
-from the datasets history. The section :ref:`cleanup` shows an example
+from the dataset's history. The section :ref:`cleanup` shows an example
 invocation. If you want to use it, however, make sure to attempt it in a dataset
-clone or with its ``--dry-run`` flag first. It is easy to loose dataset history
+clone or with its ``--dry-run`` flag first. It is easy to lose dataset history
 and files with this tool.
 
 Uninstalling or deleting subdatasets

--- a/docs/usecases/reproducible_neuroimaging_analysis.rst
+++ b/docs/usecases/reproducible_neuroimaging_analysis.rst
@@ -86,7 +86,7 @@ Step-by-Step
 The first part of this Step-by-Step guide details how to computationally
 reproducibly and automatically reproducibly perform data preparation from raw
 `DICOM <https://www.dicomstandard.org/>`_ files to BIDS-compliant
-`NifTi <https://nifti.nimh.nih.gov/>`_ images. The actual analysis, a
+`NIfTI <https://nifti.nimh.nih.gov/>`_ images. The actual analysis, a
 first-level GLM for a localization task, is performed in the second part. A
 final paragraph shows how to prepare the dataset for the afterlife.
 
@@ -141,7 +141,7 @@ Given that we have obtained *raw* data, this data is not yet ready for data
 analysis. Prior to performing actual computations, the data needs to be
 transformed into appropriate formats and standardized to an intuitive layout.
 For neuroimaging, a useful transformation is a transformation from
-DICOMs into the NifTi format, a format specifically designed for scientific
+DICOMs into the NIfTI format, a format specifically designed for scientific
 analyses of brain images. An intuitive layout is the BIDS standard.
 Performing these transformations and standardizations, however, requires
 software. For the task at hand, `HeudiConv <https://heudiconv.readthedocs.io/en/latest/>`_,
@@ -212,7 +212,7 @@ by DataLad (i.e., ``HEAD``) to the previous one (i.e., ``HEAD~1``) with
 
    $ datalad diff -f HEAD~1
 
-As expected, DICOM files of one subject were converted into NifTi files,
+As expected, DICOM files of one subject were converted into NIfTI files,
 **and** the outputs follow the BIDS standard's layout and naming conventions!
 But what's even better is that this action and the relevant software
 environment was fully recorded.
@@ -251,7 +251,7 @@ Analysis execution
 """"""""""""""""""
 
 Since the raw data are reproducibly prepared in BIDS standard we can now go
-further an conduct an analysis. For this example, we will implement a very
+further and conduct an analysis. For this example, we will implement a very
 basic first-level GLM analysis using `FSL <http://fsl.fmrib.ox.ac.uk/>`__
 that takes only a few minutes to run. As before, we will capture all provenance:
 inputs, computational environments, code, and outputs.


### PR DESCRIPTION
This PR fixes various typos that were tracked in https://github.com/datalad-handbook/book/issues/733. Closes https://github.com/datalad-handbook/book/issues/733.