### PR TITLE
Link fixes: Remove or replace a range of relative links

### DIFF
--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -363,7 +363,7 @@ Re-obtained!
 This was only a quick digression into :command:`datalad drop`. The main principles
 of this command will become clear after chapter
 :ref:`chapter_gitannex`, and its precise use is shown in the paragraph on
-`removing file contents <101-136-filesystem.html#removing-annexed-content-entirely>`_.
+:ref:`removing file contents <remove>`.
 At this point in time, however, you already know that datasets allow you do
 :command:`drop` file contents flexibly. If you want to, you could have more
 podcasts (or other data) on your computer than you have disk space available

--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -42,7 +42,7 @@ to generate a text file that lists speaker and title
 name instead.
 
 To do this, we're following a best practice that will reappear in the
-later section on `YODA principles <101-127-yoda.html>`_: Collecting all
+later section on :ref:`YODA principles <yoda>`: Collecting all
 additional scripts that work with content of a subdataset *outside*
 of this subdataset, in a dedicated ``code/`` directory,
 and collating the output of the execution of these scripts

--- a/docs/basics/101-116-sharelocal.rst
+++ b/docs/basics/101-116-sharelocal.rst
@@ -205,7 +205,7 @@ and hostname of your computer. "This", you exclaim, excited about your own reali
    increases. If you have only one other dataset it may be easy to
    remember what and where it is. But once you have one back-up
    of your dataset on a USB-Stick, one dataset shared with
-   `Dropbox <dropbox.com>`_, and a third one on your institutions
+   `Dropbox <https://www.dropbox.com>`_, and a third one on your institutions
    :term:`GitLab` instance you will be grateful for the descriptions
    you provided these locations with.
 

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -83,7 +83,7 @@ as an excerpt here):
    $ datalad get --help
 
 This for example is the help page on :command:`datalad get`
-(the same you would find in the `documentation <docs.datalad.org>`__,
+(the same you would find in the `documentation <http://docs.datalad.org>`__,
 but in your terminal, here - for brevity - slightly cut).
 It contains a command description, a list
 of all the available options with a short explanation of them, and

--- a/docs/basics/101-146-gists.rst
+++ b/docs/basics/101-146-gists.rst
@@ -31,7 +31,7 @@ Parallelize subdataset processing
 
 DataLad can not yet parallelize processes that are performed
 independently over a large number of subdatasets. Pushing across a dataset
-hierarchy or creating `RIA siblings <../usecases/datastore_for_institutions.html>`_
+hierarchy or creating :ref:`RIA siblings <usecase_datastore>`
 for all subdatasets of a superdataset, for example, is performed one after the other.
 Unix however, has a few tools such as `xargs <https://en.wikipedia.org/wiki/Xargs>`_
 or the ``parallel`` tool of `moreutils <https://joeyh.name/code/moreutils/>`_

--- a/docs/beyond_basics/101-147-riastores.rst
+++ b/docs/beyond_basics/101-147-riastores.rst
@@ -477,7 +477,7 @@ sibling creation:
   creation: ``ria+file:///absolute/path/to/ria-store``
 - A URL for read (without annex) access to a store via :term:`http` (e.g., to a RIA store like
   `store.datalad.org <http://store.datalad.org/>`_, through which the
-  `HCP dataset is published <../usecases/HCP_dataset.html>`_) looks like this:
+  :ref:`HCP dataset is published <usecase_HCP_dataset>`) looks like this:
   ``ria+http://store.datalad.org:/absolute/path/to/ria-store``
 
 The appropriate ``ria+`` URL needs to be suffixed with a ``#`` sign and a dataset

--- a/docs/beyond_basics/101-163-summary.rst
+++ b/docs/beyond_basics/101-163-summary.rst
@@ -27,6 +27,6 @@ some thought, and in some instances compromise, though.
 Now what can I do with it?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Go big, if you want to. `Distribute 80TB of files <../usecases/HCP_dataset.html>`_
+Go big, if you want to. :ref:`Distribute 80TB of files <usecase_HCP_dataset>`
 or `more <https://github.com/datalad/datalad-ukbiobank>`_, or version control
 large analyses with minimized performance loss of your version control tools.

--- a/docs/code_from_chapters/ABCD.rst
+++ b/docs/code_from_chapters/ABCD.rst
@@ -237,7 +237,7 @@ This is done with the ``-d/--dataset`` option of :command:`datalad clone`::
 
    datalad clone -d . git@github.com:datalad-handbook/iris_data.git input/
 
-This dataset has been linked in a precise version to the dataset, and it has preserved its complete history (if you are on a native Windows installation, please run ``git show master`` instead -- the reason for this is explained in the `first chapter of the handbook <createDS>`_)::
+This dataset has been linked in a precise version to the dataset, and it has preserved its complete history (if you are on a native Windows installation, please run ``git show master`` instead -- the reason for this is explained in the :ref:`first chapter of the handbook <createDS>`)::
 
    # this shows details of the last entry in your dataset history
    git show

--- a/docs/intro/executive_summary.rst
+++ b/docs/intro/executive_summary.rst
@@ -21,7 +21,6 @@ DataLad. A *dataset* is a directory on a computer that DataLad manages.
 .. figure:: ../artwork/src/dataset.svg
    :alt: Create DataLad datasets
    :width: 70%
-   :target: ../basics/101-101-create.html
 
 You can create new, empty datasets from scratch and populate them,
 or transform existing directories into datasets.
@@ -35,7 +34,6 @@ version control arbitrarily large files in datasets.
 .. figure:: ../artwork/src/local_wf.svg
    :alt: Version control arbitrarily large contents
    :width: 70%
-   :target: ../basics/101-107-summary.html
 
 Thus, you can keep track of revisions of data of any size, and view, interact with or
 restore any version of your dataset's history.
@@ -52,7 +50,6 @@ collaboration and data sharing.
 .. figure:: ../artwork/src/collaboration.svg
    :alt: Consume and collaborate
    :width: 130%
-   :target: ../basics/101-120-summary.html
 
 Additionally, you can get access to publicly available open
 data collections with :term:`the DataLad superdataset ///`.
@@ -68,7 +65,6 @@ a hierarchy of datasets, and it is the basis for advanced provenance capture abi
 .. figure:: ../artwork/src/linkage_subds.svg
    :alt: Dataset nesting
    :width: 100%
-   :target: ../basics/101-106-nesting.html
 
 Full provenance capture and reproducibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +77,6 @@ environments).
 .. figure:: ../artwork/src/reproducible_execution.svg
    :alt: provenance capture
    :width: 100%
-   :target: ../basics/101-113-summary.html
 
 You or your collaborators can thus re-obtain or reproducibly recompute content
 with a single command, and make use of extensive provenance of dataset content

--- a/docs/intro/user_types.rst
+++ b/docs/intro/user_types.rst
@@ -22,7 +22,7 @@ Start by reading sections :ref:`executive_summary` to get a high-level overview
 about DataLad's functionality, and continue with section :ref:`philo` for
 a short introduction to the fundamental principles of the software.
 Afterwards, you may want to skim through the different
-`usecases <../usecases/intro>`_ to see whether one catches your attention.
+:ref:`usecases <usecase-intro>` to see whether one catches your attention.
 The :ref:`cheat`, finally, can give you concrete command overviews.
 
 **2** Eager to try all of the things!

--- a/docs/teaching.rst
+++ b/docs/teaching.rst
@@ -53,7 +53,7 @@ course repository), and provide a path to the demo you want to run::
 
    $ cast_live casts/01_dataset_basics
 
-For existing code demos, the chapter `Code from chapters <code_from_chapters/intro.html>`_
+For existing code demos, the chapter :ref:`Code from chapters <codecasts>`
 contains numbered lists of code snippets to allow your audience to copy-paste what
 you execute to follow along.
 

--- a/docs/usecases/intro.rst
+++ b/docs/usecases/intro.rst
@@ -36,4 +36,4 @@ Contributing
 
 If you are using DataLad for a use  case that is not yet in this chapter, we would
 be delighted to have you tell us about it in the form of a usecase.
-Please see the `contributing guide <../contributing.html>`_ for more info.
+Please see the :ref:`contributing guide <contribute>` for more info.


### PR DESCRIPTION
Its unclear why they suddendly stopped working, but now those sections
are linked via their ref, which should be more resilient anyway.
Thanks monthly linkcheck!