### PR TITLE
Avoid a global random seed fix

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -47,6 +47,8 @@ Let's start:
 .. runrecord:: _examples/DL-101-101-101
    :language: console
    :workdir: dl-101
+   :env:
+     DATALAD_SEED=0
    :realcommand: ( mkdir DataLad-101 && cd DataLad-101 && git init && git config annex.uuid 46b169aa-bb91-42d6-be06-355d957fb4f7 ) &> /dev/null && datalad create --force -c text2git DataLad-101
    :cast: 01_dataset_basics
    :notes: Datasets are datalads core data type. We will explore the concepts of datasets by creating one with datalad create. optional configuration template and a description

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,9 +85,6 @@ autorunrecord_env = {
     'GIT_EDITOR': 'vim',
     # prevent progress bars - makes for ugly runrecords. See https://github.com/datalad-handbook/book/issues/390
     'DATALAD_UI_PROGRESSBAR': 'none',
-    # consistent starting point to suppress undesired randomness in, e.g.,
-    # UUID generation
-    'DATALAD_SEED': '0',
 }
 if 'CAST_DIR' in os.environ:
     autorunrecord_env['CAST_DIR'] = os.environ['CAST_DIR']


### PR DESCRIPTION
This leads to all dataset IDs being identical.

This PR is not exhaustively annotating everything.