### PR TITLE
Generic command output normalization

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -47,6 +47,7 @@ Let's start:
 .. runrecord:: _examples/DL-101-101-101
    :language: console
    :workdir: dl-101
+   :realcommand: ( mkdir DataLad-101 && cd DataLad-101 && git init && git config annex.uuid 46b169aa-bb91-42d6-be06-355d957fb4f7 ) &> /dev/null && datalad create --force -c text2git DataLad-101
    :cast: 01_dataset_basics
    :notes: Datasets are datalads core data type. We will explore the concepts of datasets by creating one with datalad create. optional configuration template and a description
 

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -56,7 +56,7 @@ are presented here, make sure to check the :windows-wit:`on peculiarities of its
 .. runrecord:: _examples/DL-101-102-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :realcommand: cd books && wget -nv https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download -O TLCL.pdf && wget -nv https://github.com/swaroopch/byte-of-python/releases/download/v14558db59a326ba99eda0da6c4548c48ccb4cd0f/byte-of-python.pdf -O byte-of-python.pdf && cd ../
+   :realcommand: ( cd books && wget -nv https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download -O TLCL.pdf && wget -nv https://github.com/swaroopch/byte-of-python/releases/download/v14558db59a326ba99eda0da6c4548c48ccb4cd0f/byte-of-python.pdf -O byte-of-python.pdf ) 3>&1 1>&2 2>&3 | grep -v URL:
    :cast: 01_dataset_basics
    :notes: We use wget to download a few books from the web. CAVE: longish realcommand!
 
@@ -233,7 +233,7 @@ Let's try this by adding yet another book, a good reference work about git,
 .. runrecord:: _examples/DL-101-102-108
    :language: console
    :workdir: dl-101/DataLad-101
-   :realcommand: cd books && wget -nv https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf && cd ../
+   :realcommand: cd books && wget -nv https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf 3>&1 1>&2 2>&3 | grep -v URL: && cd ../
    :cast: 01_dataset_basics
    :notes: Its inconvenient that we saved two books together - we should have saved them as independent modifications of the dataset. To see how single modifications can be saved, let's download another book
 

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -150,6 +150,7 @@ small size of ~130 Bytes:
 .. runrecord:: _examples/DL-101-115-103
    :language: console
    :workdir: dl-101/DataLad-101/books
+   :realcommand: ls -lah --time-style=long-iso
    :notes: Symlinks are super small in size, just the amount of characters in the symlink!
    :cast: 03_git_annex_basics
 
@@ -229,6 +230,7 @@ to manage the file system in a DataLad dataset (:ref:`filesystem`).
    .. runrecord:: _examples/DL-101-115-104
       :language: console
       :workdir: dl-101/DataLad-101/books
+      :realcommand: ls -lah --time-style=long-iso TLCL.pdf
       :notes: how does the symlink relate to the shasum of the file?
       :cast: 03_git_annex_basics
 

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -41,6 +41,7 @@ moving a file, and uses the :command:`mv` command.
 .. runrecord:: _examples/DL-101-136-101
    :language: console
    :workdir: dl-101/DataLad-101
+   :realcommand: cd books/ && mv TLCL.pdf The_Linux_Command_Line.pdf && ls -lah --time-style=long-iso
    :notes: Let's look into file system operations. What does renaming does to a file that is symlinked?
    :cast: 03_git_annex_basics
 
@@ -213,6 +214,7 @@ at the symlink:
 .. runrecord:: _examples/DL-101-136-121
    :language: console
    :workdir: dl-101/DataLad-101/books
+   :realcommand: cd .. && ls -l --time-style=long-iso TLCL.pdf
    :notes: currently the symlink is broken! it points into nowhere
    :cast: 03_git_annex_basics
 
@@ -232,6 +234,7 @@ rectify this as well:
 .. runrecord:: _examples/DL-101-136-122
    :language: console
    :workdir: dl-101/DataLad-101
+   :realcommand: datalad save -m "moved book into root" && ls -l --time-style=long-iso TLCL.pdf
    :notes: but a save rectifies it
    :cast: 03_git_annex_basics
 
@@ -508,6 +511,7 @@ That's it.
    .. runrecord:: _examples/DL-101-136-143
       :language: console
       :workdir: dl-101/DataLad-101
+      :realcommand: ls -l --time-style=long-iso copyofTLCL.pdf && ls -l --time-style=long-iso books/TLCL.pdf
       :notes: A cool thing is that the two identical files link to the same place in the object tree
       :cast: 03_git_annex_basics
 

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -347,6 +347,7 @@ thus a :term:`symlink`:
 
 .. runrecord:: _examples/DL-101-137-114
    :language: console
+   :realcommand:  ls -l --time-style=long-iso apdffile.pdf
    :workdir: dl-101/DataLad-101
 
    $ ls -l apdffile.pdf
@@ -365,6 +366,7 @@ The file is now no longer symlinked:
 
 .. runrecord:: _examples/DL-101-137-116
    :language: console
+   :realcommand:  ls -l --time-style=long-iso apdffile.pdf
    :workdir: dl-101/DataLad-101
 
    $ ls -l apdffile.pdf

--- a/docs/basics/_examples/DL-101-101-101
+++ b/docs/basics/_examples/DL-101-101-101
@@ -1,8 +1,8 @@
 $ datalad create -c text2git DataLad-101
-[INFO] Running procedure cfg_text2git 
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
-run(ok): /home/me/dl-101/DataLad-101 (dataset) [/home/adina/env/handbook/bin/python /hom...]
+[INFO] Running procedure cfg_text2git
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
+run(ok): /home/me/dl-101/DataLad-101 (dataset) [VIRTUALENV/bin/python /ho...]
 create(ok): /home/me/dl-101/DataLad-101 (dataset)
 action summary:
   create (ok: 1)

--- a/docs/basics/_examples/DL-101-101-103
+++ b/docs/basics/_examples/DL-101-101-103
@@ -1,12 +1,12 @@
 $ git log
-commit 3cad6a7c5f3f80a3bddb87beba86154e04961219
+commit 24acc0aa0757bfe5863ea3287b1db05651eeaf5a
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:42 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Instruct annex to add text files to Git
 
-commit d62a40236830fa2261d442e498c88cdb78fa469d
+commit 70625078afb176674a165d37df21c9939b67c008
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:41 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-102-103
+++ b/docs/basics/_examples/DL-101-102-103
@@ -5,5 +5,3 @@ $ wget -q https://homepages.uc.edu/~becktl/byte_of_python.pdf \
   -O byte-of-python.pdf
 # get back into the root of the dataset
 $ cd ../
-2022-12-14 16:56:49 URL:https://netcologne.dl.sourceforge.net/project/linuxcommand/TLCL/19.01/TLCL-19.01.pdf [2120211/2120211] -> "TLCL.pdf" [1]
-2022-12-14 16:56:56 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/6501727/56225300-af61-11ea-8d7f-be2b68e479be?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221214%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221214T155654Z&X-Amz-Expires=300&X-Amz-Signature=842342dd77268cc6e62e035524f3d8959d70e3b257166bf8a35cab0694be9bb3&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=6501727&response-content-disposition=attachment%3B%20filename%3Dbyte-of-python.pdf&response-content-type=application%2Foctet-stream [4208954/4208954] -> "byte-of-python.pdf" [1]

--- a/docs/basics/_examples/DL-101-102-107
+++ b/docs/basics/_examples/DL-101-102-107
@@ -1,7 +1,7 @@
 $ git log -p -n 1
-commit ec47a53d873990d4aa54138172d30c8a24e22eb4
+commit da2ba3e8a2972f20af214541c2a53cfec0cd263f
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:56 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add books on Python and Unix to read later
 

--- a/docs/basics/_examples/DL-101-102-108
+++ b/docs/basics/_examples/DL-101-102-108
@@ -1,4 +1,3 @@
 $ cd books
 $ wget -q https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf
 $ cd ../
-2022-12-14 16:57:00 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/15400220/57552a00-9a49-11e9-9144-d9607ed4c2db?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221214%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221214T155657Z&X-Amz-Expires=300&X-Amz-Signature=20fa457e0642504fc2adfa931c9912f0c8a84c19dd0232f936de16ff6b4ad43f&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=15400220&response-content-disposition=attachment%3B%20filename%3Dprogit.pdf&response-content-type=application%2Foctet-stream [12465653/12465653] -> "progit.pdf" [1]

--- a/docs/basics/_examples/DL-101-102-111
+++ b/docs/basics/_examples/DL-101-102-111
@@ -1,6 +1,6 @@
 # lets make the output a bit more concise with the --oneline option
 $ git log --oneline
-b017afc add reference book about git
-ec47a53 add books on Python and Unix to read later
-3cad6a7 Instruct annex to add text files to Git
-d62a402 [DATALAD] new dataset
+535ad8d add reference book about git
+da2ba3e add books on Python and Unix to read later
+24acc0a Instruct annex to add text files to Git
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-102-115
+++ b/docs/basics/_examples/DL-101-102-115
@@ -1,7 +1,7 @@
 $ git log -p -n 1
-commit fa7c9c79854b58fc93e1f24e9de4f06eb762ef09
+commit b47b42a43296b0413c3b3d9ca87b051ebd0ba389
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:10 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add beginners guide on bash
 

--- a/docs/basics/_examples/DL-101-102-116
+++ b/docs/basics/_examples/DL-101-102-116
@@ -1,6 +1,6 @@
 $ git log --oneline
-fa7c9c7 add beginners guide on bash
-b017afc add reference book about git
-ec47a53 add books on Python and Unix to read later
-3cad6a7 Instruct annex to add text files to Git
-d62a402 [DATALAD] new dataset
+b47b42a add beginners guide on bash
+535ad8d add reference book about git
+da2ba3e add books on Python and Unix to read later
+24acc0a Instruct annex to add text files to Git
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-103-107
+++ b/docs/basics/_examples/DL-101-103-107
@@ -1,7 +1,7 @@
 $ git log -p -n 2
-commit c4170cea37b9ad7b35f19167b2d20f09d33cd3db
+commit 469f388cd0dac764e8bdfc4a4576994cc9e235a6
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:13 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add note on datalad save
 
@@ -12,15 +12,15 @@ index 3a7a1fe..0142412 100644
 @@ -1,3 +1,7 @@
  One can create a new dataset with 'datalad create [--description] PATH'.
  The dataset is created empty
- 
+
 +The command "datalad save [-m] PATH" saves the file (modifications) to
 +history.
 +Note to self: Always use informative, concise commit messages.
 +
 
-commit 4d5c65a1870650721a8083867860235e22ba283c
+commit 122906227ec4a7b6c8233026739831fcd09aa7cd
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:13 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Add notes on datalad create
 

--- a/docs/basics/_examples/DL-101-105-102
+++ b/docs/basics/_examples/DL-101-105-102
@@ -1,12 +1,12 @@
 $ datalad clone --dataset . \
  https://github.com/datalad-datasets/longnow-podcasts.git recordings/longnow
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/DataLad-101/recordings/longnow) 
-[INFO] Attempting to clone from https://github.com/datalad-datasets/longnow-podcasts.git to /home/me/dl-101/DataLad-101/recordings/longnow 
-[INFO] Start enumerating objects 
-[INFO] Start receiving objects 
-[INFO] Start resolving deltas 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/DataLad-101/recordings/longnow) 
-[INFO] Remote origin not usable by git-annex; setting annex-ignore 
+[INFO] Cloning dataset to Dataset(/home/me/dl-101/DataLad-101/recordings/longnow)
+[INFO] Attempting to clone from https://github.com/datalad-datasets/longnow-podcasts.git to /home/me/dl-101/DataLad-101/recordings/longnow
+[INFO] Start enumerating objects
+[INFO] Start receiving objects
+[INFO] Start resolving deltas
+[INFO] Completed clone attempts for Dataset(/home/me/dl-101/DataLad-101/recordings/longnow)
+[INFO] Remote origin not usable by git-annex; setting annex-ignore
 [INFO] https://github.com/datalad-datasets/longnow-podcasts.git/config download failed: Not Found
 install(ok): recordings/longnow (dataset)
 add(ok): recordings/longnow (file)

--- a/docs/basics/_examples/DL-101-105-114
+++ b/docs/basics/_examples/DL-101-105-114
@@ -34,7 +34,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Fri Dec 14 18:58:03 2018 +0100
 
     Update from feed
-    
+
     Via: git annex importfeed --template '${feedtitle}/${itempubdate}__${itemtitle}${extension}' --force http://longnow.org/projects/seminars/SALT.xml
 
 commit 7f36dea615f0fe117aed74a04ad325aacc714111
@@ -42,7 +42,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Fri Dec 14 19:00:08 2018 +0100
 
     Update from feed
-    
+
     Via: git annex importfeed --template '${feedtitle}/${itempubdate}__${itemtitle}${extension}' --force http://longnow.org/projects/seminars/interval.xml
 
 commit 21d92907c1d05b246ea5eee805ac00c91366ae04
@@ -50,7 +50,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Wed Jul 10 09:41:13 2019 +0200
 
     [DATALAD RUNCMD] Update Interval seminar series
-    
+
     === Do not change lines below ===
     {
      "chain": [],
@@ -69,7 +69,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Wed Jul 10 09:43:02 2019 +0200
 
     [DATALAD RUNCMD] Update SALT series
-    
+
     === Do not change lines below ===
     {
      "chain": [],
@@ -94,7 +94,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Thu Jul 11 18:42:08 2019 +0200
 
     Script to convert the RSS feed metadata into JSON-LD metadata
-    
+
     For consumption by the `custom` metadata extractor
 
 commit 9bece59fbd606290a124bbf9a3dc3218e4b7612e
@@ -132,7 +132,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Thu Jul 11 19:28:23 2019 +0200
 
     [DATALAD RUNCMD] Update from feed
-    
+
     === Do not change lines below ===
     {
      "chain": [],
@@ -163,7 +163,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Fri Jul 12 12:37:16 2019 +0200
 
     Make sure extracted metadata is directly in Git
-    
+
     to avoid the need for separate hosting
 
 commit 5dd77723418c5c25bf49a29d55e8db273dd39217
@@ -195,7 +195,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Mon Jul 15 07:50:44 2019 +0200
 
     Consolidate all metadata-related files under .datalad
-    
+
     This prevents such content from being intermingled with the
     "intentional" dataset components.
 
@@ -234,7 +234,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Mon Jul 15 10:22:38 2019 +0200
 
     [DATALAD RUNCMD] .datalad/maint/make_readme.py
-    
+
     === Do not change lines below ===
     {
      "chain": [],
@@ -257,7 +257,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Mon Jul 15 12:45:36 2019 +0200
 
     Uniformize JSON-LD context with DataLad's internal extractors
-    
+
     This makes it easier to merge documents for a joint report.
 
 commit 36a30a1a1d8725658410b650d516d9d3c640427d
@@ -265,7 +265,7 @@ Author: Michael Hanke <michael.hanke@gmail.com>
 Date:   Mon Jul 15 12:59:27 2019 +0200
 
     [DATALAD RUNCMD] Update from feed
-    
+
     === Do not change lines below ===
     {
      "chain": [

--- a/docs/basics/_examples/DL-101-106-101
+++ b/docs/basics/_examples/DL-101-106-101
@@ -1,7 +1,7 @@
 $ git log -p -n 3
-commit 79cb8c0053a686e221b8752b8a7f61314eb70afe
+commit 98db0ecab1333d2da431669f1e8c59f31eb6a998
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:58 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Add note on datalad clone
 
@@ -12,16 +12,16 @@ index 0142412..e34ef1f 100644
 @@ -5,3 +5,8 @@ The command "datalad save [-m] PATH" saves the file (modifications) to
  history.
  Note to self: Always use informative, concise commit messages.
- 
+
 +The command 'datalad clone URL/PATH [PATH]' installs a dataset from
 +e.g., a URL or a path. If you install a dataset into an existing
 +dataset (as a subdataset), remember to specify the root of the
 +superdataset with the '-d' option.
 +
 
-commit 63939add03b155f996c96ecfb067064ee75b19c1
+commit c30b17255e0b7a994fd0911faa0f1e3732c9b798
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:16 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] Added subdataset
 
@@ -44,9 +44,9 @@ index 0000000..dcc34fb
 @@ -0,0 +1 @@
 +Subproject commit dcc34fbe669b06ced84ced381ba0db21cf5e665f
 
-commit c4170cea37b9ad7b35f19167b2d20f09d33cd3db
+commit 469f388cd0dac764e8bdfc4a4576994cc9e235a6
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:13 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add note on datalad save
 
@@ -57,15 +57,15 @@ index 3a7a1fe..0142412 100644
 @@ -1,3 +1,7 @@
  One can create a new dataset with 'datalad create [--description] PATH'.
  The dataset is created empty
- 
+
 +The command "datalad save [-m] PATH" saves the file (modifications) to
 +history.
 +Note to self: Always use informative, concise commit messages.
 +
 
-commit 4d5c65a1870650721a8083867860235e22ba283c
+commit 122906227ec4a7b6c8233026739831fcd09aa7cd
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:13 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Add notes on datalad create
 
@@ -79,9 +79,9 @@ index 0000000..3a7a1fe
 +The dataset is created empty
 +
 
-commit fa7c9c79854b58fc93e1f24e9de4f06eb762ef09
+commit b47b42a43296b0413c3b3d9ca87b051ebd0ba389
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:10 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add beginners guide on bash
 
@@ -94,9 +94,9 @@ index 0000000..00ca6bd
 +../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
 \ No newline at end of file
 
-commit b017afc667a953788c674525237a64049e51d632
+commit 535ad8d72e18fd0615780359a2ca935295c3c479
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:57:01 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add reference book about git
 
@@ -109,9 +109,9 @@ index 0000000..c5d2ab2
 +../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
 \ No newline at end of file
 
-commit ec47a53d873990d4aa54138172d30c8a24e22eb4
+commit da2ba3e8a2972f20af214541c2a53cfec0cd263f
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:56 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add books on Python and Unix to read later
 
@@ -132,9 +132,9 @@ index 0000000..adaec61
 +../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
 \ No newline at end of file
 
-commit 3cad6a7c5f3f80a3bddb87beba86154e04961219
+commit 24acc0aa0757bfe5863ea3287b1db05651eeaf5a
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:42 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Instruct annex to add text files to Git
 
@@ -147,9 +147,9 @@ index af926ef..6e474fe 100644
  **/.git* annex.largefiles=nothing
 +* annex.largefiles=((mimeencoding=binary)and(largerthan=0))
 
-commit d62a40236830fa2261d442e498c88cdb78fa469d
+commit 70625078afb176674a165d37df21c9939b67c008
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:56:41 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] new dataset
 
@@ -164,12 +164,12 @@ index 0000000..59157cb
 +metadata/objects/** annex.largefiles=(anything)
 diff --git a/.datalad/config b/.datalad/config
 new file mode 100644
-index 0000000..c61fb51
+index 0000000..d72c8f0
 --- /dev/null
 +++ b/.datalad/config
 @@ -0,0 +1,2 @@
 +[datalad "dataset"]
-+	id = 5d24f8fb-8339-4fe7-9b64-fec6af4e9676
++	id = e3e70682-c209-4cac-629f-6fbed82c07cd
 diff --git a/.gitattributes b/.gitattributes
 new file mode 100644
 index 0000000..af926ef

--- a/docs/basics/_examples/DL-101-108-105
+++ b/docs/basics/_examples/DL-101-108-105
@@ -1,7 +1,7 @@
 $ datalad run -m "create a list of podcast titles" \
   "bash code/list_titles.sh > recordings/podcasts.tsv"
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [bash code/list_titles.sh > recordings/po...]
 add(ok): recordings/podcasts.tsv (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-108-106
+++ b/docs/basics/_examples/DL-101-108-106
@@ -1,15 +1,15 @@
 $ git log -p -n 1   # On Windows, you may just want to type "git log".
-commit 287af8ef3f64a0747a977f9b80d7fec0f1a9be81
+commit a4622a5460845b70ad90b70fe069cba6419628a8
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:01 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] create a list of podcast titles
-    
+
     === Do not change lines below ===
     {
      "chain": [],
      "cmd": "bash code/list_titles.sh > recordings/podcasts.tsv",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [],
@@ -56,12 +56,12 @@ index 0000000..f691b53
 +2006-05-13	Chris Anderson  Will Hearst  The Long Time Tail
 +2006-06-27	Brian Eno  Will Wright  Playing with Time
 +2006-07-15	John Rendon  Long term Policy to Make the War on Terror Short
-+2006-09-23	Orville Schell  China Thinks Long term  But Can It Relearn to Act Long term 
++2006-09-23	Orville Schell  China Thinks Long term  But Can It Relearn to Act Long term
 +2006-10-14	John Baez  Zooming Out in Time
 +2006-11-04	Larry Brilliant  Katherine Fulton  Richard Rockefeller  The Deeper News About the New Philanthropy
-+2006-12-01	Philip Rosedale   Second Life   What Do We Learn If We Digitize EVERYTHING 
++2006-12-01	Philip Rosedale   Second Life   What Do We Learn If We Digitize EVERYTHING
 +2007-01-27	Philip Tetlock  Why Foxes Are Better Forecasters Than Hedgehogs
-+2007-02-16	Vernor Vinge  What If the Singularity Does NOT Happen 
++2007-02-16	Vernor Vinge  What If the Singularity Does NOT Happen
 +2007-03-10	Brian Fagan  We Are Not the First to Suffer Through Climate Change
 +2007-04-28	Frans Lanting  Life s Journey Through Time
 +2007-05-12	Steven Johnson  The Long Zoom
@@ -176,7 +176,7 @@ index 0000000..f691b53
 +2014-09-17	Drew Endy  The iGEM Revolution
 +2014-10-21	Larry  Harvey  Why The Man Keeps Burning
 +2014-11-13	Kevin Kelly  Technium Unbound
-+2015-01-14	Jesse Ausubel  Nature is Rebounding  Land  and Ocean sparing through Concentrating Human Activities 
++2015-01-14	Jesse Ausubel  Nature is Rebounding  Land  and Ocean sparing through Concentrating Human Activities
 +2015-01-28	Stewart Brand  Paul Saffo  Pace Layers Thinking
 +2015-02-18	David Keith  Patient Geoengineering
 +2015-04-01	Paul Saffo  The Creator Economy
@@ -214,9 +214,9 @@ index 0000000..f691b53
 +2018-01-23	Charles C. Mann  The Wizard and the Prophet
 +2018-02-27	Michael Frachetti  Open Source Civilization and the Unexpected Origins of the Silk Road
 +2018-03-14	Steven Pinker  A New Enlightenment
-+2018-04-24	Kishore Mahbubani  Has the West Lost It  Can Asia Save It 
++2018-04-24	Kishore Mahbubani  Has the West Lost It  Can Asia Save It
 +2018-05-23	Benjamin Grant  Overview  Earth and Civilization in the Macroscope
-+2018-06-20	Chris D. Thomas  Are We Initiating The Great Anthropocene Speciation Event 
++2018-06-20	Chris D. Thomas  Are We Initiating The Great Anthropocene Speciation Event
 +2018-07-17	George P. Shultz  Perspective
 +2018-08-07	Juan Benet  Long Term Info structure
 +2018-09-13	Julia Galef  Soldiers and Scouts  Why our minds weren t built for truth  and how we can change that

--- a/docs/basics/_examples/DL-101-108-107
+++ b/docs/basics/_examples/DL-101-108-107
@@ -1,5 +1,5 @@
 $ datalad run -m "Try again to create a list of podcast titles" \
   "bash code/list_titles.sh > recordings/podcasts.tsv"
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [bash code/list_titles.sh > recordings/po...]

--- a/docs/basics/_examples/DL-101-108-108
+++ b/docs/basics/_examples/DL-101-108-108
@@ -1,12 +1,12 @@
 $ git log --oneline
-287af8e [DATALAD RUNCMD] create a list of podcast titles
-cdf94a1 Add short script to write a list of podcast speakers and titles
-79cb8c0 Add note on datalad clone
-63939ad [DATALAD] Added subdataset
-c4170ce add note on datalad save
-4d5c65a Add notes on datalad create
-fa7c9c7 add beginners guide on bash
-b017afc add reference book about git
-ec47a53 add books on Python and Unix to read later
-3cad6a7 Instruct annex to add text files to Git
-d62a402 [DATALAD] new dataset
+a4622a5 [DATALAD RUNCMD] create a list of podcast titles
+96e094b Add short script to write a list of podcast speakers and titles
+98db0ec Add note on datalad clone
+c30b172 [DATALAD] Added subdataset
+469f388 add note on datalad save
+1229062 Add notes on datalad create
+b47b42a add beginners guide on bash
+535ad8d add reference book about git
+da2ba3e add books on Python and Unix to read later
+24acc0a Instruct annex to add text files to Git
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-109-101
+++ b/docs/basics/_examples/DL-101-109-101
@@ -31,12 +31,12 @@ $ less recordings/podcasts.tsv
 2006-05-13	Chris Anderson  Will Hearst  The Long Time Tail
 2006-06-27	Brian Eno  Will Wright  Playing with Time
 2006-07-15	John Rendon  Long term Policy to Make the War on Terror Short
-2006-09-23	Orville Schell  China Thinks Long term  But Can It Relearn to Act Long term 
+2006-09-23	Orville Schell  China Thinks Long term  But Can It Relearn to Act Long term
 2006-10-14	John Baez  Zooming Out in Time
 2006-11-04	Larry Brilliant  Katherine Fulton  Richard Rockefeller  The Deeper News About the New Philanthropy
-2006-12-01	Philip Rosedale   Second Life   What Do We Learn If We Digitize EVERYTHING 
+2006-12-01	Philip Rosedale   Second Life   What Do We Learn If We Digitize EVERYTHING
 2007-01-27	Philip Tetlock  Why Foxes Are Better Forecasters Than Hedgehogs
-2007-02-16	Vernor Vinge  What If the Singularity Does NOT Happen 
+2007-02-16	Vernor Vinge  What If the Singularity Does NOT Happen
 2007-03-10	Brian Fagan  We Are Not the First to Suffer Through Climate Change
 2007-04-28	Frans Lanting  Life s Journey Through Time
 2007-05-12	Steven Johnson  The Long Zoom
@@ -151,7 +151,7 @@ $ less recordings/podcasts.tsv
 2014-09-17	Drew Endy  The iGEM Revolution
 2014-10-21	Larry  Harvey  Why The Man Keeps Burning
 2014-11-13	Kevin Kelly  Technium Unbound
-2015-01-14	Jesse Ausubel  Nature is Rebounding  Land  and Ocean sparing through Concentrating Human Activities 
+2015-01-14	Jesse Ausubel  Nature is Rebounding  Land  and Ocean sparing through Concentrating Human Activities
 2015-01-28	Stewart Brand  Paul Saffo  Pace Layers Thinking
 2015-02-18	David Keith  Patient Geoengineering
 2015-04-01	Paul Saffo  The Creator Economy
@@ -189,9 +189,9 @@ $ less recordings/podcasts.tsv
 2018-01-23	Charles C. Mann  The Wizard and the Prophet
 2018-02-27	Michael Frachetti  Open Source Civilization and the Unexpected Origins of the Silk Road
 2018-03-14	Steven Pinker  A New Enlightenment
-2018-04-24	Kishore Mahbubani  Has the West Lost It  Can Asia Save It 
+2018-04-24	Kishore Mahbubani  Has the West Lost It  Can Asia Save It
 2018-05-23	Benjamin Grant  Overview  Earth and Civilization in the Macroscope
-2018-06-20	Chris D. Thomas  Are We Initiating The Great Anthropocene Speciation Event 
+2018-06-20	Chris D. Thomas  Are We Initiating The Great Anthropocene Speciation Event
 2018-07-17	George P. Shultz  Perspective
 2018-08-07	Juan Benet  Long Term Info structure
 2018-09-13	Julia Galef  Soldiers and Scouts  Why our minds weren t built for truth  and how we can change that

--- a/docs/basics/_examples/DL-101-109-105
+++ b/docs/basics/_examples/DL-101-109-105
@@ -1,21 +1,21 @@
 $ git log -n 2
-commit 149e5976c696b7c7c6b8e4a847492aa6abe3a890
+commit 77bc37dfb2b0708e36c456ec19e350029e7cbf2e
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:02 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     BF: list both directories content
 
-commit 287af8ef3f64a0747a977f9b80d7fec0f1a9be81
+commit a4622a5460845b70ad90b70fe069cba6419628a8
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:01 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] create a list of podcast titles
-    
+
     === Do not change lines below ===
     {
      "chain": [],
      "cmd": "bash code/list_titles.sh > recordings/podcasts.tsv",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [],

--- a/docs/basics/_examples/DL-101-109-106
+++ b/docs/basics/_examples/DL-101-109-106
@@ -1,8 +1,8 @@
 
-$ datalad rerun 287af8ef3f64a0747a977f9b80d7fec0f1a9be81
-[INFO] run commit 287af8e; (create a list of ...)
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+$ datalad rerun a4622a5460845b70ad90b70fe069cba6419628a8
+[INFO] run commit a4622a5; (create a list of ...)
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [bash code/list_titles.sh > recordings/po...]
 add(ok): recordings/podcasts.tsv (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-109-107
+++ b/docs/basics/_examples/DL-101-109-107
@@ -1,17 +1,17 @@
 $ git log -n 1
-commit c4797ead6360fa6f813aacdf2ce58e96efa8d0d8
+commit 42edaa9225c8ba6945d0d0747be4b5508f729e06
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:04 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] create a list of podcast titles
-    
+
     === Do not change lines below ===
     {
      "chain": [
-      "287af8ef3f64a0747a977f9b80d7fec0f1a9be81"
+      "a4622a5460845b70ad90b70fe069cba6419628a8"
      ],
      "cmd": "bash code/list_titles.sh > recordings/podcasts.tsv",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [],

--- a/docs/basics/_examples/DL-101-109-112
+++ b/docs/basics/_examples/DL-101-109-112
@@ -1,17 +1,17 @@
 $ git log -- recordings/podcasts.tsv
-commit c4797ead6360fa6f813aacdf2ce58e96efa8d0d8
+commit 42edaa9225c8ba6945d0d0747be4b5508f729e06
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:04 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] create a list of podcast titles
-    
+
     === Do not change lines below ===
     {
      "chain": [
-      "287af8ef3f64a0747a977f9b80d7fec0f1a9be81"
+      "a4622a5460845b70ad90b70fe069cba6419628a8"
      ],
      "cmd": "bash code/list_titles.sh > recordings/podcasts.tsv",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [],
@@ -20,17 +20,17 @@ Date:   Wed Dec 14 16:58:04 2022 +0100
     }
     ^^^ Do not change lines above ^^^
 
-commit 287af8ef3f64a0747a977f9b80d7fec0f1a9be81
+commit a4622a5460845b70ad90b70fe069cba6419628a8
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:01 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] create a list of podcast titles
-    
+
     === Do not change lines below ===
     {
      "chain": [],
      "cmd": "bash code/list_titles.sh > recordings/podcasts.tsv",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [],

--- a/docs/basics/_examples/DL-101-110-102
+++ b/docs/basics/_examples/DL-101-110-102
@@ -1,8 +1,8 @@
 $ datalad run -m "Resize logo for slides" \
 "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-[INFO] == Command start (output follows) ===== 
+[INFO] == Command start (output follows) =====
 convert-im6.q16: unable to open image `recordings/longnow/.datalad/feed_metadata/logo_salt.jpg': No such file or directory @ error/blob.c/OpenBlob/2924.
 convert-im6.q16: no images defined `recordings/salt_logo_small.jpg' @ error/convert.c/ConvertImageCommand/3229.
-[INFO] == Command exit (modification check follows) ===== 
-[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG' 
+[INFO] == Command exit (modification check follows) =====
+[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG'
 run(error): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 400x400 recordings/longn...]

--- a/docs/basics/_examples/DL-101-110-103
+++ b/docs/basics/_examples/DL-101-110-103
@@ -5,10 +5,10 @@ $ datalad run -m "Resize logo for slides" \
 $ datalad run -m "Resize logo for slides" \
 -i "recordings/longnow/.datalad/feed_metadata/logo_salt.jpg" \
 "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 get(ok): recordings/longnow/.datalad/feed_metadata/logo_salt.jpg (file) [from web...]
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 400x400 recordings/longn...]
 add(ok): recordings/salt_logo_small.jpg (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-110-104
+++ b/docs/basics/_examples/DL-101-110-104
@@ -5,9 +5,9 @@ $ datalad run -m "Resize logo for slides" \
 $ datalad run -m "Resize logo for slides" \
 -i "recordings/longnow/.datalad/feed_metadata/logo_salt.jpg" \
 "convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-[INFO] Making sure inputs are available (this may take some time) 
-[INFO] == Command start (output follows) ===== 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
 convert-im6.q16: unable to open image `recordings/salt_logo_small.jpg': Permission denied @ error/blob.c/OpenBlob/2924.
-[INFO] == Command exit (modification check follows) ===== 
-[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG' 
+[INFO] == Command exit (modification check follows) =====
+[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG'
 run(error): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 450x450 recordings/longn...]

--- a/docs/basics/_examples/DL-101-111-101
+++ b/docs/basics/_examples/DL-101-111-101
@@ -1,5 +1,5 @@
 $ datalad unlock recordings/salt_logo_small.jpg
 [INFO] Unlocking files
-unlock(ok): recordings/salt_logo_small.jpg (file)
 [INFO] Recording unlocked state in git
 [INFO] Completed unlocking files
+unlock(ok): recordings/salt_logo_small.jpg (file)

--- a/docs/basics/_examples/DL-101-111-105
+++ b/docs/basics/_examples/DL-101-111-105
@@ -8,10 +8,10 @@ $ datalad run -m "Resize logo for slides" \
 -i "recordings/longnow/.datalad/feed_metadata/logo_interval.jpg" \
 -o "recordings/interval_logo_small.jpg" \
 "convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_interval.jpg recordings/interval_logo_small.jpg"
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 get(ok): recordings/longnow/.datalad/feed_metadata/logo_interval.jpg (file) [from web...]
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 450x450 recordings/longn...]
 add(ok): recordings/interval_logo_small.jpg (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-112-104
+++ b/docs/basics/_examples/DL-101-112-104
@@ -2,13 +2,13 @@ $ datalad run -m "Resize logo for slides" \
 --input "recordings/longnow/.datalad/feed_metadata/logo_interval.jpg" \
 --output "recordings/interval_logo_small.jpg" \
 "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_interval.jpg recordings/interval_logo_small.jpg"
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
 [INFO] Unlocking files
-unlock(ok): recordings/interval_logo_small.jpg (file)
 [INFO] Recording unlocked state in git
 [INFO] Completed unlocking files
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
+unlock(ok): recordings/interval_logo_small.jpg (file)
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 400x400 recordings/longn...]
 add(ok): recordings/interval_logo_small.jpg (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-112-106
+++ b/docs/basics/_examples/DL-101-112-106
@@ -3,13 +3,13 @@ $ datalad run -m "Resize logo for slides" \
 --output "recordings/salt_logo_small.jpg" \
 --explicit \
 "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
 [INFO] Unlocking files
-unlock(ok): recordings/salt_logo_small.jpg (file)
 [INFO] Recording unlocked state in git
 [INFO] Completed unlocking files
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
+unlock(ok): recordings/salt_logo_small.jpg (file)
 run(ok): /home/me/dl-101/DataLad-101 (dataset) [convert -resize 400x400 recordings/longn...]
 add(ok): recordings/salt_logo_small.jpg (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-112-109
+++ b/docs/basics/_examples/DL-101-112-109
@@ -1,7 +1,7 @@
 $ git log -p -n 2
-commit 1f1f35627e7e49d1f638111d5887cf14249e7487
+commit db17294a4c3dea1a9733e74c912228e3c63f8eab
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:20 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add note on clean datasets
 
@@ -12,7 +12,7 @@ index 6a465f0..e2829b2 100644
 @@ -32,3 +32,9 @@ should be specified with an -o/--output flag. Upon a run or rerun of
  the command, the contents of these files will get unlocked so that
  they can be modified.
- 
+
 +Important! If the dataset is not "clean" (a datalad status output is
 +empty), datalad run will not work - you will have to save
 +modifications present in your dataset.
@@ -20,17 +20,17 @@ index 6a465f0..e2829b2 100644
 +those changes done to the files listed with --output flags.
 +
 
-commit a5729b53f6a8c189323464faa77614a8191a2d18
+commit 7948b8623305841048fd93e73dcb646c6fa3dcd6
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:19 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] Resize logo for slides
-    
+
     === Do not change lines below ===
     {
      "chain": [],
      "cmd": "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg",
-     "dsid": "5d24f8fb-8339-4fe7-9b64-fec6af4e9676",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [],
      "inputs": [

--- a/docs/basics/_examples/DL-101-114-101
+++ b/docs/basics/_examples/DL-101-114-101
@@ -1,23 +1,23 @@
 $ git log --reverse --oneline
-d62a402 [DATALAD] new dataset
-3cad6a7 Instruct annex to add text files to Git
-ec47a53 add books on Python and Unix to read later
-b017afc add reference book about git
-fa7c9c7 add beginners guide on bash
-4d5c65a Add notes on datalad create
-c4170ce add note on datalad save
-63939ad [DATALAD] Added subdataset
-79cb8c0 Add note on datalad clone
-cdf94a1 Add short script to write a list of podcast speakers and titles
-287af8e [DATALAD RUNCMD] create a list of podcast titles
-149e597 BF: list both directories content
-c4797ea [DATALAD RUNCMD] create a list of podcast titles
-b4a391c add note datalad and git diff
-f08b4b4 add note on basic datalad run and datalad rerun
-574930a [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
-f039d4e resized picture by hand
-65497e0 [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
-4c17ac8 add additional notes on run options
-d0e2f68 [DATALAD RUNCMD] Resize logo for slides
-a5729b5 [DATALAD RUNCMD] Resize logo for slides
-1f1f356 add note on clean datasets
+7062507 [DATALAD] new dataset
+24acc0a Instruct annex to add text files to Git
+da2ba3e add books on Python and Unix to read later
+535ad8d add reference book about git
+b47b42a add beginners guide on bash
+1229062 Add notes on datalad create
+469f388 add note on datalad save
+c30b172 [DATALAD] Added subdataset
+98db0ec Add note on datalad clone
+96e094b Add short script to write a list of podcast speakers and titles
+a4622a5 [DATALAD RUNCMD] create a list of podcast titles
+77bc37d BF: list both directories content
+42edaa9 [DATALAD RUNCMD] create a list of podcast titles
+7a07f8d add note datalad and git diff
+35769e1 add note on basic datalad run and datalad rerun
+388bd58 [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
+1e1f344 resized picture by hand
+9fed9dc [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
+79116aa add additional notes on run options
+a674b2d [DATALAD RUNCMD] Resize logo for slides
+7948b86 [DATALAD RUNCMD] Resize logo for slides
+db17294 add note on clean datasets

--- a/docs/basics/_examples/DL-101-115-103
+++ b/docs/basics/_examples/DL-101-115-103
@@ -1,8 +1,8 @@
 $ ls -lah
 total 24K
-drwxr-xr-x 2 adina adina 4.0K Dec 14 16:57 .
-drwxr-xr-x 7 adina adina 4.0K Dec 14 16:57 ..
-lrwxrwxrwx 1 adina adina  131 Jan 19  2009 bash_guide.pdf -> ../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-lrwxrwxrwx 1 adina adina  131 Dec  8  2021 byte-of-python.pdf -> ../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
-lrwxrwxrwx 1 adina adina  133 Dec  7  2021 progit.pdf -> ../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
-lrwxrwxrwx 1 adina adina  131 Jan 28  2019 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+drwxrwxr-x 2 elena elena 4.0K 2019-06-18 16:13 .
+drwxrwxr-x 7 elena elena 4.0K 2019-06-18 16:13 ..
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 bash_guide.pdf -> ../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 byte-of-python.pdf -> ../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
+lrwxrwxrwx 1 elena elena 133 2019-06-18 16:13 progit.pdf -> ../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-115-104
+++ b/docs/basics/_examples/DL-101-115-104
@@ -1,3 +1,3 @@
 # take a look at the last part of the target path:
 $ ls -lah TLCL.pdf
-lrwxrwxrwx 1 adina adina 131 Jan 28  2019 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-116-105
+++ b/docs/basics/_examples/DL-101-116-105
@@ -1,4 +1,4 @@
 $ git annex whereis books/TLCL.pdf
 whereis books/TLCL.pdf (1 copy)
-	49a69e90-9581-4205-b2d5-a5c3fe832f0d -- me@muninn:~/dl-101/DataLad-101 [origin]
+  	REDACTED-UUID -- me@meiner:~/dl-101/DataLad-101 [origin]
 ok

--- a/docs/basics/_examples/DL-101-116-106
+++ b/docs/basics/_examples/DL-101-116-106
@@ -1,7 +1,7 @@
 $ git annex whereis books/bash_guide.pdf
 whereis books/bash_guide.pdf (2 copies)
-	00000000-0000-0000-0000-000000000001 -- web
-	49a69e90-9581-4205-b2d5-a5c3fe832f0d -- me@muninn:~/dl-101/DataLad-101 [origin]
+  	00000000-0000-0000-0000-000000000001 -- web
+   	REDACTED-UUID -- me@meiner:~/dl-101/DataLad-101 [origin]
 
   web: http://www.tldp.org/LDP/Bash-Beginners-Guide/Bash-Beginners-Guide.pdf
 ok

--- a/docs/basics/_examples/DL-101-117-101
+++ b/docs/basics/_examples/DL-101-117-101
@@ -6,7 +6,7 @@ $ cd recordings/longnow
 $ git annex whereis Long_Now__Seminars_About_Long_term_Thinking/2003_11_15__Brian_Eno__The_Long_Now.mp3
 whereis Long_Now__Seminars_About_Long_term_Thinking/2003_11_15__Brian_Eno__The_Long_Now.mp3 (2 copies)
   	00000000-0000-0000-0000-000000000001 -- web
-   	da3bf937-5bd2-43ea-a07b-bcbe71f3b875 -- mih@medusa:/tmp/seminars-on-longterm-thinking
+   	REDACTED-UUID -- mih@medusa:/tmp/seminars-on-longterm-thinking
 
   web: http://podcast.longnow.org/salt/redirect/salt-020031114-eno-podcast.mp3
 ok

--- a/docs/basics/_examples/DL-101-117-102
+++ b/docs/basics/_examples/DL-101-117-102
@@ -1,8 +1,8 @@
 # but not for this:
 $ git annex whereis Long_Now__Seminars_About_Long_term_Thinking/2005_01_15__James_Carse__Religious_War_In_Light_of_the_Infinite_Game.mp3
-whereis Long_Now__Seminars_About_Long_term_Thinking/2005_01_15__James_Carse__Religious_War_In_Light_of_the_Infinite_Game.mp3 (2 copies) 
+whereis Long_Now__Seminars_About_Long_term_Thinking/2005_01_15__James_Carse__Religious_War_In_Light_of_the_Infinite_Game.mp3 (2 copies)
   	00000000-0000-0000-0000-000000000001 -- web
-   	da3bf937-5bd2-43ea-a07b-bcbe71f3b875 -- mih@medusa:/tmp/seminars-on-longterm-thinking
+   	REDACTED-UUID -- mih@medusa:/tmp/seminars-on-longterm-thinking
 
   web: http://podcast.longnow.org/salt/redirect/salt-020050114-carse-podcast.mp3
 ok

--- a/docs/basics/_examples/DL-101-118-102
+++ b/docs/basics/_examples/DL-101-118-102
@@ -1,12 +1,12 @@
 # lets view the history
 $ git log --oneline -n 10
-1f1f356 add note on clean datasets
-a5729b5 [DATALAD RUNCMD] Resize logo for slides
-d0e2f68 [DATALAD RUNCMD] Resize logo for slides
-4c17ac8 add additional notes on run options
-65497e0 [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
-f039d4e resized picture by hand
-574930a [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
-f08b4b4 add note on basic datalad run and datalad rerun
-b4a391c add note datalad and git diff
-c4797ea [DATALAD RUNCMD] create a list of podcast titles
+db17294 add note on clean datasets
+7948b86 [DATALAD RUNCMD] Resize logo for slides
+a674b2d [DATALAD RUNCMD] Resize logo for slides
+79116aa add additional notes on run options
+9fed9dc [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
+1e1f344 resized picture by hand
+388bd58 [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
+35769e1 add note on basic datalad run and datalad rerun
+7a07f8d add note datalad and git diff
+42edaa9 [DATALAD RUNCMD] create a list of podcast titles

--- a/docs/basics/_examples/DL-101-118-103
+++ b/docs/basics/_examples/DL-101-118-103
@@ -1,11 +1,11 @@
 
-$ datalad rerun a5729b53f6a8c189323464faa77614a8191a2d18
-[INFO] run commit a5729b5; (Resize logo for s...)
-[INFO] Making sure inputs are available (this may take some time) 
+$ datalad rerun 7948b8623305841048fd93e73dcb646c6fa3dcd6
+[INFO] run commit 7948b86; (Resize logo for s...)
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 get(ok): recordings/longnow/.datalad/feed_metadata/logo_salt.jpg (file) [from web...]
 run.remove(ok): recordings/salt_logo_small.jpg (file) [Removed file]
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
 run(ok): /home/me/dl-101/mock_user/DataLad-101 (dataset) [convert -resize 400x400 recordings/longn...]
 add(ok): recordings/salt_logo_small.jpg (file)
 action summary:

--- a/docs/basics/_examples/DL-101-121-103
+++ b/docs/basics/_examples/DL-101-121-103
@@ -1,7 +1,7 @@
 $ git log -n 1 -p
-commit 9f91708da7046be0e9f5f65a622557400411dd9a
+commit d2254b295eb87afc1374628e7210d6251e00ee2e
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:58:46 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Include nesting demo from datalad website
 

--- a/docs/basics/_examples/DL-101-121-109
+++ b/docs/basics/_examples/DL-101-121-109
@@ -71,7 +71,7 @@ index 655be7d..3bf3281 100644
 @@ -59,3 +59,7 @@ The command "git annex whereis PATH" lists the repositories that have
  the file content of an annexed file. When using "datalad get" to
  retrieve file content, those repositories will be queried.
- 
+
 +To update a shared dataset, run the command "datalad update --merge".
 +This command will query its origin for changes, and integrate the
 +changes into the dataset.

--- a/docs/basics/_examples/DL-101-121-112
+++ b/docs/basics/_examples/DL-101-121-112
@@ -1,28 +1,28 @@
 $ git log --oneline
-0319eb7 Merge remote-tracking branch 'roommate/master'
-9f91708 Include nesting demo from datalad website
-77011c9 add note about datalad update
-c495328 add note on git annex whereis
-7b91906 add note about cloning from paths and recursive datalad get
-1f1f356 add note on clean datasets
-a5729b5 [DATALAD RUNCMD] Resize logo for slides
-d0e2f68 [DATALAD RUNCMD] Resize logo for slides
-4c17ac8 add additional notes on run options
-65497e0 [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
-f039d4e resized picture by hand
-574930a [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
-f08b4b4 add note on basic datalad run and datalad rerun
-b4a391c add note datalad and git diff
-c4797ea [DATALAD RUNCMD] create a list of podcast titles
-149e597 BF: list both directories content
-287af8e [DATALAD RUNCMD] create a list of podcast titles
-cdf94a1 Add short script to write a list of podcast speakers and titles
-79cb8c0 Add note on datalad clone
-63939ad [DATALAD] Added subdataset
-c4170ce add note on datalad save
-4d5c65a Add notes on datalad create
-fa7c9c7 add beginners guide on bash
-b017afc add reference book about git
-ec47a53 add books on Python and Unix to read later
-3cad6a7 Instruct annex to add text files to Git
-d62a402 [DATALAD] new dataset
+584ce91 Merge remote-tracking branch 'roommate/master'
+1c6a22d add note about datalad update
+d2254b2 Include nesting demo from datalad website
+3722356 add note on git annex whereis
+51eede3 add note about cloning from paths and recursive datalad get
+db17294 add note on clean datasets
+7948b86 [DATALAD RUNCMD] Resize logo for slides
+a674b2d [DATALAD RUNCMD] Resize logo for slides
+79116aa add additional notes on run options
+9fed9dc [DATALAD RUNCMD] convert -resize 450x450 recordings/longn...
+1e1f344 resized picture by hand
+388bd58 [DATALAD RUNCMD] convert -resize 400x400 recordings/longn...
+35769e1 add note on basic datalad run and datalad rerun
+7a07f8d add note datalad and git diff
+42edaa9 [DATALAD RUNCMD] create a list of podcast titles
+77bc37d BF: list both directories content
+a4622a5 [DATALAD RUNCMD] create a list of podcast titles
+96e094b Add short script to write a list of podcast speakers and titles
+98db0ec Add note on datalad clone
+c30b172 [DATALAD] Added subdataset
+469f388 add note on datalad save
+1229062 Add notes on datalad create
+b47b42a add beginners guide on bash
+535ad8d add reference book about git
+da2ba3e add books on Python and Unix to read later
+24acc0a Instruct annex to add text files to Git
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-122-101
+++ b/docs/basics/_examples/DL-101-122-101
@@ -5,17 +5,16 @@ $ cat .git/config
 	bare = false
 	logallrefupdates = true
 [annex]
-	uuid = 49a69e90-9581-4205-b2d5-a5c3fe832f0d
-	version = 10
+	uuid = 46b169aa-bb91-42d6-be06-355d957fb4f7
+	version = 8
 [filter "annex"]
 	smudge = git-annex smudge -- %f
 	clean = git-annex smudge --clean -- %f
-	process = git-annex filter-process
 [submodule "recordings/longnow"]
 	active = true
 	url = https://github.com/datalad-datasets/longnow-podcasts.git
 [remote "roommate"]
 	url = ../mock_user/DataLad-101
 	fetch = +refs/heads/*:refs/remotes/roommate/*
-	annex-uuid = bd057cda-8db2-4bcc-aff2-975cb5b000cf
+	annex-uuid = REDACTED-RANDOM-UUID
 	annex-ignore = false

--- a/docs/basics/_examples/DL-101-122-103
+++ b/docs/basics/_examples/DL-101-122-103
@@ -6,17 +6,16 @@ $ cat .git/config
 	logallrefupdates = true
 	editor = nano
 [annex]
-	uuid = 49a69e90-9581-4205-b2d5-a5c3fe832f0d
-	version = 10
+	uuid = 46b169aa-bb91-42d6-be06-355d957fb4f7
+	version = 8
 [filter "annex"]
 	smudge = git-annex smudge -- %f
 	clean = git-annex smudge --clean -- %f
-	process = git-annex filter-process
 [submodule "recordings/longnow"]
 	active = true
 	url = https://github.com/datalad-datasets/longnow-podcasts.git
 [remote "roommate"]
 	url = ../mock_user/DataLad-101
 	fetch = +refs/heads/*:refs/remotes/roommate/*
-	annex-uuid = bd057cda-8db2-4bcc-aff2-975cb5b000cf
+	annex-uuid = REDACTED-RANDOM-UUID
 	annex-ignore = false

--- a/docs/basics/_examples/DL-101-123-105
+++ b/docs/basics/_examples/DL-101-123-105
@@ -1,3 +1,3 @@
 $ cat .datalad/config
 [datalad "dataset"]
-	id = 5d24f8fb-8339-4fe7-9b64-fec6af4e9676
+	id = e3e70682-c209-4cac-629f-6fbed82c07cd

--- a/docs/basics/_examples/DL-101-123-108
+++ b/docs/basics/_examples/DL-101-123-108
@@ -9,4 +9,4 @@ index 9bc9ee9..11273e1 100644
 -	url = https://github.com/datalad-datasets/longnow-podcasts.git
 +	url = git@github.com:datalad-datasets/longnow-podcasts.git
  	datalad-id = b3ca2718-8901-11e8-99aa-a0369f7c647e
-	datalad-url = https://github.com/datalad-datasets/longnow-podcasts.git
+ 	datalad-url = https://github.com/datalad-datasets/longnow-podcasts.git

--- a/docs/basics/_examples/DL-101-124-101
+++ b/docs/basics/_examples/DL-101-124-101
@@ -1,5 +1,5 @@
 $ datalad run-procedure --discover
-cfg_metadatatypes (/home/adina/repos/datalad/datalad/resources/procedures/cfg_metadatatypes.py) [python_script]
-cfg_noannex (/home/adina/repos/datalad/datalad/resources/procedures/cfg_noannex.py) [python_script]
-cfg_text2git (/home/adina/repos/datalad/datalad/resources/procedures/cfg_text2git.py) [python_script]
-cfg_yoda (/home/adina/repos/datalad/datalad/resources/procedures/cfg_yoda.py) [python_script]
+cfg_noannex (/home/mih/hacking/datalad/git/datalad/resources/procedures/cfg_noannex.py) [python_script]
+cfg_metadatatypes (/home/mih/hacking/datalad/git/datalad/resources/procedures/cfg_metadatatypes.py) [python_script]
+cfg_text2git (/home/mih/hacking/datalad/git/datalad/resources/procedures/cfg_text2git.py) [python_script]
+cfg_yoda (/home/mih/hacking/datalad/git/datalad/resources/procedures/cfg_yoda.py) [python_script]

--- a/docs/basics/_examples/DL-101-124-103
+++ b/docs/basics/_examples/DL-101-124-103
@@ -1,2 +1,2 @@
 $ datalad create somedataset; cd somedataset
-create(ok): /home/me/procs/somedataset (dataset)
+create(error): /home/me/procs/somedataset (dataset) [will not create a dataset in a non-empty directory, use `--force` option to ignore]

--- a/docs/basics/_examples/DL-101-124-104
+++ b/docs/basics/_examples/DL-101-124-104
@@ -37,3 +37,5 @@ ds.repo.set_gitattributes([('example', {'annex.largefiles': 'nothing'})])
 ds.save(message="Apply custom procedure")
 
 EOT
+mkdir: cannot create directory ‘.datalad/procedures’: File exists
+bash: line 2: .datalad/procedures/example.py: Permission denied

--- a/docs/basics/_examples/DL-101-124-105
+++ b/docs/basics/_examples/DL-101-124-105
@@ -1,6 +1,1 @@
 $ datalad save -m "add custom procedure"
-add(ok): .datalad/procedures/example.py (file)
-save(ok): . (dataset)
-action summary:
-  add (ok: 1)
-  save (ok: 1)

--- a/docs/basics/_examples/DL-101-124-106
+++ b/docs/basics/_examples/DL-101-124-106
@@ -1,12 +1,11 @@
 $ datalad run-procedure example "this text will be in the file 'example2'"
-[INFO] Running procedure example 
-[INFO] == Command start (output follows) ===== 
-add(ok): example2 (file)
-add(ok): somedir/example (file)
-add(ok): .gitattributes (file)
-save(ok): . (dataset)
-action summary:
-  add (ok: 3)
-  save (ok: 1)
-[INFO] == Command exit (modification check follows) ===== 
-run(ok): /home/me/procs/somedataset (dataset) [/home/adina/env/handbook/bin/python /hom...]
+[INFO] Running procedure example
+[INFO] == Command start (output follows) =====
+Traceback (most recent call last):
+  File "/home/me/procs/somedataset/.datalad/procedures/example.py", line 28, in <module>
+    create_tree(ds.path, tmpl)
+  File "/home/mih/hacking/datalad/git/datalad/utils.py", line 2505, in create_tree
+    with open_func(full_name, "wb") as f:
+PermissionError: [Errno 13] Permission denied: '/home/me/procs/somedataset/example2'
+[INFO] == Command exit (modification check follows) =====
+run(error): /home/me/procs/somedataset (dataset) [VIRTUALENV/bin/python /ho...]

--- a/docs/basics/_examples/DL-101-124-109
+++ b/docs/basics/_examples/DL-101-124-109
@@ -1,7 +1,2 @@
 $ git config -f .datalad/config datalad.procedures.example.help "A toy example"
 $ datalad save -m "add help description"
-add(ok): .datalad/config (file)
-save(ok): . (dataset)
-action summary:
-  add (ok: 1)
-  save (ok: 1)

--- a/docs/basics/_examples/DL-101-130-103
+++ b/docs/basics/_examples/DL-101-130-103
@@ -1,9 +1,9 @@
 # inside of DataLad-101
 $ datalad create -c yoda --dataset . midterm_project
-[INFO] Running procedure cfg_yoda 
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
-run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [/home/adina/env/handbook/bin/python /hom...]
+[INFO] Running procedure cfg_yoda
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
+run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [VIRTUALENV/bin/python /ho...]
 add(ok): midterm_project (file)
 add(ok): .gitmodules (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-130-110
+++ b/docs/basics/_examples/DL-101-130-110
@@ -1,7 +1,7 @@
 $ git show ready4analysis
-commit 5b94db49daff0e8dd71b8925ce06ce9b1535859f
+commit 4c8041994890dbb0228e00d691ce63b4023464d3
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:59:02 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add script for kNN classification and plotting
 

--- a/docs/basics/_examples/DL-101-130-111
+++ b/docs/basics/_examples/DL-101-130-111
@@ -3,11 +3,13 @@ $ datalad run -m "analyze iris data with classification analysis" \
   --output "pairwise_relationships.png" \
   --output "prediction_report.csv" \
   "python3 code/script.py {inputs} {outputs}"
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+Traceback (most recent call last):
+  File "/home/me/dl-101/DataLad-101/midterm_project/code/script.py", line 3, in <module>
+    import pandas as pd
+ModuleNotFoundError: No module named 'pandas'
+[INFO] == Command exit (modification check follows) =====
+[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG'
 get(ok): input/iris.csv (file) [from web...]
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
-run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [python3 code/script.py input/iris.csv pa...]
-add(ok): pairwise_relationships.png (file)
-add(ok): prediction_report.csv (file)
-save(ok): . (dataset)
+run(error): /home/me/dl-101/DataLad-101/midterm_project (dataset) [python3 code/script.py input/iris.csv pa...]

--- a/docs/basics/_examples/DL-101-130-112
+++ b/docs/basics/_examples/DL-101-130-112
@@ -1,6 +1,5 @@
 $ git log --oneline
-0259c02 [DATALAD RUNCMD] analyze iris data with classification analysis
-5b94db4 add script for kNN classification and plotting
-fbe9e32 [DATALAD] Added subdataset
-291157d Apply YODA dataset setup
-9da5830 [DATALAD] new dataset
+4c80419 add script for kNN classification and plotting
+e447760 [DATALAD] Added subdataset
+eff57e7 Apply YODA dataset setup
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-130-118
+++ b/docs/basics/_examples/DL-101-130-118
@@ -2,16 +2,13 @@ $ datalad push --to github
 [INFO] Determine push target
 [INFO] Push refspecs
 [INFO] Transfer data
-copy(ok): pairwise_relationships.png (file) [to github...]
-copy(ok): prediction_report.csv (file) [to github...]
 [INFO] Update availability information
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-publish(ok): . (dataset) [refs/heads/git-annex->github:refs/heads/git-annex 8180609..4b573b1]
-publish(ok): . (dataset) [refs/heads/master->github:refs/heads/master [new branch]]
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
 [INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project)
+publish(ok): . (dataset) [refs/heads/git-annex->github:refs/heads/git-annex FROM..TO (REDACTED)]
+publish(ok): . (dataset) [refs/heads/master->github:refs/heads/master [new branch]]
 action summary:
-  copy (ok: 2)
   publish (ok: 2)

--- a/docs/basics/_examples/DL-101-130-122
+++ b/docs/basics/_examples/DL-101-130-122
@@ -1,20 +1,22 @@
 
 $ datalad rerun d715890b36b9a089eedbb0c929f52e182e889735
 [INFO] run commit d715890; (analyze iris data...)
-[INFO] Making sure inputs are available (this may take some time) 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+Traceback (most recent call last):
+  File "/home/me/dl-101/midtermproject/code/script.py", line 2, in <module>
+    import pandas as pd
+ModuleNotFoundError: No module named 'pandas'
+[INFO] == Command exit (modification check follows) =====
 run.remove(ok): pairwise_relationships.png (file) [Removed file]
 run.remove(ok): prediction_report.csv (file) [Removed file]
-[INFO] == Command start (output follows) =====
-action summary:
-  get (notneeded: 2)
-[INFO] == Command exit (modification check follows) =====
-run(ok): /home/me/dl-101/midtermproject (dataset) [python3 code/script.py]
-add(ok): pairwise_relationships.png (file)
-add(ok): prediction_report.csv (file)
+run(error): /home/me/dl-101/midtermproject (dataset) [python3 code/script.py]
+delete(ok): pairwise_relationships.png (file)
+delete(ok): prediction_report.csv (file)
 save(ok): . (dataset)
 action summary:
-  add (ok: 2)
+  delete (ok: 2)
   get (notneeded: 3)
-  run (ok: 1)
+  run (error: 1)
   run.remove (ok: 2)
   save (notneeded: 1, ok: 1)

--- a/docs/basics/_examples/DL-101-132-101
+++ b/docs/basics/_examples/DL-101-132-101
@@ -1,7 +1,6 @@
 $ git log --oneline
-6e38da4 Provide project description
-0259c02 [DATALAD RUNCMD] analyze iris data with classification analysis
-5b94db4 add script for kNN classification and plotting
-fbe9e32 [DATALAD] Added subdataset
-291157d Apply YODA dataset setup
-9da5830 [DATALAD] new dataset
+2e3d361 Provide project description
+4c80419 add script for kNN classification and plotting
+e447760 [DATALAD] Added subdataset
+eff57e7 Apply YODA dataset setup
+7062507 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-132-112
+++ b/docs/basics/_examples/DL-101-132-112
@@ -1,14 +1,14 @@
 $ git log -p -n 1
-commit e295e506c5d6d49a0b22ab16f922d8d22d30c53c
+commit 3adfd398b34c0107828b4b23b48dc548f4b4e512
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 16:59:24 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     finished my midterm project
 
 diff --git a/midterm_project b/midterm_project
-index 291157d..6e38da4 160000
+index eff57e7..2e3d361 160000
 --- a/midterm_project
 +++ b/midterm_project
 @@ -1 +1 @@
--Subproject commit 291157d9c10d6a1f9f95ac6524a47d445ec0d508
-+Subproject commit 6e38da4ff41cdb99f2a766fa2470605abe65c42b
+-Subproject commit eff57e7a902431a1570a7d4f49a04f160bb6259d
++Subproject commit 2e3d3614f635f9a8ba6fad743a480c3bdabb5b9a

--- a/docs/basics/_examples/DL-101-133-102
+++ b/docs/basics/_examples/DL-101-133-102
@@ -1,6 +1,6 @@
 $ cat .datalad/config
 [datalad "dataset"]
-	id = fea11e88-f41c-4447-8e34-17ea56f7ef92
+	id = e3e70682-c209-4cac-629f-6fbed82c07cd
 [datalad "containers.midterm-software"]
 	image = .datalad/environments/midterm-software/image
 	cmdexec = singularity exec {img} {cmd}

--- a/docs/basics/_examples/DL-101-133-103
+++ b/docs/basics/_examples/DL-101-133-103
@@ -1,17 +1,17 @@
 $ git log -n 1 -p
-commit 0e4bcbd2d10d6b523aad0332f9afc4f58f52f9b5
+commit f34b9aa0380e76f663825dc9433a1c2142682295
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:16 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] Configure containerized environment 'midterm-software'
 
 diff --git a/.datalad/config b/.datalad/config
-index 6adc04c..dc0fca8 100644
+index d72c8f0..deb4b2c 100644
 --- a/.datalad/config
 +++ b/.datalad/config
 @@ -1,2 +1,5 @@
  [datalad "dataset"]
-	id = fea11e88-f41c-4447-8e34-17ea56f7ef92
+ 	id = e3e70682-c209-4cac-629f-6fbed82c07cd
 +[datalad "containers.midterm-software"]
 +	image = .datalad/environments/midterm-software/image
 +	cmdexec = singularity exec {img} {cmd}

--- a/docs/basics/_examples/DL-101-133-105
+++ b/docs/basics/_examples/DL-101-133-105
@@ -4,14 +4,9 @@ $ datalad containers-run -m "rerun analysis in container" \
   --output "pairwise_relationships.png" \
   --output "prediction_report.csv" \
   "python3 code/script.py {inputs} {outputs}"
-[INFO] Making sure inputs are available (this may take some time) 
-[INFO] Unlocking files
-unlock(ok): pairwise_relationships.png (file)
-unlock(ok): prediction_report.csv (file)
-[INFO] Recording unlocked state in git
-[INFO] Completed unlocking files
-[INFO] == Command start (output follows) ===== 
-[INFO] == Command exit (modification check follows) ===== 
+[INFO] Making sure inputs are available (this may take some time)
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [singularity exec -B /home/me/dl-101/Data...]
 add(ok): pairwise_relationships.png (file)
 add(ok): prediction_report.csv (file)
@@ -21,4 +16,3 @@ action summary:
   get (notneeded: 4)
   run (ok: 1)
   save (notneeded: 1, ok: 1)
-  unlock (ok: 2)

--- a/docs/basics/_examples/DL-101-133-111
+++ b/docs/basics/_examples/DL-101-133-111
@@ -1,15 +1,15 @@
 $ git log -p -n 1
-commit 263e285456a285eb8708dd2b3a427801d751e745
+commit 0282a0107582999c3eaad979541da6a8a18cfe38
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:22 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD RUNCMD] rerun analysis in container
-    
+
     === Do not change lines below ===
     {
      "chain": [],
      "cmd": "singularity exec -B {pwd} .datalad/environments/midterm-software/image python3 code/script.py {inputs} {outputs}",
-     "dsid": "fea11e88-f41c-4447-8e34-17ea56f7ef92",
+     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
      "exit": 0,
      "extra_inputs": [
       ".datalad/environments/midterm-software/image"
@@ -26,11 +26,18 @@ Date:   Wed Dec 14 17:01:22 2022 +0100
     ^^^ Do not change lines above ^^^
 
 diff --git a/pairwise_relationships.png b/pairwise_relationships.png
-index 0900ce6..963d5a8 120000
---- a/pairwise_relationships.png
+new file mode 120000
+index 0000000..963d5a8
+--- /dev/null
 +++ b/pairwise_relationships.png
-@@ -1 +1 @@
--.git/annex/objects/MP/V8/MD5E-s260804--fe419ff41dd6cd65b4bca2803e3d0190.png/MD5E-s260804--fe419ff41dd6cd65b4bca2803e3d0190.png
-\ No newline at end of file
+@@ -0,0 +1 @@
 +.git/annex/objects/q1/gp/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png
+\ No newline at end of file
+diff --git a/prediction_report.csv b/prediction_report.csv
+new file mode 120000
+index 0000000..42d194b
+--- /dev/null
++++ b/prediction_report.csv
+@@ -0,0 +1 @@
++.git/annex/objects/8q/6M/MD5E-s345--a88cab39b1a5ec59ace322225cc88bc9.csv/MD5E-s345--a88cab39b1a5ec59ace322225cc88bc9.csv
 \ No newline at end of file

--- a/docs/basics/_examples/DL-101-135-101
+++ b/docs/basics/_examples/DL-101-135-101
@@ -1,2 +1,2 @@
 $ datalad --version
-datalad 0.17.9+99.g95214312b
+datalad 0.17.10+2.g23b376756

--- a/docs/basics/_examples/DL-101-135-102
+++ b/docs/basics/_examples/DL-101-135-102
@@ -7,59 +7,61 @@ $ datalad wtf
       - PlaintextKeyring with no encyption v.1.0 at /home/me/.local/share/python_keyring/keyring_pass.cfg
     - config_file: /home/me/.config/python_keyring/keyringrc.cfg
     - data_root: /home/me/.local/share/python_keyring
-## datalad 
-  - version: 0.17.9+99.g95214312b
-## dataset 
+## datalad
+  - version: 0.17.10+2.g23b376756
+## dataset
   - branches:
-    - git-annex@f4808f1
-    - master@b66e68e
-    - sct_computational_reproducibility@b66e68e
-    - sct_create_a_dataset@3cad6a7
-    - sct_datalad_rerun@f08b4b4
-    - sct_input_and_output@65497e0
-    - sct_install_datasets@79cb8c0
-    - sct_keeping_track@287af8e
-    - sct_looking_without_touching@7b91906
-    - sct_modify_content@c4170ce
-    - sct_more_on_DYI_configurations@c57072b
-    - sct_more_on_dataset_nesting@e295e50
-    - sct_networking@c55a616
-    - sct_populate_a_dataset@fa7c9c7
-    - sct_retrace_and_reenact@c495328
-    - sct_stay_up_to_date@77011c9
-    - sct_where_is_waldo@c495328
-    - sct_yoda_project@1abf6d4
-  - id: 5d24f8fb-8339-4fe7-9b64-fec6af4e9676
+    - git-annex@<REDACTED-GITSHA>
+    - master@90f3ec0
+    - sct_computational_reproducibility@90f3ec0
+    - sct_create_a_dataset@24acc0a
+    - sct_datalad_rerun@35769e1
+    - sct_input_and_output@9fed9dc
+    - sct_install_datasets@98db0ec
+    - sct_keeping_track@a4622a5
+    - sct_looking_without_touching@51eede3
+    - sct_modify_content@469f388
+    - sct_more_on_DYI_configurations@4c39ad7
+    - sct_more_on_dataset_nesting@3adfd39
+    - sct_networking@3dee0dc
+    - sct_populate_a_dataset@b47b42a
+    - sct_retrace_and_reenact@3722356
+    - sct_stay_up_to_date@1c6a22d
+    - sct_where_is_waldo@3722356
+    - sct_yoda_project@2dbbd41
+  - id: e3e70682-c209-4cac-629f-6fbed82c07cd
   - metadata: <SENSITIVE, report disabled by configuration>
   - path: /home/me/dl-101/DataLad-101
   - repo: AnnexRepo
-## dependencies 
+## dependencies
   - annexremote: 1.6.0
   - boto: 2.49.0
   - cmd:7z: 16.02
-  - cmd:annex: 10.20221003
-  - cmd:bundled-git: UNKNOWN
-  - cmd:git: 2.37.2
-  - cmd:ssh: 9.0p1
-  - cmd:system-git: 2.37.2
-  - cmd:system-ssh: 9.0p1
-  - git: 3.1.29
-  - gitdb: 4.0.9
-  - humanize: 4.4.0
-  - iso8601: 1.1.0
-  - keyring: 23.9.3
-  - keyrings.alt: 4.2.0
+  - cmd:annex: 10.20220504-1~ndall+1
+  - cmd:bundled-git: 2.30.2
+  - cmd:git: 2.30.2
+  - cmd:ssh: 9.1p1
+  - cmd:system-git: 2.38.1
+  - cmd:system-ssh: 9.1p1
+  - humanize: 4.3.0
+  - iso8601: 1.0.2
+  - keyring: 23.8.2
+  - keyrings.alt: 4.1.1
   - msgpack: 1.0.4
   - platformdirs: 2.5.2
   - requests: 2.28.1
-## environment 
+## environment
+  - GIT_AUTHOR_DATE: 2019-06-18T16:13:00
   - GIT_AUTHOR_EMAIL: elena@example.net
   - GIT_AUTHOR_NAME: Elena Piscopia
+  - GIT_COMMITTER_DATE: 2019-06-18T16:13:00
+  - GIT_COMMITTER_EMAIL: elena@example.net
+  - GIT_COMMITTER_NAME: Elena Piscopia
   - GIT_EDITOR: vim
   - LANG: en_US.UTF-8
   - LANGUAGE: en_US:en
   - LC_CTYPE: en_US.UTF-8
-  - PATH: /home/adina/env/handbook/bin:/home/adina/.dotfiles/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/X11R6/bin:/usr/local/games:/usr/games:/home/adina/.local/bin:/home/adina/bin:/snap/bin:/home/adina/repos/latexrun/:/home/adina/node_modules/.bin:/home/adina/pycharm/pycharm-community-2022.2.2/bin
+  - PATH: VIRTUALENV/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/mih/bin:/home/mih/bin/pycharm/bin:/home/mih/.yarn/bin
 ## extensions
   - container:
     - description: Containerized environments
@@ -94,38 +96,152 @@ $ datalad wtf
           - containers_run
     - load_error: None
     - module: datalad_container
-    - version: 1.1.8
+    - version: 1.1.6
+  - datalad_debian:
+    - description: DataLad for working with Debian packages
+    - entrypoints:
+      - datalad_debian.add_distribution.AddDistribution:
+        - class: AddDistribution
+        - load_error: None
+        - module: datalad_debian.add_distribution
+        - names:
+          - deb-add-distribution
+          - deb_add_distribution
+      - datalad_debian.bootstrap_builder.BootstrapBuilder:
+        - class: BootstrapBuilder
+        - load_error: None
+        - module: datalad_debian.bootstrap_builder
+        - names:
+          - deb-bootstrap-builder
+          - deb_bootstrap_builder
+      - datalad_debian.build_package.BuildPackage:
+        - class: BuildPackage
+        - load_error: None
+        - module: datalad_debian.build_package
+        - names:
+          - deb-build-package
+          - deb_build_package
+      - datalad_debian.configure_builder.ConfigureBuilder:
+        - class: ConfigureBuilder
+        - load_error: None
+        - module: datalad_debian.configure_builder
+        - names:
+          - deb-configure-builder
+          - deb_configure_builder
+      - datalad_debian.new_distribution.NewDistribution:
+        - class: NewDistribution
+        - load_error: None
+        - module: datalad_debian.new_distribution
+        - names:
+          - deb-new-distribution
+          - deb_new_distribution
+      - datalad_debian.new_package.NewPackage:
+        - class: NewPackage
+        - load_error: None
+        - module: datalad_debian.new_package
+        - names:
+          - deb-new-package
+          - deb_new_package
+      - datalad_debian.new_reprepro_repository.NewRepreproRepository:
+        - class: NewRepreproRepository
+        - load_error: None
+        - module: datalad_debian.new_reprepro_repository
+        - names:
+          - deb-new-reprepro-repository
+          - deb_new_reprepro_repository
+      - datalad_debian.update_reprepro_repository.UpdateRepreproRepository:
+        - class: UpdateRepreproRepository
+        - load_error: None
+        - module: datalad_debian.update_reprepro_repository
+        - names:
+          - deb-update-reprepro-repository
+          - deb_update_reprepro_repository
+    - load_error: None
+    - module: datalad_debian
+    - version: 0.0.1+16.g069c3c6
+  - ebrains:
+    - description: HBP/EBRAINS support
+    - entrypoints:
+      - datalad_ebrains.authenticate.Authenticate:
+        - class: Authenticate
+        - load_error: None
+        - module: datalad_ebrains.authenticate
+        - names:
+          - ebrains-authenticate
+          - ebrains_authenticate
+      - datalad_ebrains.clone.Clone:
+        - class: Clone
+        - load_error: None
+        - module: datalad_ebrains.clone
+        - names:
+          - ebrains-clone
+          - ebrains_clone
+    - load_error: None
+    - module: datalad_ebrains
+    - version: 0+untagged.70.g59a9263
+  - gooey:
+    - description: Gooey (GUI)
+    - entrypoints:
+      - datalad_gooey.askpass.GooeyAskPass:
+        - class: GooeyAskPass
+        - load_error: None
+        - module: datalad_gooey.askpass
+        - names:
+          - gooey-askpass
+          - gooey_askpass
+      - datalad_gooey.gooey.Gooey:
+        - class: Gooey
+        - load_error: None
+        - module: datalad_gooey.gooey
+        - names:
+      - datalad_gooey.lsdir.GooeyLsDir:
+        - class: GooeyLsDir
+        - load_error: None
+        - module: datalad_gooey.lsdir
+        - names:
+          - gooey-lsdir
+          - gooey_lsdir
+      - datalad_gooey.status_light.GooeyStatusLight:
+        - class: GooeyStatusLight
+        - load_error: None
+        - module: datalad_gooey.status_light
+        - names:
+          - gooey-status-light
+          - gooey_status_light
+    - load_error: None
+    - module: datalad_gooey
+    - version: 0.2.0
   - next:
     - description: What is next in DataLad
-    - entrypoints: 
+    - entrypoints:
       - datalad_next.commands.create_sibling_webdav.CreateSiblingWebDAV:
         - class: CreateSiblingWebDAV
         - load_error: None
         - module: datalad_next.commands.create_sibling_webdav
-        - names: 
+        - names:
           - create-sibling-webdav
       - datalad_next.commands.credentials.Credentials:
         - class: Credentials
         - load_error: None
         - module: datalad_next.commands.credentials
-        - names: 
+        - names:
       - datalad_next.commands.download.Download:
         - class: Download
         - load_error: None
         - module: datalad_next.commands.download
-        - names: 
+        - names:
           - download
       - datalad_next.commands.tree.TreeCommand:
         - class: TreeCommand
         - load_error: None
         - module: datalad_next.commands.tree
-        - names: 
+        - names:
           - tree
     - load_error: None
     - module: datalad_next
-    - version: 0.6.3+174.g74bbd95
-## git-annex 
-  - build flags: 
+    - version: 0.6.3+211.gdedaf93
+## git-annex
+  - build flags:
     - Assistant
     - Webapp
     - Pairing
@@ -134,24 +250,23 @@ $ datalad wtf
     - DesktopNotify
     - TorrentParser
     - MagicMime
-    - Benchmark
     - Feeds
     - Testsuite
     - S3
     - WebDAV
-  - dependency versions: 
-    - aws-0.22.1
+  - dependency versions:
+    - aws-0.22
     - bloomfilter-2.0.1.0
-    - cryptonite-0.29
+    - cryptonite-0.26
     - DAV-1.3.4
-    - feed-1.3.2.1
-    - ghc-9.0.2
-    - http-client-0.7.11
-    - persistent-sqlite-2.13.1.0
+    - feed-1.3.0.1
+    - ghc-8.8.4
+    - http-client-0.6.4.1
+    - persistent-sqlite-2.10.6.2
     - torrent-10000.1.1
-    - uuid-1.3.15
-    - yesod-1.6.2
-  - key/value backends: 
+    - uuid-1.3.13
+    - yesod-1.6.1.0
+  - key/value backends:
     - SHA256E
     - SHA256
     - SHA512E
@@ -201,9 +316,9 @@ $ datalad wtf
     - WORM
     - URL
     - X*
-  - local repository version: 10
+  - local repository version: 8
   - operating system: linux x86_64
-  - remote types: 
+  - remote types:
     - git
     - gcrypt
     - p2p
@@ -223,11 +338,11 @@ $ datalad wtf
     - borg
     - hook
     - external
-  - supported repository versions: 
+  - supported repository versions:
     - 8
     - 9
     - 10
-  - upgrade supported from repository versions: 
+  - upgrade supported from repository versions:
     - 0
     - 1
     - 2
@@ -239,75 +354,67 @@ $ datalad wtf
     - 8
     - 9
     - 10
-  - version: 10.20221003
-## location 
+  - version: 10.20220504-1~ndall+1
+## location
   - path: /home/me/dl-101/DataLad-101
   - type: dataset
-## metadata_extractors 
+## metadata_extractors
   - annex:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.annex
   - audio:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: ModuleNotFoundError(No module named 'mutagen')
     - module: datalad.metadata.extractors.audio
   - datacite:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.datacite
   - datalad_core:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.datalad_core
   - datalad_rfc822:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.datalad_rfc822
   - exif:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: ModuleNotFoundError(No module named 'exifread')
     - module: datalad.metadata.extractors.exif
   - frictionless_datapackage:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.frictionless_datapackage
   - image:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: None
     - module: datalad.metadata.extractors.image
   - xmp:
-    - distribution: datalad 0.17.9+99.g95214312b
+    - distribution: datalad 0.17.9+84.ge23154a54
     - load_error: ModuleNotFoundError(No module named 'libxmp')
     - module: datalad.metadata.extractors.xmp
 ## metadata_indexers
-## python 
+## python
   - implementation: CPython
-  - version: 3.10.7
-## system 
-  - distribution: debian/testing/bookworm
-  - encoding: 
+  - version: 3.10.8
+## system
+  - distribution: debian/n/a/bookworm
+  - encoding:
     - default: utf-8
     - filesystem: utf-8
     - locale.prefered: UTF-8
   - filesystem:
     - CWD:
-      - max_pathlength: 4096
-      - mount_opts: rw,relatime,errors=remount-ro
       - path: /home/me/dl-101/DataLad-101
-      - type: ext4
     - HOME:
-      - max_pathlength: 4096
-      - mount_opts: rw,relatime,errors=remount-ro
       - path: /home/me
-      - type: ext4
     - TMP:
-      - max_pathlength: 4096
-      - mount_opts: rw,relatime,errors=remount-ro
       - path: /tmp
-      - type: ext4
   - max_path_length: 283
   - name: Linux
-  - release: 5.19.0-2-amd64
+  - release: 6.0.0-4-amd64
   - type: posix
-  - version: #1 SMP PREEMPT_DYNAMIC Debian 5.19.11-1 (2022-09-24)
+  - version: #1 SMP PREEMPT_DYNAMIC Debian 6.0.8-1 (2022-11-11)
+Hint: install psutil to get filesystem information

--- a/docs/basics/_examples/DL-101-135-105
+++ b/docs/basics/_examples/DL-101-135-105
@@ -1,8 +1,8 @@
 $ datalad --log-level debug status
-[DEBUG] Command line args 1st pass for DataLad 0.17.9+99.g95214312b. Parsed: Namespace() Unparsed: ['status']
-[DEBUG] Building doc for <class 'datalad.core.local.status.Status'> 
-[DEBUG] Parsing known args among ['/home/adina/env/handbook/bin/datalad', '--log-level', 'debug', 'status']
-[DEBUG] Determined class of decorated function: <class 'datalad.core.local.status.Status'> 
+[DEBUG] Command line args 1st pass for DataLad 0.17.10+2.g23b376756. Parsed: Namespace() Unparsed: ['status']
+[DEBUG] Building doc for <class 'datalad.core.local.status.Status'>
+[DEBUG] Parsing known args among ['VIRTUALENV/bin/datalad', '--log-level', 'debug', 'status']
+[DEBUG] Determined class of decorated function: <class 'datalad.core.local.status.Status'>
 [DEBUG] Resolved dataset to report status: /home/me/dl-101/DataLad-101
 [DEBUG] Run ['git', 'config', '-z', '-l', '--show-origin'] (protocol_class=StdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101)
 [DEBUG] Finished ['git', 'config', '-z', '-l', '--show-origin'] with status 0
@@ -10,17 +10,17 @@ $ datalad --log-level debug status
 [DEBUG] Finished ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/me/dl-101/DataLad-101/.datalad/config'] with status 0
 [DEBUG] Querying AnnexRepo(/home/me/dl-101/DataLad-101).diffstatus() for paths: None
 [DEBUG] Run ['git', '-c', 'diff.ignoreSubmodules=none', 'rev-parse', '--quiet', '--verify', 'HEAD^{commit}'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101)
-[DEBUG] AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...) 
+[DEBUG] AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...)
 [DEBUG] Query repo: ['ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory']
 [DEBUG] Run ['git', '-c', 'diff.ignoreSubmodules=none', 'ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101)
 [DEBUG] Done query repo: ['ls-files', '--stage', '-z', '--exclude-standard', '-o', '--directory', '--no-empty-directory']
-[DEBUG] Done AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...) 
+[DEBUG] Done AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...)
 [DEBUG] Run ['git', '-c', 'diff.ignoreSubmodules=none', 'ls-files', '-z', '-m', '-d'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101)
-[DEBUG] AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...) 
+[DEBUG] AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...)
 [DEBUG] Query repo: ['ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l']
 [DEBUG] Run ['git', '-c', 'diff.ignoreSubmodules=none', 'ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l'] (protocol_class=GeneratorStdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101)
 [DEBUG] Done query repo: ['ls-tree', 'HEAD', '-z', '-r', '--full-tree', '-l']
-[DEBUG] Done AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...) 
+[DEBUG] Done AnnexRepo(/home/me/dl-101/DataLad-101).get_content_info(...)
 [DEBUG] Run ['git', 'config', '-z', '-l', '--show-origin'] (protocol_class=StdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101/midterm_project)
 [DEBUG] Finished ['git', 'config', '-z', '-l', '--show-origin'] with status 0
 [DEBUG] Run ['git', 'config', '-z', '-l', '--show-origin', '--file', '/home/me/dl-101/DataLad-101/midterm_project/.datalad/config'] (protocol_class=StdOutErrCapture) (cwd=/home/me/dl-101/DataLad-101/midterm_project)

--- a/docs/basics/_examples/DL-101-136-101
+++ b/docs/basics/_examples/DL-101-136-101
@@ -2,9 +2,9 @@ $ cd books/
 $ mv TLCL.pdf The_Linux_Command_Line.pdf
 $ ls -lah
 total 24K
-drwxr-xr-x 2 adina adina 4.0K Dec 14 17:01 .
-drwxr-xr-x 8 adina adina 4.0K Dec 14 17:01 ..
-lrwxrwxrwx 1 adina adina  131 Jan 19  2009 bash_guide.pdf -> ../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-lrwxrwxrwx 1 adina adina  131 Dec  8  2021 byte-of-python.pdf -> ../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
-lrwxrwxrwx 1 adina adina  133 Dec  7  2021 progit.pdf -> ../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
-lrwxrwxrwx 1 adina adina  131 Jan 28  2019 The_Linux_Command_Line.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+drwxrwxr-x 2 elena elena 4.0K 2019-06-18 16:13 .
+drwxrwxr-x 8 elena elena 4.0K 2019-06-18 16:13 ..
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 bash_guide.pdf -> ../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 byte-of-python.pdf -> ../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
+lrwxrwxrwx 1 elena elena 133 2019-06-18 16:13 progit.pdf -> ../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 The_Linux_Command_Line.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-136-104
+++ b/docs/basics/_examples/DL-101-136-104
@@ -1,7 +1,7 @@
 $ git log -n 1 -p
-commit 1cd81ab630a26762f5c9dba8ad3b7de330061eab
+commit f93118d5867b33d3854e6dc05ea667c3cf90f573
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:26 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     rename the book
 

--- a/docs/basics/_examples/DL-101-136-105
+++ b/docs/basics/_examples/DL-101-136-105
@@ -1,4 +1,4 @@
 $ git reset --hard HEAD~1
 $ datalad status
-HEAD is now at b66e68e add container and execute analysis within container
+HEAD is now at 90f3ec0 add container and execute analysis within container
 nothing to save, working tree clean

--- a/docs/basics/_examples/DL-101-136-109
+++ b/docs/basics/_examples/DL-101-136-109
@@ -1,4 +1,4 @@
 $ git commit -m "rename book"
-[master 475c300] rename book
+[master dbaa534] rename book
  1 file changed, 0 insertions(+), 0 deletions(-)
  rename books/{TLCL.pdf => The_Linux_Command_Line.pdf} (100%)

--- a/docs/basics/_examples/DL-101-136-110
+++ b/docs/basics/_examples/DL-101-136-110
@@ -1,4 +1,4 @@
 $ git reset --hard HEAD~1
 $ datalad status
-HEAD is now at b66e68e add container and execute analysis within container
+HEAD is now at 90f3ec0 add container and execute analysis within container
 nothing to save, working tree clean

--- a/docs/basics/_examples/DL-101-136-121
+++ b/docs/basics/_examples/DL-101-136-121
@@ -1,3 +1,3 @@
 $ cd ../
 $ ls -l TLCL.pdf
-lrwxrwxrwx 1 adina adina 131 Dec 14 17:01 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-136-122
+++ b/docs/basics/_examples/DL-101-136-122
@@ -7,4 +7,4 @@ action summary:
   add (ok: 1)
   delete (ok: 1)
   save (ok: 1)
-lrwxrwxrwx 1 adina adina 128 Dec 14 17:01 TLCL.pdf -> .git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+lrwxrwxrwx 1 elena elena 128 2019-06-18 16:13 TLCL.pdf -> .git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-136-123
+++ b/docs/basics/_examples/DL-101-136-123
@@ -1,7 +1,7 @@
 $ git log -n 1 -p
-commit 0d615ccd59c51768b34c0a7a44aa320f18efe24f
+commit b408344b557ccb064f2df58a6309377a1c855cab
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:27 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     moved book into root
 

--- a/docs/basics/_examples/DL-101-136-124
+++ b/docs/basics/_examples/DL-101-136-124
@@ -1,2 +1,2 @@
 $ git reset --hard HEAD~1
-HEAD is now at b66e68e add container and execute analysis within container
+HEAD is now at 90f3ec0 add container and execute analysis within container

--- a/docs/basics/_examples/DL-101-136-128
+++ b/docs/basics/_examples/DL-101-136-128
@@ -1,7 +1,7 @@
 $ cd midterm_project
 $ git log notes.txt
-commit 27280681cae72f7820db61d06ac76c63c147edfc
+commit 400c43620a13a13d9ac7afcb1f21d04c03aa0af4
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:28 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     moved notes.txt from root of top-ds to midterm subds

--- a/docs/basics/_examples/DL-101-136-129
+++ b/docs/basics/_examples/DL-101-136-129
@@ -4,5 +4,5 @@ $ git reset --hard HEAD~
 # in DataLad-101
 $ cd ../
 $ git reset --hard HEAD~
-HEAD is now at 263e285 [DATALAD RUNCMD] rerun analysis in container
-HEAD is now at b66e68e add container and execute analysis within container
+HEAD is now at 0282a01 [DATALAD RUNCMD] rerun analysis in container
+HEAD is now at 90f3ec0 add container and execute analysis within container

--- a/docs/basics/_examples/DL-101-136-133
+++ b/docs/basics/_examples/DL-101-136-133
@@ -1,5 +1,5 @@
 $ git reset --hard HEAD~
 $ cd ../
 $ git reset --hard HEAD~
-HEAD is now at 263e285 [DATALAD RUNCMD] rerun analysis in container
-HEAD is now at b66e68e add container and execute analysis within container
+HEAD is now at 0282a01 [DATALAD RUNCMD] rerun analysis in container
+HEAD is now at 90f3ec0 add container and execute analysis within container

--- a/docs/basics/_examples/DL-101-136-136
+++ b/docs/basics/_examples/DL-101-136-136
@@ -1,5 +1,5 @@
 $ cd midterm_project
 $ git annex whereis TLCL.pdf
 whereis TLCL.pdf (1 copy)
-	f99ce3a1-b0d4-4d88-b0eb-068589f19a5b -- me@muninn:~/dl-101/DataLad-101/midterm_project [here]
+  	REDACTED-UUID -- me@meiner:~/dl-101/DataLad-101/midterm_project [here]
 ok

--- a/docs/basics/_examples/DL-101-136-142
+++ b/docs/basics/_examples/DL-101-136-142
@@ -1,7 +1,7 @@
 $ git log -n 1 -p
-commit f485657900d8412a5d162a1c36e1fe91dee5f5ca
+commit 68b3cf90ea0af917fbde31e45cffe362a4bdee87
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:33 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add copy of TLCL.pdf
 

--- a/docs/basics/_examples/DL-101-136-143
+++ b/docs/basics/_examples/DL-101-136-143
@@ -1,4 +1,4 @@
 $ ls -l copyofTLCL.pdf
 $ ls -l books/TLCL.pdf
-lrwxrwxrwx 1 adina adina 128 Dec 14 17:01 copyofTLCL.pdf -> .git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
-lrwxrwxrwx 1 adina adina 131 Jan 28  2019 books/TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+lrwxrwxrwx 1 elena elena 128 2019-06-18 16:13 copyofTLCL.pdf -> .git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+lrwxrwxrwx 1 elena elena 131 2019-06-18 16:13 books/TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf

--- a/docs/basics/_examples/DL-101-136-144
+++ b/docs/basics/_examples/DL-101-136-144
@@ -1,2 +1,2 @@
 $ git reset --hard HEAD~1
-HEAD is now at d48d7a8 move book back from midterm_project
+HEAD is now at d175b5e move book back from midterm_project

--- a/docs/basics/_examples/DL-101-136-145
+++ b/docs/basics/_examples/DL-101-136-145
@@ -1,5 +1,5 @@
 $ datalad copy-file notes.txt midterm_project -d midterm_project
-[INFO] Copying non-annexed file or copy into non-annex dataset: /home/me/dl-101/DataLad-101/notes.txt -> <datalad.local.copy_file._CachedRepo object at 0x7fe0bc110550>
+[INFO] Copying non-annexed file or copy into non-annex dataset: /home/me/dl-101/DataLad-101/notes.txt -> <datalad.local.copy_file._CachedRepo object at REDACTED-MEMORYADDRESS
 copy_file(ok): /home/me/dl-101/DataLad-101/notes.txt
 add(ok): notes.txt (file)
 save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-136-149
+++ b/docs/basics/_examples/DL-101-136-149
@@ -1,7 +1,7 @@
 $ cd midterm_project
 $ git log notes.txt
-commit d2970df1078a52bbff0a7966e017c40e398b8b20
+commit d464eca87646a497cc0cae321cb96567fd3daa21
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:33 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] Recorded changes

--- a/docs/basics/_examples/DL-101-136-150
+++ b/docs/basics/_examples/DL-101-136-150
@@ -1,2 +1,2 @@
 $ git reset --hard HEAD~2
-HEAD is now at 0cd8e99 move book back from midterm_project
+HEAD is now at ef9112f move book back from midterm_project

--- a/docs/basics/_examples/DL-101-136-153
+++ b/docs/basics/_examples/DL-101-136-153
@@ -1,2 +1,2 @@
 $ git reset --hard HEAD~1
-HEAD is now at d48d7a8 move book back from midterm_project
+HEAD is now at d175b5e move book back from midterm_project

--- a/docs/basics/_examples/DL-101-136-157
+++ b/docs/basics/_examples/DL-101-136-157
@@ -1,3 +1,3 @@
 $ git reset --hard HEAD~1
 warning: unable to rmdir 'longnow': Directory not empty
-HEAD is now at d48d7a8 move book back from midterm_project
+HEAD is now at d175b5e move book back from midterm_project

--- a/docs/basics/_examples/DL-101-136-160
+++ b/docs/basics/_examples/DL-101-136-160
@@ -6,19 +6,18 @@ $ cat .git/config
 	logallrefupdates = true
 	editor = nano
 [annex]
-	uuid = 49a69e90-9581-4205-b2d5-a5c3fe832f0d
-	version = 10
+	uuid = 46b169aa-bb91-42d6-be06-355d957fb4f7
+	version = 8
 [filter "annex"]
 	smudge = git-annex smudge -- %f
 	clean = git-annex smudge --clean -- %f
-	process = git-annex filter-process
 [submodule "recordings/longnow"]
 	active = true
 	url = https://github.com/datalad-datasets/longnow-podcasts.git
 [remote "roommate"]
 	url = ../mock_user/DataLad-101
 	fetch = +refs/heads/*:refs/remotes/roommate/*
-	annex-uuid = bd057cda-8db2-4bcc-aff2-975cb5b000cf
+	annex-uuid = REDACTED-RANDOM-UUID
 	annex-ignore = false
 [submodule "midterm_project"]
 	active = true

--- a/docs/basics/_examples/DL-101-136-162
+++ b/docs/basics/_examples/DL-101-136-162
@@ -2,7 +2,7 @@
 $ cd ../DataLad-101
 # attempt a datalad update
 $ datalad update
-[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101) 
+[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101)
 update(error): . (dataset) [Fetch failed: CommandError(CommandError: 'git -c diff.ignoreSubmodules=none fetch --verbose --progress --no-recurse-submodules --prune roommate' failed with exitcode 128 under /home/me/dl-101/DataLad-101 [err: 'fatal: '../mock_user/DataLad-101' does not appear to be a git repository
 fatal: Could not read from remote repository.
 

--- a/docs/basics/_examples/DL-101-136-164
+++ b/docs/basics/_examples/DL-101-136-164
@@ -6,19 +6,18 @@ $ cat .git/config
 	logallrefupdates = true
 	editor = nano
 [annex]
-	uuid = 49a69e90-9581-4205-b2d5-a5c3fe832f0d
-	version = 10
+	uuid = 46b169aa-bb91-42d6-be06-355d957fb4f7
+	version = 8
 [filter "annex"]
 	smudge = git-annex smudge -- %f
 	clean = git-annex smudge --clean -- %f
-	process = git-annex filter-process
 [submodule "recordings/longnow"]
 	active = true
 	url = https://github.com/datalad-datasets/longnow-podcasts.git
 [remote "roommate"]
 	url = ../mock_user/onemoredir/DataLad-101
 	fetch = +refs/heads/*:refs/remotes/roommate/*
-	annex-uuid = bd057cda-8db2-4bcc-aff2-975cb5b000cf
+	annex-uuid = REDACTED-RANDOM-UUID
 	annex-ignore = false
 [submodule "midterm_project"]
 	active = true

--- a/docs/basics/_examples/DL-101-136-165
+++ b/docs/basics/_examples/DL-101-136-165
@@ -1,3 +1,3 @@
 $ datalad update
-[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101) 
+[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101)
 update(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-136-168
+++ b/docs/basics/_examples/DL-101-136-168
@@ -1,7 +1,7 @@
 $ git log -p -n 1
-commit d48d7a81f513d0b9c8696ea550cff819a7d96d24
+commit d175b5e8567659734c7d660581792c149fd6c8cb
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:32 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     move book back from midterm_project
 
@@ -14,9 +14,9 @@ index 0000000..4c84b61
 +../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
 \ No newline at end of file
 diff --git a/midterm_project b/midterm_project
-index 65aacf3..0cd8e99 160000
+index f77d011..ef9112f 160000
 --- a/midterm_project
 +++ b/midterm_project
 @@ -1 +1 @@
--Subproject commit 65aacf3b830b721c97f3d66ddf3febc6da8d5e8b
-+Subproject commit 0cd8e9937c31122823ea8056a8e0f90535912b9a
+-Subproject commit f77d0114c7aa2d731960187c0da6847e33eb4f32
++Subproject commit ef9112facb6e42758204005c8da2b7606b32d11e

--- a/docs/basics/_examples/DL-101-136-170
+++ b/docs/basics/_examples/DL-101-136-170
@@ -11,4 +11,4 @@ action summary:
   add (ok: 1)
   download_url (ok: 1)
   save (ok: 1)
-lrwxrwxrwx 1 adina adina 128 Oct  6  2013 flowers.jpg -> .git/annex/objects/7q/9Z/MD5E-s4487679--3898ef0e3497a89fa1ea74698992bf51.jpg/MD5E-s4487679--3898ef0e3497a89fa1ea74698992bf51.jpg
+lrwxrwxrwx 1 elena elena 128 2019-06-18 16:13  2013 flowers.jpg -> .git/annex/objects/7q/9Z/MD5E-s4487679--3898ef0e3497a89fa1ea74698992bf51.jpg/MD5E-s4487679--3898ef0e3497a89fa1ea74698992bf51.jpg

--- a/docs/basics/_examples/DL-101-136-174
+++ b/docs/basics/_examples/DL-101-136-174
@@ -1,6 +1,6 @@
 $ git reset --hard HEAD~1
 $ ls
-HEAD is now at 5403d26 Added flower mosaic from wikimedia
+HEAD is now at 7130582 Added flower mosaic from wikimedia
 books
 code
 flowers.jpg

--- a/docs/basics/_examples/DL-101-136-177
+++ b/docs/basics/_examples/DL-101-136-177
@@ -1,5 +1,6 @@
 $ convert xc:none -page Letter a.pdf
 $ datalad save -m "add empty pdf"
+convert-im6.q16: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421.
 add(ok): a.pdf (file)
 save(ok): . (dataset)
 action summary:

--- a/docs/basics/_examples/DL-101-136-178
+++ b/docs/basics/_examples/DL-101-136-178
@@ -1,2 +1,1 @@
 $ datalad drop a.pdf
-drop(error): a.pdf (file) [unsafe; Could only verify the existence of 0 out of 1 necessary copy; (Use --reckless availability to override this check, or adjust numcopies.)]

--- a/docs/basics/_examples/DL-101-136-179
+++ b/docs/basics/_examples/DL-101-136-179
@@ -1,2 +1,1 @@
 $ datalad drop --reckless availability a.pdf
-drop(ok): a.pdf (file)

--- a/docs/basics/_examples/DL-101-136-180
+++ b/docs/basics/_examples/DL-101-136-180
@@ -1,2 +1,2 @@
 $ git reset --hard HEAD~2
-HEAD is now at 5fb84f0 save cropped logos to Git
+HEAD is now at 706b223 save cropped logos to Git

--- a/docs/basics/_examples/DL-101-137-101
+++ b/docs/basics/_examples/DL-101-137-101
@@ -1,16 +1,16 @@
 $ git log -15 --oneline
-99126bb remove obsolete subds
-3de5206 [DATALAD] Added subdataset
-5fb84f0 save cropped logos to Git
-d48d7a8 move book back from midterm_project
-3ea2c19 move book into midterm_project
-b66e68e add container and execute analysis within container
-e295e50 finished my midterm project
-1abf6d4 [DATALAD] Recorded changes
-ab0d331 add note on DataLad's procedures
-c57072b add note on configurations and git config
-c55a616 Add note on adding siblings
-0319eb7 Merge remote-tracking branch 'roommate/master'
-9f91708 Include nesting demo from datalad website
-77011c9 add note about datalad update
-c495328 add note on git annex whereis
+9456110 remove obsolete subds
+2a002ad [DATALAD] Added subdataset
+706b223 save cropped logos to Git
+d175b5e move book back from midterm_project
+7947e79 move book into midterm_project
+90f3ec0 add container and execute analysis within container
+3adfd39 finished my midterm project
+2dbbd41 [DATALAD] Recorded changes
+eb76389 add note on DataLad's procedures
+4c39ad7 add note on configurations and git config
+3dee0dc Add note on adding siblings
+584ce91 Merge remote-tracking branch 'roommate/master'
+1c6a22d add note about datalad update
+d2254b2 Include nesting demo from datalad website
+3722356 add note on git annex whereis

--- a/docs/basics/_examples/DL-101-137-105
+++ b/docs/basics/_examples/DL-101-137-105
@@ -1,7 +1,7 @@
 $ git log -p -1
-commit d9a7846853e8170ffb3a1218bddef5a3783d0184
+commit 4ff83852cf0260776621b4ab14c1b548fb81a5e9
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:51 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] Recorded changes
 

--- a/docs/basics/_examples/DL-101-137-106
+++ b/docs/basics/_examples/DL-101-137-106
@@ -1,4 +1,4 @@
 $ git log -n 3 --oneline
-d9a7846 [DATALAD] Recorded changes
-99126bb remove obsolete subds
-3de5206 [DATALAD] Added subdataset
+4ff8385 [DATALAD] Recorded changes
+9456110 remove obsolete subds
+2a002ad [DATALAD] Added subdataset

--- a/docs/basics/_examples/DL-101-137-107
+++ b/docs/basics/_examples/DL-101-137-107
@@ -1,2 +1,2 @@
 
-$ git reset --mixed 99126bbb010d6ae75a4edcf2c4c78b9d65698bde
+$ git reset --mixed 9456110db1d4c5196438bdfbcdbe5fbc3c92a1ff

--- a/docs/basics/_examples/DL-101-137-108
+++ b/docs/basics/_examples/DL-101-137-108
@@ -1,3 +1,3 @@
 $ git log -n 2 --oneline
-99126bb remove obsolete subds
-3de5206 [DATALAD] Added subdataset
+9456110 remove obsolete subds
+2a002ad [DATALAD] Added subdataset

--- a/docs/basics/_examples/DL-101-137-112
+++ b/docs/basics/_examples/DL-101-137-112
@@ -1,12 +1,12 @@
 $ git log -2
-commit 8112ec1725aa3648b94fe6fe5b35597abb4869bd
+commit 8b385b01cc0531710257340781c34258067c8244
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:52 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     save my favorite Git joke
 
-commit 99126bbb010d6ae75a4edcf2c4c78b9d65698bde
+commit 9456110db1d4c5196438bdfbcdbe5fbc3c92a1ff
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:51 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     remove obsolete subds

--- a/docs/basics/_examples/DL-101-137-113
+++ b/docs/basics/_examples/DL-101-137-113
@@ -2,6 +2,7 @@
 $ convert xc:none -page Letter apdffile.pdf
 # accidentally save it
 $ datalad save
+convert-im6.q16: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421.
 add(ok): Gitjoke1.txt (file)
 add(ok): Gitjoke3.txt (file)
 add(ok): apdffile.pdf (file)

--- a/docs/basics/_examples/DL-101-137-114
+++ b/docs/basics/_examples/DL-101-137-114
@@ -1,2 +1,2 @@
 $ ls -l apdffile.pdf
-lrwxrwxrwx 1 adina adina 122 Dec 14 17:01 apdffile.pdf -> .git/annex/objects/7Z/xF/MD5E-s1858--03b46bc32de0fc2fac45b8bc006f103c.pdf/MD5E-s1858--03b46bc32de0fc2fac45b8bc006f103c.pdf
+-rw-rw-r-- 1 elena elena 0 2019-06-18 16:13 apdffile.pdf

--- a/docs/basics/_examples/DL-101-137-115
+++ b/docs/basics/_examples/DL-101-137-115
@@ -1,5 +1,1 @@
 $ datalad unlock apdffile.pdf
-[INFO] Unlocking files
-unlock(ok): apdffile.pdf (file)
-[INFO] Recording unlocked state in git
-[INFO] Completed unlocking files

--- a/docs/basics/_examples/DL-101-137-116
+++ b/docs/basics/_examples/DL-101-137-116
@@ -1,2 +1,2 @@
 $ ls -l apdffile.pdf
--rw-r--r-- 1 adina adina 1858 Dec 14 17:01 apdffile.pdf
+-rw-rw-r-- 1 elena elena 0 2019-06-18 16:13 apdffile.pdf

--- a/docs/basics/_examples/DL-101-137-117
+++ b/docs/basics/_examples/DL-101-137-117
@@ -1,4 +1,4 @@
 $ git log -n 3 --oneline
-68a6c97 [DATALAD] Recorded changes
-8112ec1 save my favorite Git joke
-99126bb remove obsolete subds
+8925513 [DATALAD] Recorded changes
+8b385b0 save my favorite Git joke
+9456110 remove obsolete subds

--- a/docs/basics/_examples/DL-101-137-118
+++ b/docs/basics/_examples/DL-101-137-118
@@ -1,2 +1,2 @@
 
-$ git reset --mixed 8112ec1725aa3648b94fe6fe5b35597abb4869bd
+$ git reset --mixed 8b385b01cc0531710257340781c34258067c8244

--- a/docs/basics/_examples/DL-101-137-119
+++ b/docs/basics/_examples/DL-101-137-119
@@ -1,3 +1,3 @@
 $ git log -n 2 --oneline
-8112ec1 save my favorite Git joke
-99126bb remove obsolete subds
+8b385b0 save my favorite Git joke
+9456110 remove obsolete subds

--- a/docs/basics/_examples/DL-101-137-121
+++ b/docs/basics/_examples/DL-101-137-121
@@ -1,21 +1,21 @@
 $ git log -n 20 --oneline
-8112ec1 save my favorite Git joke
-99126bb remove obsolete subds
-3de5206 [DATALAD] Added subdataset
-5fb84f0 save cropped logos to Git
-d48d7a8 move book back from midterm_project
-3ea2c19 move book into midterm_project
-b66e68e add container and execute analysis within container
-e295e50 finished my midterm project
-1abf6d4 [DATALAD] Recorded changes
-ab0d331 add note on DataLad's procedures
-c57072b add note on configurations and git config
-c55a616 Add note on adding siblings
-0319eb7 Merge remote-tracking branch 'roommate/master'
-9f91708 Include nesting demo from datalad website
-77011c9 add note about datalad update
-c495328 add note on git annex whereis
-7b91906 add note about cloning from paths and recursive datalad get
-1f1f356 add note on clean datasets
-a5729b5 [DATALAD RUNCMD] Resize logo for slides
-d0e2f68 [DATALAD RUNCMD] Resize logo for slides
+8b385b0 save my favorite Git joke
+9456110 remove obsolete subds
+2a002ad [DATALAD] Added subdataset
+706b223 save cropped logos to Git
+d175b5e move book back from midterm_project
+7947e79 move book into midterm_project
+90f3ec0 add container and execute analysis within container
+3adfd39 finished my midterm project
+2dbbd41 [DATALAD] Recorded changes
+eb76389 add note on DataLad's procedures
+4c39ad7 add note on configurations and git config
+3dee0dc Add note on adding siblings
+584ce91 Merge remote-tracking branch 'roommate/master'
+1c6a22d add note about datalad update
+d2254b2 Include nesting demo from datalad website
+3722356 add note on git annex whereis
+51eede3 add note about cloning from paths and recursive datalad get
+db17294 add note on clean datasets
+7948b86 [DATALAD RUNCMD] Resize logo for slides
+a674b2d [DATALAD RUNCMD] Resize logo for slides

--- a/docs/basics/_examples/DL-101-137-122
+++ b/docs/basics/_examples/DL-101-137-122
@@ -1,7 +1,7 @@
 
-$ git checkout 7b91906b81f11207310ed2694289ad5ee8872337
+$ git checkout 51eede3a47d4ebfcbe8d666d448a02c838843ffd
 warning: unable to rmdir 'midterm_project': Directory not empty
-Note: switching to '7b91906b81f11207310ed2694289ad5ee8872337'.
+Note: switching to '51eede3a47d4ebfcbe8d666d448a02c838843ffd'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
@@ -18,4 +18,4 @@ Or undo this operation with:
 
 Turn off this advice by setting config variable advice.detachedHead to false
 
-HEAD is now at 7b91906 add note about cloning from paths and recursive datalad get
+HEAD is now at 51eede3 add note about cloning from paths and recursive datalad get

--- a/docs/basics/_examples/DL-101-137-124
+++ b/docs/basics/_examples/DL-101-137-124
@@ -1,3 +1,3 @@
 $ git checkout master
-Previous HEAD position was 7b91906 add note about cloning from paths and recursive datalad get
+Previous HEAD position was 51eede3 add note about cloning from paths and recursive datalad get
 Switched to branch 'master'

--- a/docs/basics/_examples/DL-101-137-126
+++ b/docs/basics/_examples/DL-101-137-126
@@ -8,3 +8,4 @@ to a dataset. Procedures shipped with DataLad or its extensions
 starting with a "cfg" prefix can also be applied at the creation of a
 dataset with "datalad create -c <PROC-NAME> <PATH>" (omitting the
 "cfg" prefix).
+

--- a/docs/basics/_examples/DL-101-137-127
+++ b/docs/basics/_examples/DL-101-137-127
@@ -1,5 +1,5 @@
 
-$ git cat-file --textconv 7b91906b81f11207310ed2694289ad5ee8872337:notes.txt
+$ git cat-file --textconv 51eede3a47d4ebfcbe8d666d448a02c838843ffd:notes.txt
 One can create a new dataset with 'datalad create [--description] PATH'.
 The dataset is created empty
 

--- a/docs/basics/_examples/DL-101-137-132
+++ b/docs/basics/_examples/DL-101-137-132
@@ -1,3 +1,3 @@
 $ git log -n 2 --oneline
-d84fbd7 add joke evaluation to joke
-8112ec1 save my favorite Git joke
+e7fe11a add joke evaluation to joke
+8b385b0 save my favorite Git joke

--- a/docs/basics/_examples/DL-101-137-133
+++ b/docs/basics/_examples/DL-101-137-133
@@ -1,3 +1,3 @@
 
-$ git reset --hard 8112ec1725aa3648b94fe6fe5b35597abb4869bd
-HEAD is now at 8112ec1 save my favorite Git joke
+$ git reset --hard 8b385b01cc0531710257340781c34258067c8244
+HEAD is now at 8b385b0 save my favorite Git joke

--- a/docs/basics/_examples/DL-101-137-144
+++ b/docs/basics/_examples/DL-101-137-144
@@ -1,5 +1,5 @@
 
-$ git revert 7571eb8c2caf6e1c4b23c07fce96a8d6142e55af
-[master 5346fb9] Revert "did a bad modification"
- Date: Wed Dec 14 17:01:56 2022 +0100
+$ git revert eee275056d14ce7b224c59524b4da58f62a7a9c9
+[master b8ced8e] Revert "did a bad modification"
+ Date: Tue Jun 18 16:13:00 2019 +0200
  1 file changed, 1 deletion(-)

--- a/docs/basics/_examples/DL-101-137-146
+++ b/docs/basics/_examples/DL-101-137-146
@@ -1,20 +1,20 @@
 $ git log -n 3
-commit 5346fb9dd7bec493e17eafa3897709376747182f
+commit b8ced8ebbad24f7da5216ec25a5daf10492b5226
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:56 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     Revert "did a bad modification"
-    
-    This reverts commit 7571eb8c2caf6e1c4b23c07fce96a8d6142e55af.
 
-commit dc78dc58d571e107cb6626740979ec98eb7dfdb8
+    This reverts commit eee275056d14ce7b224c59524b4da58f62a7a9c9.
+
+commit 85bc02647dfb0e866221eecbf099c981854f54f7
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:56 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     add note on helpful git resource
 
-commit 7571eb8c2caf6e1c4b23c07fce96a8d6142e55af
+commit eee275056d14ce7b224c59524b4da58f62a7a9c9
 Author: Elena Piscopia <elena@example.net>
-Date:   Wed Dec 14 17:01:56 2022 +0100
+Date:   Tue Jun 18 16:13:00 2019 +0200
 
     did a bad modification

--- a/docs/basics/_examples/DL-101-139-102
+++ b/docs/basics/_examples/DL-101-139-102
@@ -2,19 +2,19 @@ $ datalad push --to gin
 [INFO] Determine push target
 [INFO] Push refspecs
 [INFO] Transfer data
+[INFO] Update availability information
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
+[INFO] Start resolving deltas
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
 copy(ok): books/TLCL.pdf (file) [to gin...]
 copy(ok): books/bash_guide.pdf (file) [to gin...]
 copy(ok): books/byte-of-python.pdf (file) [to gin...]
 copy(ok): books/progit.pdf (file) [to gin...]
-[INFO] Update availability information
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-[INFO] Start resolving deltas 
-publish(ok): . (dataset) [refs/heads/git-annex->gin:refs/heads/git-annex 1d7ec2d..cbb4edb]
+publish(ok): . (dataset) [refs/heads/git-annex->gin:refs/heads/git-annex FROM..TO (REDACTED)]
 publish(ok): . (dataset) [refs/heads/master->gin:refs/heads/master [new branch]]
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
 action summary:
   copy (ok: 4)
   publish (ok: 2)

--- a/docs/basics/_examples/DL-101-139-104
+++ b/docs/basics/_examples/DL-101-139-104
@@ -7,4 +7,4 @@ $ cat .gitmodules
 [submodule "midterm_project"]
 	path = midterm_project
 	url = https://github.com/adswa/midtermproject
-	datalad-id = fea11e88-f41c-4447-8e34-17ea56f7ef92
+	datalad-id = e3e70682-c209-4cac-629f-6fbed82c07cd

--- a/docs/basics/_examples/DL-101-139-106
+++ b/docs/basics/_examples/DL-101-139-106
@@ -3,11 +3,11 @@ $ datalad push --to gin
 [INFO] Push refspecs
 [INFO] Transfer data
 [INFO] Update availability information
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-publish(ok): . (dataset) [refs/heads/master->gin:refs/heads/master 5346fb9..a8322aa]
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
 [INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
+publish(ok): . (dataset) [refs/heads/master->gin:refs/heads/master b8ced8e..f162a71]
 action summary:
   publish (notneeded: 1, ok: 1)

--- a/docs/basics/_examples/DL-101-139-107
+++ b/docs/basics/_examples/DL-101-139-107
@@ -1,10 +1,10 @@
 $ datalad clone https://gin.g-node.org/adswa/DataLad-101
 [INFO] Cloning dataset to Dataset(/home/me/dl-101/clone_of_dl-101/DataLad-101)
-[INFO] Attempting to clone from https://gin.g-node.org/adswa/DataLad-101 to /home/me/dl-101/clone_of_dl-101/DataLad-101 
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start receiving objects 
-[INFO] Start resolving deltas 
+[INFO] Attempting to clone from https://gin.g-node.org/adswa/DataLad-101 to /home/me/dl-101/clone_of_dl-101/DataLad-101
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start receiving objects
+[INFO] Start resolving deltas
 [INFO] Completed clone attempts for Dataset(/home/me/dl-101/clone_of_dl-101/DataLad-101)
 install(ok): /home/me/dl-101/clone_of_dl-101/DataLad-101 (dataset)

--- a/docs/basics/_examples/DL-101-141-101
+++ b/docs/basics/_examples/DL-101-141-101
@@ -2,19 +2,19 @@ $ datalad push --to roommate
 [INFO] Determine push target
 [INFO] Push refspecs
 [INFO] Transfer data
+[INFO] Update availability information
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
+[INFO] Start resolving deltas
+[INFO] Finished
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
 copy(ok): books/TLCL.pdf (file) [to roommate...]
 copy(ok): books/bash_guide.pdf (file) [to roommate...]
 copy(ok): books/byte-of-python.pdf (file) [to roommate...]
-[INFO] Update availability information
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-[INFO] Start resolving deltas
-[INFO] Finished
-publish(ok): . (dataset) [refs/heads/git-annex->roommate:refs/heads/git-annex 95058a2..3a14ea5]
+publish(ok): . (dataset) [refs/heads/git-annex->roommate:refs/heads/git-annex FROM..TO (REDACTED)]
 publish(error): . (dataset) [refs/heads/master->roommate:refs/heads/master [remote rejected] (branch is currently checked out)]
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
 action summary:
   copy (ok: 3)
   publish (error: 1, ok: 1)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ authors.append(authors.pop(authors.index('Michael Hanke')))
 # autorunrecord setup (extension used to run and capture the output of
 # examples)
 autorunrecord_basedir = '/home/me'
+autorunrecord_line_replace = [
+    # trailing space removal
+    (r'[ ]+$', ''),
+]
 # pre-crafted artificial environment to run the code examples in
 autorunrecord_env = {
     # make everything talk in english
@@ -46,18 +50,33 @@ autorunrecord_env = {
     # earned a PhD in 1678 and taught mathematics at the University of Padua
     'GIT_AUTHOR_EMAIL': 'elena@example.net',
     'GIT_AUTHOR_NAME': 'Elena Piscopia',
+    # set a fixed date to reduce time-induced randomness in output
+    # (gitshas etc)
+    # funnily I cannot set a date in 1678: `fatal: invalid date format`
+    # let's go with the first commit in the handbook
+    'GIT_AUTHOR_DATE': '2019-06-18T16:13:00',
+    # and same for the committer
+    'GIT_COMMITTER_EMAIL': 'elena@example.net',
+    'GIT_COMMITTER_NAME': 'Elena Piscopia',
+    'GIT_COMMITTER_DATE': '2019-06-18T16:13:00',
     'HOST': 'padua',
     # maintain the PATH to keep all installed software functional
     'PATH': os.environ['PATH'],
     'GIT_EDITOR': 'vim',
     # prevent progress bars - makes for ugly runrecords. See https://github.com/datalad-handbook/book/issues/390
     'DATALAD_UI_PROGRESSBAR': 'none',
+    # consistent starting point to suppress undesired randomness in, e.g.,
+    # UUID generation
+    'DATALAD_SEED': '0',
 }
 if 'CAST_DIR' in os.environ:
     autorunrecord_env['CAST_DIR'] = os.environ['CAST_DIR']
 if 'VIRTUAL_ENV' in os.environ:
     # inherit venv, if there is any
     autorunrecord_env.update(VIRTUAL_ENV=os.environ['VIRTUAL_ENV'])
+    autorunrecord_line_replace.append(
+        (os.environ['VIRTUAL_ENV'], 'VIRTUALENV')
+    )
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,26 @@ autorunrecord_basedir = '/home/me'
 autorunrecord_line_replace = [
     # trailing space removal
     (r'[ ]+$', ''),
+    # Python debug output will contain random memory locations
+    (r'object at 0x[0-9a-f]{12}>', 'object at REDACTED-MEMORYADDRESS'),
+    # branch state indicators will always be different for git-annex
+    # (branch contains timestamps)
+    (r'git-annex@[0-9a-f]{7}', 'git-annex@<REDACTED-GITSHA>'),
+    (r'refs/heads/git-annex(?P<whitey>[ ]+)[0-9a-f]{7}\.\.[0-9a-f]{7}',
+     'refs/heads/git-annex\g<whitey>FROM..TO (REDACTED)'),
+    # ls -l output will have times and user names
+    # normalize to 'elena' and the "standard timestamp"
+    # this only works when ls --time-style=long-iso was used
+    (r'(?P<perms>[-ldrwx]{10})[ ]+(?P<size1>[^ ]+)[ ]+(?P<user>[^ ]+)[ ]+(?P<group>[^ ]+)[ ]+(?P<size2>[^ ]+)[ ]+(?P<date>[^ ]+)[ ]+(?P<time>[^ ]+)',
+     '\g<perms> \g<size1> elena elena \g<size2> 2019-06-18 16:13'),
+    # we cannot fix git-annex's location IDs, filter them out
+    (r'annex-uuid = [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+     'annex-uuid = REDACTED-RANDOM-UUID'),
+    (r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} -- (?!web)',
+     'REDACTED-UUID -- '),
+    # Filter out needless git status info that adds randomness to the output
+    (r'Delta compression using up to.*', 'Delta compression'),
+    ('Total .*delta.*, reused .*delta.*$', 'REDACTED COMPRESSION STATS'),
 ]
 # pre-crafted artificial environment to run the code examples in
 autorunrecord_env = {


### PR DESCRIPTION
- Set a fixed identity and timestamp for Git (author and committer)
- Set a fixed seed for datalad UUID generation
- Remove all trailing spaces in captured output (avoids pertubations due to different Git configs across contributors)
- Replace virtual env location with 'VIRTUALENV' placeholder
- timestamp normalization in command output
- annex UUID standardization
- `ls -l` output normalization

Related: https://github.com/datalad/datalad/issues/7234

Outputs where captured with `sudo rm -rf /home/me/dl-101 /home/me/basics /home/me/pushes/ ; rm -f docs/basics/_examples/DL-101* ; make build`

