### PR TITLE
Installation: Detail the current workarounds for installations on M1 Macs

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -188,9 +188,10 @@ Windows users, please `get in touch
 warnings. If you on a native Windows 10 system, you should pay close
 attention to them.
 
+.. _mac:
 
-Mac OSX
-"""""""
+Mac OSX (non-M1)
+""""""""""""""""
 
 Modern Macs come with a compatible Python 3 version installed by default. The
 :find-out-more:`on Python versions <fom-py2v3>` has instructions on how to
@@ -269,6 +270,15 @@ Python's package manager <fom-macosx-pip>`.
            /sbin
            /Users/MYUSERNAME/Library/Python/3.7/bin
 
+M1 Mac OSX
+""""""""""
+
+As of April 2022, :term:`git-annex` isn't yet available from the `homebrew <https://brew.sh>`_ package manager for M1 Macs, complicating the installation process.
+Our current recommendations are:
+
+#. Check `formulae.brew.sh/formula/git-annex#default <https://formulae.brew.sh/formula/git-annex#default>`_ if there is bottle installation support provided for Apple Silicon. If there is, rely on the installation instructions for :ref:`mac` instead, and consider `opening an issue <https://github.com/datalad-handbook/book/issues/new>`_ to let us know about this.
+#. Perform a manual installation of git-annex. `This step-by-step instruction <https://github.com/fraimondo/csguide-hands-on#problem-3--git-annex-on-m1-mac>`_ has been successfully used to obtain fully functional git-annex installations (with thanks to Fede Raimondo and Vera Komeyer).
+#. Install DataLad as a Python package, using either :ref:`conda` or :ref:`pipinstall`.
 
 Linux: (Neuro)Debian, Ubuntu, and similar systems
 """""""""""""""""""""""""""""""""""""""""""""""""
@@ -320,6 +330,7 @@ Linux-machines with no root access (e.g. HPC systems)
 
 The most convenient user-based installation can be achieved via Conda_.
 
+.. _conda:
 
 Conda
 """""
@@ -386,6 +397,7 @@ To update an existing installation with conda, use:
 The `DataLad installer`_ also supports setting up a Conda environment, in case
 a suitable Python version is already available.
 
+.. _pipinstall:
 
 Using Python's package manager ``pip``
 """"""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This arose from #833, which revealed an urgent need to document the difficulties of installing DataLad on M1 macs due to the inavailability of git-annex from brew. Thanks to  @anadiasmaile's patience, we walked through the installation instructions for a standalone git-annex install created by Fede and Vera in the Office hour, and a new paragraph on M1 macs links to those instructions now. 