### PR TITLE
ENH: git a code snippet to define a typical collection of git ignores

### DIFF
--- a/docs/beyond_basics/101-179-gitignore.rst
+++ b/docs/beyond_basics/101-179-gitignore.rst
@@ -186,8 +186,8 @@ your dataset to be messy, if you want to be.
       $ git config --global core.excludesfile ~/.gitignore_global
 
    Git -- and consequently DataLad -- will not bother you about any of the files
-   or file types you have specified. Following snippet defines a typical
-   collection of ignores to be defined across different platforms
+   or file types you have specified. The following snippet defines a typical
+   collection of ignored files to be defined across different platforms, and should work on Unix-like systems (like MacOS and Linux distributions).
 
    .. code-block:: bash
 

--- a/docs/beyond_basics/101-179-gitignore.rst
+++ b/docs/beyond_basics/101-179-gitignore.rst
@@ -186,8 +186,14 @@ your dataset to be messy, if you want to be.
       $ git config --global core.excludesfile ~/.gitignore_global
 
    Git -- and consequently DataLad -- will not bother you about any of the files
-   or file types you have specified.
+   or file types you have specified. Following snippet defines a typical
+   collection of ignores to be defined across different platforms
 
+   .. code-block:: bash
+
+     $ touch ~/.gitignore_global
+     $ for f in .DS_Store ._.DS_Store '*.swp' Thumbs.db ehthumbs.db; do \
+       echo "$f" >> ~/.gitignore_global; done
 
 
 .. only:: adminmode


### PR DESCRIPTION
those annoyed me seeing them enough to bring up. Also a user reported a simple `datalad containers-run` snippet  failing because repo was "dirty" because of some `._DS_stores` emerging from previous steps but not being committed, as they shouldn't.

I even started wondering if we should "by default" (procedure?) define `.gitignore` in new datasets to make the world a better place? ;)