### PR TITLE
Remove comment on brew install of p7zip

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -206,10 +206,6 @@ Next, install datalad and its dependencies::
 
    $ brew install datalad
 
-Likewise, the optional, but recommended, `p7zip
-<http://p7zip.sourceforge.net/>`_ dependency can be installed via
-:command:`brew` as well.
-
 Alternatively, you can exclusively use :command:`brew` for DataLad's non-Python
 dependencies, and then check the :find-out-more:`on how to install DataLad via
 Python's package manager <fom-macosx-pip>`.


### PR DESCRIPTION
Currently, brew install of datalad includes the installaton of p7zip as a dependency already. There is no need to brew install p7zip after running "brew install datalad".