### PR TITLE
JS: Work around a redirection glitch that appends equal signs to query strings

### DIFF
--- a/docs/r.rst
+++ b/docs/r.rst
@@ -95,8 +95,8 @@ for directions.
 .. raw:: html
 
    <script>
-   // take everything after "?" as a code to identify the redirect
-   redirect_code = window.location.href.replace(/.*\?/, "");
+   // take everything after "?" as a code to identify the redirect. If there is a '=' appended (a glitch that started to surface Dec 2022), remove it and everything afterwards
+   redirect_code = window.location.href.replace(/.*\?/, "").replace(/=.*/, "");
    success = false;
    // loop over all redirect definitions (see above)
    for (rd of document.getElementsByClassName('redirect')){


### PR DESCRIPTION
This issue was brought to light by  https://github.com/datalad/datalad/pull/7223: A URL such as ``handbook.datalad.org/r.html?install`` got redirected to ``handbook.datalad.org/en/latest/r.html?install=`` - while the language and version redirection was fine, this automatic redirection seemed to have appended a trailing equal sign to the query string.
This broke the logic in the JS-based redirection function, which would match the query string in the URL to the defined redirection targets IDs in r.html (i.e., ``install=`` wouldn't match the defined ``install`` anymore). While the cause for that appended equal sign is not quite clear to me, my suspicion is that its a (temporary) problem on readthedocs side, which performs the automatic redirection to default language and versions. This commits adds a workaround to this by stripping any eventual equal sign (as well as anything after the equal sign) in a query string before matching. While not super pretty, there aren't equal signs in query strings, so I suspect there won't be adverse effects other than a slightly more confusing regex replacement (but I hope the additional comment reminds our future selves on why this was done).

Related issue on readthedocs: https://github.com/readthedocs/readthedocs.org/issues/9799