### PR TITLE
Update git-annex install method for Windows

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -130,7 +130,7 @@ Git-annex:
 
     .. code-block:: bat
 
-      > datalad-installer git-annex -m datalad:release
+      > datalad-installer git-annex -m datalad/git-annex:release
 
     This will download a recent git-annex, and configure it for your Git installation.
     The admin command prompt can be closed afterwards, all other steps do not need it.


### PR DESCRIPTION
Fixes the recommended method for datalad-installer (`/git-annex` part was missing).

This is a follow-up to PR #868 and issue #865.