### PR TITLE
Compartmentalize the Makefile , exit codes, and associated fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ clean-beyond_basics:
 	@chmod +w -R /home/me/beyond_basics; rm -vrf /home/me/beyond_basics
 	# wipe out bare push repos
 	@chmod +w -R /home/me/pushes/data-version-control; rm -vrf /home/me/pushes/data-version-control
+	# wipe myriastore
+	@rm -vrf /home/me/myriastore
 
 # remove all usecases
 clean-usecases:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean-examples
+.PHONY: build clean-ml clean-neuro2 clean-neuro clean-provenance clean-collaboration clean-usecases clean-beyond_basics clean-basics clean
 build: html
 SHELL := /bin/bash
 
@@ -9,34 +9,6 @@ SHELL := /bin/bash
 
 clean-build:
 	rm -rf docs/_build 
-
-# wipe out all recorded examples
-clean-examples:
-	# check if we have something like .xsession or a .bashrc
-	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
-	@find docs/*/_examples -name 'DL*' | sed 's/docs\/usecases\/_examples//' | sed 's/docs\/beyond_basics\/_examples\/DL-101-168-[0-9]*[a,b]*//' |xargs rm -vrf
-	# also wipe the workdirs, otherwise a rebuild will lead to chaos
-	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq | sed 's/usecases//' | sed 's/DVCvsDL//'); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
-	# wipe out bare push repos
-	@chmod +w -R /home/me/pushes/DataLad-101 /home/me/pushes/midterm_project; rm -vrf /home/me/pushes/DataLad-101 /home/me/pushes/midterm_project
-	@rm -vrf /home/me/makepushtarget.py
-	# wipe out the RIA store
-	@rm -vrf /home/me/myriastore
-
-# do not touch what's in the DataLad narrative, only certain unrelated wdirs and examples
-clean-DVC:
-	# wipe out the DVC comparison
-	@find docs/beyond_basics/_examples -name DL-101-168* -type f | xargs rm -vrf
-	@chmod +w -R /home/me/DVCvsDL; rm -vrf /home/me/DVCvsDL
-	@chmod +w -R /home/me/pushes/data-version-control; rm -vrf /home/me/pushes/data-version-control
-
-# wipe out usecases
-clean-usecases:
-	# check if we have something like .xsession or a .bashrc
-	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
-	@rm -vrf docs/usecases/_examples
-	# also wipe the workdirs, otherwise a rebuild will lead to chaos
-	@chmod +w -R /home/me/usecases; rm -vrf /home/me/usecases
 
 # wipe out everything
 clean:
@@ -52,3 +24,68 @@ clean:
 	@rm -vrf /home/me/myriastore
 	# wipe out the DVC comparison
 	@chmod +w -R /home/me/DVCvsDL; rm -vrf /home/me/DVCvsDL
+
+# remove the Basics
+clean-basics:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/basics/_examples -name 'DL*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@for d in $$(git grep ':workdir:' -- docs | cut -d ':' -f 4- | sort | uniq|cut -d '/' -f 1 | uniq | sed 's/usecases//' | sed 's/DVCvsDL//' | sed 's/beyond_basics//'); do chmod +w -R /home/me/$$d; rm -vrf /home/me/$$d ; done
+	# wipe out bare push repos
+	@chmod +w -R /home/me/pushes/DataLad-101 /home/me/pushes/midterm_project; rm -vrf /home/me/pushes/DataLad-101 /home/me/pushes/midterm_project
+	@rm -vrf /home/me/makepushtarget.py
+
+# remove Beyond-Basics
+clean-beyond_basics:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/beyond_basics/_examples -name 'DL*' |xargs rm -vrf
+    # also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/beyond_basics; rm -vrf /home/me/beyond_basics
+	# wipe out bare push repos
+	@chmod +w -R /home/me/pushes/data-version-control; rm -vrf /home/me/pushes/data-version-control
+
+# remove all usecases
+clean-usecases:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'DL*' |xargs rm -vrf
+    # also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases; rm -vrf /home/me/usecases
+
+# remove specific usecases
+clean-collaboration:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'collab*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases/collab; rm -vrf /home/me/usecases/collab
+
+clean-provenance:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'prov*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases/provenance; rm -vrf /home/me/usecases/provenance
+
+clean-neuro:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'repro-*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases/repro; rm -vrf /home/me/usecases/repro
+
+clean-neuro2:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'repro2*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases/{ml-project,imagenette}; rm -vrf /home/me/usecases/{ml-project,imagenette}
+
+clean-ml:
+	# check if we have something like .xsession or a .bashrc
+	@[ -n "$$(ls -a /home/me/.x* /home/me/.*rc 2>/dev/null)" ] && echo "/home/me looks like a real HOME dir. Refusing to bring chaos" && exit 1 || true
+	@find docs/usecases/_examples -name 'ml*' |xargs rm -vrf
+	# also wipe the workdirs, otherwise a rebuild will lead to chaos
+	@chmod +w -R /home/me/usecases/collab; rm -vrf /home/me/usecases/collab

--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -47,6 +47,8 @@ Let's start:
 .. runrecord:: _examples/DL-101-101-101
    :language: console
    :workdir: dl-101
+   :env:
+     DATALAD_SEED=0
    :realcommand: ( mkdir DataLad-101 && cd DataLad-101 && git init && git config annex.uuid 46b169aa-bb91-42d6-be06-355d957fb4f7 ) &> /dev/null && datalad create --force -c text2git DataLad-101
    :cast: 01_dataset_basics
    :notes: Datasets are datalads core data type. We will explore the concepts of datasets by creating one with datalad create. optional configuration template and a description

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -56,7 +56,6 @@ are presented here, make sure to check the :windows-wit:`on peculiarities of its
 .. runrecord:: _examples/DL-101-102-103
    :language: console
    :workdir: dl-101/DataLad-101
-   :realcommand: ( cd books && wget -nv https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download -O TLCL.pdf && wget -nv https://github.com/swaroopch/byte-of-python/releases/download/v14558db59a326ba99eda0da6c4548c48ccb4cd0f/byte-of-python.pdf -O byte-of-python.pdf ) 3>&1 1>&2 2>&3 | grep -v URL:
    :cast: 01_dataset_basics
    :notes: We use wget to download a few books from the web. CAVE: longish realcommand!
 
@@ -233,7 +232,6 @@ Let's try this by adding yet another book, a good reference work about git,
 .. runrecord:: _examples/DL-101-102-108
    :language: console
    :workdir: dl-101/DataLad-101
-   :realcommand: cd books && wget -nv https://github.com/progit/progit2/releases/download/2.1.154/progit.pdf 3>&1 1>&2 2>&3 | grep -v URL: && cd ../
    :cast: 01_dataset_basics
    :notes: Its inconvenient that we saved two books together - we should have saved them as independent modifications of the dataset. To see how single modifications can be saved, let's download another book
 

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -78,6 +78,7 @@ a single line.
    :emphasize-lines: 4
    :notes: This command resizes the logo to 400 by 400 px -- but it will fail!
    :cast: 02_reproducible_execution
+   :exitcode: 1
 
    $ datalad run -m "Resize logo for slides" \
    "convert -resize 400x400 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
@@ -187,6 +188,7 @@ To establish best-practices, let's specify the input even though it is already p
    :emphasize-lines: 10
    :realcommand: datalad run --input "recordings/longnow/.datalad/feed_metadata/logo_salt.jpg" "convert -resize 450x450 recordings/longnow/.datalad/feed_metadata/logo_salt.jpg recordings/salt_logo_small.jpg"
    :notes: Maybe 400x400 is too small. We should try 450x450. Can we use a datalad rerun for this? (no)
+   :exitcode: 1
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \

--- a/docs/basics/101-112-run4.rst
+++ b/docs/basics/101-112-run4.rst
@@ -16,6 +16,7 @@ you think.
    :workdir: dl-101/DataLad-101
    :emphasize-lines: 5
    :notes: mhh, 450x450px seems a bit large, we have to go back to 400. Lets make yet another, complete run command
+   :exitcode: 1
    :cast: 02_reproducible_execution
 
    $ datalad run -m "Resize logo for slides" \

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -824,6 +824,7 @@ reproduce your data science project easily from scratch (take a look into the :r
 
    .. runrecord:: _examples/DL-101-130-121
       :language: console
+      :exitcode: 1
       :workdir: dl-101/midtermproject
 
       $ datalad get prediction_report.csv pairwise_relationships.png

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -169,6 +169,8 @@ independent dataset from scratch in a :ref:`dedicated Findoutmore <fom-iris>`.
    .. runrecord:: _examples/DL-101-130-101
       :language: console
       :workdir: dl-101/DataLad-101
+      :env:
+         DATALAD_SEED=1
 
       # make sure to move outside of DataLad-101!
       $ cd ../
@@ -219,6 +221,8 @@ you use the ``cfg_yoda`` procedure to help you structure the dataset [#f1]_:
    :language: console
    :workdir: dl-101/DataLad-101
    :cast: 10_yoda
+   :env:
+      DATALAD_SEED=2
    :notes: Let's create a data analysis project with a yoda procedure
 
    # inside of DataLad-101

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -383,6 +383,7 @@ has no way of finding out where the file content could be:
 .. runrecord:: _examples/DL-101-136-132
    :language: console
    :workdir: dl-101/DataLad-101
+   :exitcode: 1
    :notes: demonstrate broken symlink with git-annex-whereis
    :cast: 03_git_annex_basics
 
@@ -781,6 +782,7 @@ section.
 
    .. runrecord:: _examples/DL-101-136-162
       :language: console
+      :exitcode: 1
       :workdir: dl-101/mock_user
 
       # navigate back into your dataset
@@ -1036,6 +1038,7 @@ DataLad will safeguard dropping content that it can not retrieve again:
 .. runrecord:: _examples/DL-101-136-178
    :workdir: dl-101/DataLad-101
    :language: console
+   :exitcode: 1
    :notes: datalad does not know how to re-obtain the file, so it complains
    :cast: 03_git_annex_basics
 

--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -161,6 +161,7 @@ As an example, consider what happens if we attempt a :command:`datalad push` to 
 
 .. runrecord:: _examples/DL-101-141-101
    :language: console
+   :exitcode: 1
    :workdir: dl-101/DataLad-101
 
    $ datalad push --to roommate

--- a/docs/basics/_examples/DL-101-124-103
+++ b/docs/basics/_examples/DL-101-124-103
@@ -1,2 +1,2 @@
 $ datalad create somedataset; cd somedataset
-create(error): /home/me/procs/somedataset (dataset) [will not create a dataset in a non-empty directory, use `--force` option to ignore]
+create(ok): /home/me/procs/somedataset (dataset)

--- a/docs/basics/_examples/DL-101-124-104
+++ b/docs/basics/_examples/DL-101-124-104
@@ -37,5 +37,3 @@ ds.repo.set_gitattributes([('example', {'annex.largefiles': 'nothing'})])
 ds.save(message="Apply custom procedure")
 
 EOT
-mkdir: cannot create directory ‘.datalad/procedures’: File exists
-bash: line 2: .datalad/procedures/example.py: Permission denied

--- a/docs/basics/_examples/DL-101-124-105
+++ b/docs/basics/_examples/DL-101-124-105
@@ -1,1 +1,6 @@
 $ datalad save -m "add custom procedure"
+add(ok): .datalad/procedures/example.py (file)
+save(ok): . (dataset)
+action summary:
+  add (ok: 1)
+  save (ok: 1)

--- a/docs/basics/_examples/DL-101-124-106
+++ b/docs/basics/_examples/DL-101-124-106
@@ -1,11 +1,12 @@
 $ datalad run-procedure example "this text will be in the file 'example2'"
 [INFO] Running procedure example
 [INFO] == Command start (output follows) =====
-Traceback (most recent call last):
-  File "/home/me/procs/somedataset/.datalad/procedures/example.py", line 28, in <module>
-    create_tree(ds.path, tmpl)
-  File "/home/mih/hacking/datalad/git/datalad/utils.py", line 2505, in create_tree
-    with open_func(full_name, "wb") as f:
-PermissionError: [Errno 13] Permission denied: '/home/me/procs/somedataset/example2'
+add(ok): example2 (file)
+add(ok): somedir/example (file)
+add(ok): .gitattributes (file)
+save(ok): . (dataset)
+action summary:
+  add (ok: 3)
+  save (ok: 1)
 [INFO] == Command exit (modification check follows) =====
-run(error): /home/me/procs/somedataset (dataset) [VIRTUALENV/bin/python /ho...]
+run(ok): /home/me/procs/somedataset (dataset) [VIRTUALENV/bin/python /hom...]

--- a/docs/basics/_examples/DL-101-124-109
+++ b/docs/basics/_examples/DL-101-124-109
@@ -1,2 +1,7 @@
 $ git config -f .datalad/config datalad.procedures.example.help "A toy example"
 $ datalad save -m "add help description"
+add(ok): .datalad/config (file)
+save(ok): . (dataset)
+action summary:
+  add (ok: 1)
+  save (ok: 1)

--- a/docs/basics/_examples/DL-101-130-111
+++ b/docs/basics/_examples/DL-101-130-111
@@ -4,12 +4,10 @@ $ datalad run -m "analyze iris data with classification analysis" \
   --output "prediction_report.csv" \
   "python3 code/script.py {inputs} {outputs}"
 [INFO] Making sure inputs are available (this may take some time)
-[INFO] == Command start (output follows) =====
-Traceback (most recent call last):
-  File "/home/me/dl-101/DataLad-101/midterm_project/code/script.py", line 3, in <module>
-    import pandas as pd
-ModuleNotFoundError: No module named 'pandas'
-[INFO] == Command exit (modification check follows) =====
-[INFO] The command had a non-zero exit code. If this is expected, you can save the changes with 'datalad save -d . -r -F .git/COMMIT_EDITMSG'
 get(ok): input/iris.csv (file) [from web...]
-run(error): /home/me/dl-101/DataLad-101/midterm_project (dataset) [python3 code/script.py input/iris.csv pa...]
+[INFO] == Command start (output follows) =====
+[INFO] == Command exit (modification check follows) =====
+run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [python3 code/script.py input/iris.csv pa...]
+add(ok): pairwise_relationships.png (file)
+add(ok): prediction_report.csv (file)
+save(ok): . (dataset)

--- a/docs/basics/_examples/DL-101-130-112
+++ b/docs/basics/_examples/DL-101-130-112
@@ -1,5 +1,6 @@
 $ git log --oneline
-4c80419 add script for kNN classification and plotting
-e447760 [DATALAD] Added subdataset
-eff57e7 Apply YODA dataset setup
-7062507 [DATALAD] new dataset
+028397e [DATALAD RUNCMD] analyze iris data with classification analysis
+d5ecb9f add script for kNN classification and plotting
+1bd4429 [DATALAD] Added subdataset
+8b83991 Apply YODA dataset setup
+ea24ca5 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-130-118
+++ b/docs/basics/_examples/DL-101-130-118
@@ -2,13 +2,16 @@ $ datalad push --to github
 [INFO] Determine push target
 [INFO] Push refspecs
 [INFO] Transfer data
+copy(ok): pairwise_relationships.png (file) [to github...]
+copy(ok): prediction_report.csv (file) [to github...]
 [INFO] Update availability information
 [INFO] Start enumerating objects
 [INFO] Start counting objects
 [INFO] Start compressing objects
 [INFO] Start writing objects
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project)
 publish(ok): . (dataset) [refs/heads/git-annex->github:refs/heads/git-annex FROM..TO (REDACTED)]
 publish(ok): . (dataset) [refs/heads/master->github:refs/heads/master [new branch]]
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project)
 action summary:
+  copy (ok: 2)
   publish (ok: 2)

--- a/docs/basics/_examples/DL-101-130-122
+++ b/docs/basics/_examples/DL-101-130-122
@@ -2,21 +2,19 @@
 $ datalad rerun d715890b36b9a089eedbb0c929f52e182e889735
 [INFO] run commit d715890; (analyze iris data...)
 [INFO] Making sure inputs are available (this may take some time)
-[INFO] == Command start (output follows) =====
-Traceback (most recent call last):
-  File "/home/me/dl-101/midtermproject/code/script.py", line 2, in <module>
-    import pandas as pd
-ModuleNotFoundError: No module named 'pandas'
-[INFO] == Command exit (modification check follows) =====
 run.remove(ok): pairwise_relationships.png (file) [Removed file]
 run.remove(ok): prediction_report.csv (file) [Removed file]
-run(error): /home/me/dl-101/midtermproject (dataset) [python3 code/script.py]
-delete(ok): pairwise_relationships.png (file)
-delete(ok): prediction_report.csv (file)
+[INFO] == Command start (output follows) =====
+action summary:
+  get (notneeded: 2)
+[INFO] == Command exit (modification check follows) =====
+run(ok): /home/me/dl-101/midtermproject (dataset) [python3 code/script.py]
+add(ok): pairwise_relationships.png (file)
+add(ok): prediction_report.csv (file)
 save(ok): . (dataset)
 action summary:
-  delete (ok: 2)
+  add (ok: 2)
   get (notneeded: 3)
-  run (error: 1)
+  run (ok: 1)
   run.remove (ok: 2)
   save (notneeded: 1, ok: 1)

--- a/docs/basics/_examples/DL-101-132-101
+++ b/docs/basics/_examples/DL-101-132-101
@@ -1,6 +1,7 @@
 $ git log --oneline
-2e3d361 Provide project description
-4c80419 add script for kNN classification and plotting
-e447760 [DATALAD] Added subdataset
-eff57e7 Apply YODA dataset setup
-7062507 [DATALAD] new dataset
+be0956f Provide project description
+028397e [DATALAD RUNCMD] analyze iris data with classification analysis
+d5ecb9f add script for kNN classification and plotting
+1bd4429 [DATALAD] Added subdataset
+8b83991 Apply YODA dataset setup
+ea24ca5 [DATALAD] new dataset

--- a/docs/basics/_examples/DL-101-132-112
+++ b/docs/basics/_examples/DL-101-132-112
@@ -1,14 +1,14 @@
 $ git log -p -n 1
-commit 3adfd398b34c0107828b4b23b48dc548f4b4e512
+commit cbd0a6ae5799f7db094bfecb1b92711234c75758
 Author: Elena Piscopia <elena@example.net>
 Date:   Tue Jun 18 16:13:00 2019 +0200
 
     finished my midterm project
 
 diff --git a/midterm_project b/midterm_project
-index eff57e7..2e3d361 160000
+index 8b83991..be0956f 160000
 --- a/midterm_project
 +++ b/midterm_project
 @@ -1 +1 @@
--Subproject commit eff57e7a902431a1570a7d4f49a04f160bb6259d
-+Subproject commit 2e3d3614f635f9a8ba6fad743a480c3bdabb5b9a
+-Subproject commit 8b839913b6b9987ccb8b96aa68db845f6b5ad666
++Subproject commit be0956f92e12e813d2bece198852f911c435084e

--- a/docs/basics/_examples/DL-101-133-102
+++ b/docs/basics/_examples/DL-101-133-102
@@ -1,6 +1,6 @@
 $ cat .datalad/config
 [datalad "dataset"]
-	id = e3e70682-c209-4cac-629f-6fbed82c07cd
+	id = d95bafc8-f2a4-d27b-dcf4-bb99f4bea973
 [datalad "containers.midterm-software"]
 	image = .datalad/environments/midterm-software/image
 	cmdexec = singularity exec {img} {cmd}

--- a/docs/basics/_examples/DL-101-133-103
+++ b/docs/basics/_examples/DL-101-133-103
@@ -1,17 +1,17 @@
 $ git log -n 1 -p
-commit f34b9aa0380e76f663825dc9433a1c2142682295
+commit 3ca34692e3ff3421d8f85252d785fbeaac9388cd
 Author: Elena Piscopia <elena@example.net>
 Date:   Tue Jun 18 16:13:00 2019 +0200
 
     [DATALAD] Configure containerized environment 'midterm-software'
 
 diff --git a/.datalad/config b/.datalad/config
-index d72c8f0..deb4b2c 100644
+index e99ec14..ad3e5d8 100644
 --- a/.datalad/config
 +++ b/.datalad/config
 @@ -1,2 +1,5 @@
  [datalad "dataset"]
- 	id = e3e70682-c209-4cac-629f-6fbed82c07cd
+	id = d95bafc8-f2a4-d27b-dcf4-bb99f4bea973
 +[datalad "containers.midterm-software"]
 +	image = .datalad/environments/midterm-software/image
 +	cmdexec = singularity exec {img} {cmd}

--- a/docs/basics/_examples/DL-101-133-105
+++ b/docs/basics/_examples/DL-101-133-105
@@ -5,6 +5,11 @@ $ datalad containers-run -m "rerun analysis in container" \
   --output "prediction_report.csv" \
   "python3 code/script.py {inputs} {outputs}"
 [INFO] Making sure inputs are available (this may take some time)
+[INFO] Unlocking files
+unlock(ok): pairwise_relationships.png (file)
+unlock(ok): prediction_report.csv (file)
+[INFO] Recording unlocked state in git
+[INFO] Completed unlocking files
 [INFO] == Command start (output follows) =====
 [INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset) [singularity exec -B /home/me/dl-101/Data...]
@@ -16,3 +21,4 @@ action summary:
   get (notneeded: 4)
   run (ok: 1)
   save (notneeded: 1, ok: 1)
+  unlock (ok: 2)

--- a/docs/basics/_examples/DL-101-133-111
+++ b/docs/basics/_examples/DL-101-133-111
@@ -1,5 +1,5 @@
 $ git log -p -n 1
-commit 0282a0107582999c3eaad979541da6a8a18cfe38
+commit 5e3e285b91168b82929dfce6012703700fb50816
 Author: Elena Piscopia <elena@example.net>
 Date:   Tue Jun 18 16:13:00 2019 +0200
 
@@ -9,7 +9,7 @@ Date:   Tue Jun 18 16:13:00 2019 +0200
     {
      "chain": [],
      "cmd": "singularity exec -B {pwd} .datalad/environments/midterm-software/image python3 code/script.py {inputs} {outputs}",
-     "dsid": "e3e70682-c209-4cac-629f-6fbed82c07cd",
+     "dsid": "d95bafc8-f2a4-d27b-dcf4-bb99f4bea973",
      "exit": 0,
      "extra_inputs": [
       ".datalad/environments/midterm-software/image"
@@ -26,18 +26,11 @@ Date:   Tue Jun 18 16:13:00 2019 +0200
     ^^^ Do not change lines above ^^^
 
 diff --git a/pairwise_relationships.png b/pairwise_relationships.png
-new file mode 120000
-index 0000000..963d5a8
---- /dev/null
+index 0900ce6..963d5a8 120000
+--- a/pairwise_relationships.png
 +++ b/pairwise_relationships.png
-@@ -0,0 +1 @@
-+.git/annex/objects/q1/gp/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png
+@@ -1 +1 @@
+-.git/annex/objects/MP/V8/MD5E-s260804--fe419ff41dd6cd65b4bca2803e3d0190.png/MD5E-s260804--fe419ff41dd6cd65b4bca2803e3d0190.png
 \ No newline at end of file
-diff --git a/prediction_report.csv b/prediction_report.csv
-new file mode 120000
-index 0000000..42d194b
---- /dev/null
-+++ b/prediction_report.csv
-@@ -0,0 +1 @@
-+.git/annex/objects/8q/6M/MD5E-s345--a88cab39b1a5ec59ace322225cc88bc9.csv/MD5E-s345--a88cab39b1a5ec59ace322225cc88bc9.csv
++.git/annex/objects/q1/gp/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png/MD5E-s261062--025dc493ec2da6f9f79eb1ce8512cbec.png
 \ No newline at end of file

--- a/docs/basics/_examples/DL-101-135-101
+++ b/docs/basics/_examples/DL-101-135-101
@@ -1,2 +1,2 @@
 $ datalad --version
-datalad 0.17.10+2.g23b376756
+datalad 0.17.9+99.g95214312b

--- a/docs/basics/_examples/DL-101-136-177
+++ b/docs/basics/_examples/DL-101-136-177
@@ -1,6 +1,5 @@
 $ convert xc:none -page Letter a.pdf
 $ datalad save -m "add empty pdf"
-convert-im6.q16: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421.
 add(ok): a.pdf (file)
 save(ok): . (dataset)
 action summary:

--- a/docs/basics/_examples/DL-101-136-178
+++ b/docs/basics/_examples/DL-101-136-178
@@ -1,1 +1,2 @@
 $ datalad drop a.pdf
+drop(error): a.pdf (file) [unsafe; Could only verify the existence of 0 out of 1 necessary copy; (Use --reckless availability to override this check, or adjust numcopies.)]

--- a/docs/basics/_examples/DL-101-136-179
+++ b/docs/basics/_examples/DL-101-136-179
@@ -1,1 +1,2 @@
 $ datalad drop --reckless availability a.pdf
+drop(ok): a.pdf (file)

--- a/docs/basics/_examples/DL-101-137-113
+++ b/docs/basics/_examples/DL-101-137-113
@@ -2,7 +2,6 @@
 $ convert xc:none -page Letter apdffile.pdf
 # accidentally save it
 $ datalad save
-convert-im6.q16: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421.
 add(ok): Gitjoke1.txt (file)
 add(ok): Gitjoke3.txt (file)
 add(ok): apdffile.pdf (file)

--- a/docs/basics/_examples/DL-101-137-114
+++ b/docs/basics/_examples/DL-101-137-114
@@ -1,2 +1,2 @@
 $ ls -l apdffile.pdf
--rw-rw-r-- 1 elena elena 0 2019-06-18 16:13 apdffile.pdf
+lrwxrwxrwx 1 elena elena 122 2019-06-18 16:13 apdffile.pdf -> .git/annex/objects/xK/94/MD5E-s1858--1856c0d928f208c323e858ae1683a62a.pdf/MD5E-s1858--1856c0d928f208c323e858ae1683a62a.pdf

--- a/docs/basics/_examples/DL-101-137-115
+++ b/docs/basics/_examples/DL-101-137-115
@@ -1,1 +1,5 @@
 $ datalad unlock apdffile.pdf
+[INFO] Unlocking files
+unlock(ok): apdffile.pdf (file)
+[INFO] Recording unlocked state in git
+[INFO] Completed unlocking files

--- a/docs/basics/_examples/DL-101-137-116
+++ b/docs/basics/_examples/DL-101-137-116
@@ -1,2 +1,2 @@
 $ ls -l apdffile.pdf
--rw-rw-r-- 1 elena elena 0 2019-06-18 16:13 apdffile.pdf
+-rw-r--r-- 1 elena elena 1858 2019-06-18 16:13 apdffile.pdf

--- a/docs/basics/_examples/DL-101-137-117
+++ b/docs/basics/_examples/DL-101-137-117
@@ -1,4 +1,4 @@
 $ git log -n 3 --oneline
-8925513 [DATALAD] Recorded changes
-8b385b0 save my favorite Git joke
-9456110 remove obsolete subds
+975f37a [DATALAD] Recorded changes
+9427434 save my favorite Git joke
+0787e4f remove obsolete subds

--- a/docs/beyond_basics/101-147-riastores.rst
+++ b/docs/beyond_basics/101-147-riastores.rst
@@ -490,7 +490,7 @@ dataset ID:
 
 .. runrecord:: _examples/DL-101-147-120
    :language: console
-   :workdir: dl-101
+   :workdir: beyond_basics
    :realcommand: echo "$ datalad clone ria+file:///home/me/myriastore#$(datalad -C DataLad-101 -f'{infos[dataset][id]}' wtf) myclone" && datalad clone ria+file:///home/me/myriastore#$(datalad -C DataLad-101 -f'{infos[dataset][id]}' wtf) myclone
 
 There are two downsides to this method: For one, it is hard to type, remember, and
@@ -517,7 +517,7 @@ an alias ``dl-101``, the above call would simplify to
 
    .. runrecord:: _examples/DL-101-147-121
       :language: console
-      :workdir: dl-101
+      :workdir: beyond_basics
       :realcommand: echo "$ mkdir /home/me/myriastore/alias"
 
 
@@ -526,14 +526,14 @@ an alias ``dl-101``, the above call would simplify to
 
    .. runrecord:: _examples/DL-101-147-122
       :language: console
-      :workdir: dl-101
-      :realcommand: echo "$ ln -s /home/me/myriastore/$(datalad -C DataLad-101/midterm_project -f'{infos[dataset][id]}' wtf | sed 's/^\(...\)\(.*\)/\1\/\2/') /home/me/myriastore/alias/midterm_project" && ln -s /home/me/myriastore/$(datalad -C DataLad-101/midterm_project -f'{infos[dataset][id]}' wtf | sed 's/^\(...\)\(.*\)/\1\/\2/') /home/me/myriastore/alias/midterm_project
+      :workdir: beyond_basics
+      :realcommand: echo "$ ln -s /home/me/myriastore/$(datalad -C /home/me/dl-101/DataLad-101/midterm_project -f'{infos[dataset][id]}' wtf | sed 's/^\(...\)\(.*\)/\1\/\2/') /home/me/myriastore/alias/midterm_project" && ln -s /home/me/myriastore/$(datalad -C /home/me/dl-101/DataLad-101/midterm_project -f'{infos[dataset][id]}' wtf | sed 's/^\(...\)\(.*\)/\1\/\2/') /home/me/myriastore/alias/midterm_project
 
    Here is how it looks like inside of this directory. You can see both the automatically created alias as well as the newly manually created one:
 
    .. runrecord:: _examples/DL-101-147-123
       :language: console
-      :workdir: dl-101
+      :workdir: beyond_basics
 
       $ tree /home/me/myriastore/alias
 
@@ -542,7 +542,7 @@ an alias ``dl-101``, the above call would simplify to
 
    .. runrecord:: _examples/DL-101-147-124
       :language: console
-      :workdir: dl-101
+      :workdir: beyond_basics
 
       datalad clone ria+file:///home/me/myriastore#~midterm_project
 
@@ -558,7 +558,7 @@ is not yet retrieved from the store and can be obtained with a :command:`datalad
 
 .. runrecord:: _examples/DL-101-147-125
    :language: console
-   :workdir: dl-101
+   :workdir: beyond_basics
 
    $ cd myclone
    $ tree
@@ -567,7 +567,7 @@ To demonstrate file retrieval from the store, let's get an annexed file:
 
 .. runrecord:: _examples/DL-101-147-126
    :language: console
-   :workdir: dl-101/myclone
+   :workdir: beyond_basics/myclone
 
    $ datalad get books/progit.pdf
 
@@ -591,7 +591,7 @@ in the RIA store is discovered and used automatically:
 
 .. runrecord:: _examples/DL-101-147-127
    :language: console
-   :workdir: dl-101/myclone
+   :workdir: beyond_basics/myclone
 
    $ datalad get -n midterm_project
 

--- a/docs/beyond_basics/101-147-riastores.rst
+++ b/docs/beyond_basics/101-147-riastores.rst
@@ -491,7 +491,7 @@ dataset ID:
 .. runrecord:: _examples/DL-101-147-120
    :language: console
    :workdir: beyond_basics
-   :realcommand: echo "$ datalad clone ria+file:///home/me/myriastore#$(datalad -C DataLad-101 -f'{infos[dataset][id]}' wtf) myclone" && datalad clone ria+file:///home/me/myriastore#$(datalad -C DataLad-101 -f'{infos[dataset][id]}' wtf) myclone
+   :realcommand: echo "$ datalad clone ria+file:///home/me/myriastore#$(datalad -C /home/me/dl-101/DataLad-101 -f'{infos[dataset][id]}' wtf) myclone" && datalad clone ria+file:///home/me/myriastore#$(datalad -C /home/me/dl-101/DataLad-101 -f'{infos[dataset][id]}' wtf) myclone
 
 There are two downsides to this method: For one, it is hard to type, remember, and
 know the dataset ID of a desired dataset. Secondly, if no additional path is given to

--- a/docs/beyond_basics/101-149-copyfile.rst
+++ b/docs/beyond_basics/101-149-copyfile.rst
@@ -54,7 +54,7 @@ Let's start by cloning a dataset to work with:
 
 .. runrecord:: _examples/DL-101-149-01
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ datalad clone https://github.com/datalad-datasets/human-connectome-project-openaccess.git hcp
 
@@ -64,7 +64,7 @@ Note that we don't retrieve any data, using ``-n``/``--no-data``.
 
 .. runrecord:: _examples/DL-101-149-02
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
    :lines: 1-3
 
    $ cd hcp
@@ -75,7 +75,7 @@ This dataset will later hold the relevant subset of the data in the HCP dataset.
 
 .. runrecord:: _examples/DL-101-149-03
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    $ cd ..
    $ datalad create dataset-to-copy-to
@@ -87,7 +87,7 @@ Let's copy a single file (``hcp/HCP1200/130013/T1w/Diffusion/bvals``) from the `
 
 .. runrecord:: _examples/DL-101-149-04
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ datalad copy-file \
       hcp/HCP1200/130013/T1w/Diffusion/bvals  \
@@ -98,7 +98,7 @@ If a target directory or a destination path is given for a file, however, the co
 
 .. runrecord:: _examples/DL-101-149-05
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ datalad copy-file \
       hcp/HCP1200/130013/T1w/Diffusion/bvecs \
@@ -108,7 +108,7 @@ Note that instead of a as dataset, we specify it as a target path, and how the f
 
 .. runrecord:: _examples/DL-101-149-06
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ cd dataset-to-copy-to
    $ datalad status
@@ -117,7 +117,7 @@ Providing a second path as a `destination` path allows one to copy the file unde
 
 .. runrecord:: _examples/DL-101-149-07
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ datalad copy-file \
       hcp/HCP1200/130013/T1w/Diffusion/bvecs \
@@ -125,7 +125,7 @@ Providing a second path as a `destination` path allows one to copy the file unde
 
 .. runrecord:: _examples/DL-101-149-08
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ cd dataset-to-copy-to
    $ datalad status
@@ -135,7 +135,7 @@ Let's save those two unsaved files:
 
 .. runrecord:: _examples/DL-101-149-09
    :language: console
-   :workdir: dl-101/HPC/dataset-to-copy-to
+   :workdir: beyond_basics/HPC/dataset-to-copy-to
 
    $ datalad save
 
@@ -143,7 +143,7 @@ With the ``-r/--recursive`` flag enabled, the command can copy complete *subdire
 
 .. runrecord:: _examples/DL-101-149-10
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    $ cd ..
    $ datalad copy-file hcp/HCP1200/130114/T1w/Diffusion/* \
@@ -155,7 +155,7 @@ Here is how the dataset that we copied files into looks like at the moment:
 
 .. runrecord:: _examples/DL-101-149-11
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ tree dataset-to-copy-to
 
@@ -165,7 +165,7 @@ Retrieving file contents works just as it would in the full HCP dataset via :com
 
 .. runrecord:: _examples/DL-101-149-12
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ cd dataset-to-copy-to
    $ datalad get bvals anothercopyofbvecs 130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters
@@ -177,7 +177,7 @@ In order to use ``stdin`` for specification, such as the output of a ``find`` co
 
 .. runrecord:: _examples/DL-101-149-13
    :language: console
-   :workdir: dl-101/HPC
+   :workdir: beyond_basics/HPC
 
    $ cd hcp
    $ find HCP1200/130013/T1w/ -maxdepth 1 -name T1w*.nii.gz
@@ -187,7 +187,7 @@ And here is how the outputted paths can be given as source paths to :command:`da
 
 .. runrecord:: _examples/DL-101-149-14
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    # inside of hcp
    $ find HCP1200/130013/T1w/ -maxdepth 1 -name T1w*.nii.gz \
@@ -197,7 +197,7 @@ To preserve the directory structure, a target directory (``-t ../dataset-to-copy
 
 .. runrecord:: _examples/DL-101-149-15
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    $ ls ../dataset-to-copy-to
 
@@ -235,7 +235,7 @@ Here is how an output of ``find`` piped into ``sed`` looks like:
 
 .. runrecord:: _examples/DL-101-149-16
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    $ find HCP1200/130518/T1w -maxdepth 1 -name T1w*.nii.gz \
 	 | sed -e 's#\(HCP1200\)\(.*\)#\1\2\x0../dataset-to-copy-to\2#'
@@ -246,7 +246,7 @@ Let's now see a :command:`copy-file` from :term:`stdin` in action:
 
 .. runrecord:: _examples/DL-101-149-17
    :language: console
-   :workdir: dl-101/HPC/hcp
+   :workdir: beyond_basics/HPC/hcp
 
    $ find HCP1200/130518/T1w -maxdepth 1 -name T1w*.nii.gz \
     | sed -e 's#\(HCP1200\)\(.*\)#\1\2\x0../dataset-to-copy-to\2#' \

--- a/docs/beyond_basics/_examples/DL-101-147-101
+++ b/docs/beyond_basics/_examples/DL-101-147-101
@@ -8,4 +8,4 @@ $ cat .gitmodules
 [submodule "midterm_project"]
 	path = midterm_project
 	url = https://github.com/adswa/midtermproject
-	datalad-id = fea11e88-f41c-4447-8e34-17ea56f7ef92
+	datalad-id = d95bafc8-f2a4-d27b-dcf4-bb99f4bea973

--- a/docs/beyond_basics/_examples/DL-101-147-103
+++ b/docs/beyond_basics/_examples/DL-101-147-103
@@ -1,12 +1,12 @@
 # inside of the dataset DataLad-101
 # do not use --new-store-ok with datalad < 0.16
 $ datalad create-sibling-ria -s ria-backup --alias dl-101 --new-store-ok "ria+file:///home/me/myriastore"
-[INFO] Creating a new RIA store at /home/me/myriastore 
-[INFO] create siblings 'ria-backup' and 'ria-backup-storage' ... 
-[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101) 
+[INFO] Creating a new RIA store at /home/me/myriastore
+[INFO] create siblings 'ria-backup' and 'ria-backup-storage' ...
+[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101)
 update(ok): . (dataset)
 update(ok): . (dataset)
-[INFO] Configure additional publication dependency on "ria-backup-storage" 
+[INFO] Configure additional publication dependency on "ria-backup-storage"
 configure-sibling(ok): . (sibling)
 create-sibling-ria(ok): /home/me/dl-101/DataLad-101 (dataset)
 action summary:

--- a/docs/beyond_basics/_examples/DL-101-147-104
+++ b/docs/beyond_basics/_examples/DL-101-147-104
@@ -1,6 +1,6 @@
 $ datalad siblings
 .: here(+) [git]
-.: ria-backup-storage(+) [ora]
 .: roommate(+) [../mock_user/DataLad-101 (git)]
-.: ria-backup(-) [/home/me/myriastore/5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676 (git)]
+.: ria-backup(-) [/home/me/myriastore/e3e/70682-c209-4cac-629f-6fbed82c07cd (git)]
+.: ria-backup-storage(+) [ora]
 .: gin(+) [/home/me/pushes/DataLad-101 (git)]

--- a/docs/beyond_basics/_examples/DL-101-147-105
+++ b/docs/beyond_basics/_examples/DL-101-147-105
@@ -1,7 +1,9 @@
 $ tree /home/me/myriastore
 /home/me/myriastore
-├── 5d2
-│   └── 4f8fb-8339-4fe7-9b64-fec6af4e9676
+├── alias
+│   └── dl-101 -> ../e3e/70682-c209-4cac-629f-6fbed82c07cd
+├── e3e
+│   └── 70682-c209-4cac-629f-6fbed82c07cd
 │       ├── annex
 │       │   └── objects
 │       ├── archives
@@ -33,8 +35,6 @@ $ tree /home/me/myriastore
 │       │   ├── heads
 │       │   └── tags
 │       └── ria-layout-version
-├── alias
-│   └── dl-101 -> ../5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676
 ├── error_logs
 └── ria-layout-version
 

--- a/docs/beyond_basics/_examples/DL-101-147-106
+++ b/docs/beyond_basics/_examples/DL-101-147-106
@@ -1,4 +1,4 @@
 # The dataset ID is stored in .datalad/config
 $ cat .datalad/config
 [datalad "dataset"]
-	id = 5d24f8fb-8339-4fe7-9b64-fec6af4e9676
+	id = e3e70682-c209-4cac-629f-6fbed82c07cd

--- a/docs/beyond_basics/_examples/DL-101-147-107
+++ b/docs/beyond_basics/_examples/DL-101-147-107
@@ -1,24 +1,24 @@
 $ datalad push --to ria-backup
-[INFO] Determine push target 
-[INFO] Push refspecs 
-[INFO] Determine push target 
-[INFO] Push refspecs 
-[INFO] Transfer data 
+[INFO] Determine push target
+[INFO] Push refspecs
+[INFO] Determine push target
+[INFO] Push refspecs
+[INFO] Transfer data
 copy(ok): books/TLCL.pdf (file) [to ria-backup-storage...]
 copy(ok): books/bash_guide.pdf (file) [to ria-backup-storage...]
 copy(ok): books/byte-of-python.pdf (file) [to ria-backup-storage...]
 copy(ok): books/progit.pdf (file) [to ria-backup-storage...]
-[INFO] Transfer data 
-[INFO] Update availability information 
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-[INFO] Start resolving deltas 
+[INFO] Transfer data
+[INFO] Update availability information
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
+[INFO] Start resolving deltas
 publish(ok): . (dataset) [refs/heads/master->ria-backup:refs/heads/master [new branch]]
 publish(ok): . (dataset) [refs/heads/git-annex->ria-backup:refs/heads/git-annex [new branch]]
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101) 
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101) 
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101)
 action summary:
   copy (ok: 4)
   publish (ok: 2)

--- a/docs/beyond_basics/_examples/DL-101-147-108
+++ b/docs/beyond_basics/_examples/DL-101-147-108
@@ -1,7 +1,9 @@
 $ tree /home/me/myriastore
 /home/me/myriastore
-├── 5d2
-│   └── 4f8fb-8339-4fe7-9b64-fec6af4e9676
+├── alias
+│   └── dl-101 -> ../e3e/70682-c209-4cac-629f-6fbed82c07cd
+├── e3e
+│   └── 70682-c209-4cac-629f-6fbed82c07cd
 │       ├── annex
 │       │   └── objects
 │       │       ├── G6
@@ -12,14 +14,14 @@ $ tree /home/me/myriastore
 │       │       │   └── 3M
 │       │       │       └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
 │       │       │           └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
-│       │       ├── WF
-│       │       │   └── Gq
-│       │       │       └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-│       │       │           └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-│       │       └── z1
-│       │           └── Q8
-│       │               └── MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
-│       │                   └── MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
+│       │       ├── P5
+│       │       │   └── qK
+│       │       │       └── MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf
+│       │       │           └── MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf
+│       │       └── WF
+│       │           └── Gq
+│       │               └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
+│       │                   └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
 │       ├── archives
 │       ├── branches
 │       ├── config
@@ -45,9 +47,9 @@ $ tree /home/me/myriastore
 │       ├── objects
 │       │   ├── info
 │       │   └── pack
-│       │       ├── pack-09d711f30125ebc0f423bc792e1fb8dbbac458ec.idx
-│       │       └── pack-09d711f30125ebc0f423bc792e1fb8dbbac458ec.pack
-│       ├── ora-remote-49a69e90-9581-4205-b2d5-a5c3fe832f0d
+│       │       ├── pack-a7c65b335a6cda3d472e5954c15795ce78488173.idx
+│       │       └── pack-a7c65b335a6cda3d472e5954c15795ce78488173.pack
+│       ├── ora-remote-46b169aa-bb91-42d6-be06-355d957fb4f7
 │       │   └── transfer
 │       ├── refs
 │       │   ├── heads
@@ -55,8 +57,6 @@ $ tree /home/me/myriastore
 │       │   │   └── master
 │       │   └── tags
 │       └── ria-layout-version
-├── alias
-│   └── dl-101 -> ../5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676
 ├── error_logs
 └── ria-layout-version
 

--- a/docs/beyond_basics/_examples/DL-101-147-109
+++ b/docs/beyond_basics/_examples/DL-101-147-109
@@ -1,11 +1,11 @@
 $ cd midterm_project
 $ datalad create-sibling-ria -s ria-backup ria+file:///home/me/myriastore
-[INFO] Creating a new RIA store at /home/me/myriastore 
-[INFO] create siblings 'ria-backup' and 'ria-backup-storage' ... 
-[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101/midterm_project) 
+[INFO] Creating a new RIA store at /home/me/myriastore
+[INFO] create siblings 'ria-backup' and 'ria-backup-storage' ...
+[INFO] Fetching updates for Dataset(/home/me/dl-101/DataLad-101/midterm_project)
 update(ok): . (dataset)
 update(ok): . (dataset)
-[INFO] Configure additional publication dependency on "ria-backup-storage" 
+[INFO] Configure additional publication dependency on "ria-backup-storage"
 configure-sibling(ok): . (sibling)
 create-sibling-ria(ok): /home/me/dl-101/DataLad-101/midterm_project (dataset)
 action summary:

--- a/docs/beyond_basics/_examples/DL-101-147-110
+++ b/docs/beyond_basics/_examples/DL-101-147-110
@@ -1,23 +1,23 @@
 $ datalad push --to ria-backup
-[INFO] Determine push target 
-[INFO] Push refspecs 
-[INFO] Determine push target 
-[INFO] Push refspecs 
-[INFO] Transfer data 
+[INFO] Determine push target
+[INFO] Push refspecs
+[INFO] Determine push target
+[INFO] Push refspecs
+[INFO] Transfer data
 copy(ok): .datalad/environments/midterm-software/image (file) [to ria-backup-storage...]
 copy(ok): pairwise_relationships.png (file) [to ria-backup-storage...]
 copy(ok): prediction_report.csv (file) [to ria-backup-storage...]
-[INFO] Transfer data 
-[INFO] Update availability information 
-[INFO] Start enumerating objects 
-[INFO] Start counting objects 
-[INFO] Start compressing objects 
-[INFO] Start writing objects 
-[INFO] Start resolving deltas 
+[INFO] Transfer data
+[INFO] Update availability information
+[INFO] Start enumerating objects
+[INFO] Start counting objects
+[INFO] Start compressing objects
+[INFO] Start writing objects
+[INFO] Start resolving deltas
 publish(ok): . (dataset) [refs/heads/master->ria-backup:refs/heads/master [new branch]]
 publish(ok): . (dataset) [refs/heads/git-annex->ria-backup:refs/heads/git-annex [new branch]]
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project) 
-[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project) 
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project)
+[INFO] Finished push of Dataset(/home/me/dl-101/DataLad-101/midterm_project)
 action summary:
   copy (ok: 3)
   publish (ok: 2)

--- a/docs/beyond_basics/_examples/DL-101-147-111
+++ b/docs/beyond_basics/_examples/DL-101-147-111
@@ -1,6 +1,6 @@
 $ cat .datalad/config
 [datalad "dataset"]
-	id = fea11e88-f41c-4447-8e34-17ea56f7ef92
+	id = d95bafc8-f2a4-d27b-dcf4-bb99f4bea973
 [datalad "containers.midterm-software"]
 	image = .datalad/environments/midterm-software/image
 	cmdexec = singularity exec -B {{pwd}} {img} {cmd}

--- a/docs/beyond_basics/_examples/DL-101-147-112
+++ b/docs/beyond_basics/_examples/DL-101-147-112
@@ -1,65 +1,9 @@
 $ tree /home/me/myriastore
 /home/me/myriastore
-├── 5d2
-│   └── 4f8fb-8339-4fe7-9b64-fec6af4e9676
-│       ├── annex
-│       │   └── objects
-│       │       ├── G6
-│       │       │   └── Gj
-│       │       │       └── MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
-│       │       │           └── MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
-│       │       ├── jf
-│       │       │   └── 3M
-│       │       │       └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
-│       │       │           └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
-│       │       ├── WF
-│       │       │   └── Gq
-│       │       │       └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-│       │       │           └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-│       │       └── z1
-│       │           └── Q8
-│       │               └── MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
-│       │                   └── MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
-│       ├── archives
-│       ├── branches
-│       ├── config
-│       ├── config.dataladlock
-│       ├── description
-│       ├── HEAD
-│       ├── hooks
-│       │   ├── applypatch-msg.sample
-│       │   ├── commit-msg.sample
-│       │   ├── fsmonitor-watchman.sample
-│       │   ├── post-update.sample
-│       │   ├── pre-applypatch.sample
-│       │   ├── pre-commit.sample
-│       │   ├── pre-merge-commit.sample
-│       │   ├── prepare-commit-msg.sample
-│       │   ├── pre-push.sample
-│       │   ├── pre-rebase.sample
-│       │   ├── pre-receive.sample
-│       │   ├── push-to-checkout.sample
-│       │   └── update.sample
-│       ├── info
-│       │   └── exclude
-│       ├── objects
-│       │   ├── info
-│       │   └── pack
-│       │       ├── pack-09d711f30125ebc0f423bc792e1fb8dbbac458ec.idx
-│       │       └── pack-09d711f30125ebc0f423bc792e1fb8dbbac458ec.pack
-│       ├── ora-remote-49a69e90-9581-4205-b2d5-a5c3fe832f0d
-│       │   └── transfer
-│       ├── refs
-│       │   ├── heads
-│       │   │   ├── git-annex
-│       │   │   └── master
-│       │   └── tags
-│       └── ria-layout-version
 ├── alias
-│   └── dl-101 -> ../5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676
-├── error_logs
-├── fea
-│   └── 11e88-f41c-4447-8e34-17ea56f7ef92
+│   └── dl-101 -> ../e3e/70682-c209-4cac-629f-6fbed82c07cd
+├── d95
+│   └── bafc8-f2a4-d27b-dcf4-bb99f4bea973
 │       ├── annex
 │       │   └── objects
 │       │       ├── 8q
@@ -99,9 +43,9 @@ $ tree /home/me/myriastore
 │       ├── objects
 │       │   ├── info
 │       │   └── pack
-│       │       ├── pack-32d12476036bdc4f0bf7f9581681f3daff7d15de.idx
-│       │       └── pack-32d12476036bdc4f0bf7f9581681f3daff7d15de.pack
-│       ├── ora-remote-f99ce3a1-b0d4-4d88-b0eb-068589f19a5b
+│       │       ├── pack-31bcf87514087d313bac97730c39f38db17cc322.idx
+│       │       └── pack-31bcf87514087d313bac97730c39f38db17cc322.pack
+│       ├── ora-remote-9fb7f1f9-b6e6-4131-8d4c-2cee2e00b27a
 │       │   └── transfer
 │       ├── refs
 │       │   ├── heads
@@ -109,6 +53,62 @@ $ tree /home/me/myriastore
 │       │   │   └── master
 │       │   └── tags
 │       └── ria-layout-version
+├── e3e
+│   └── 70682-c209-4cac-629f-6fbed82c07cd
+│       ├── annex
+│       │   └── objects
+│       │       ├── G6
+│       │       │   └── Gj
+│       │       │       └── MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
+│       │       │           └── MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
+│       │       ├── jf
+│       │       │   └── 3M
+│       │       │       └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+│       │       │           └── MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
+│       │       ├── P5
+│       │       │   └── qK
+│       │       │       └── MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf
+│       │       │           └── MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf
+│       │       └── WF
+│       │           └── Gq
+│       │               └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
+│       │                   └── MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
+│       ├── archives
+│       ├── branches
+│       ├── config
+│       ├── config.dataladlock
+│       ├── description
+│       ├── HEAD
+│       ├── hooks
+│       │   ├── applypatch-msg.sample
+│       │   ├── commit-msg.sample
+│       │   ├── fsmonitor-watchman.sample
+│       │   ├── post-update.sample
+│       │   ├── pre-applypatch.sample
+│       │   ├── pre-commit.sample
+│       │   ├── pre-merge-commit.sample
+│       │   ├── prepare-commit-msg.sample
+│       │   ├── pre-push.sample
+│       │   ├── pre-rebase.sample
+│       │   ├── pre-receive.sample
+│       │   ├── push-to-checkout.sample
+│       │   └── update.sample
+│       ├── info
+│       │   └── exclude
+│       ├── objects
+│       │   ├── info
+│       │   └── pack
+│       │       ├── pack-a7c65b335a6cda3d472e5954c15795ce78488173.idx
+│       │       └── pack-a7c65b335a6cda3d472e5954c15795ce78488173.pack
+│       ├── ora-remote-46b169aa-bb91-42d6-be06-355d957fb4f7
+│       │   └── transfer
+│       ├── refs
+│       │   ├── heads
+│       │   │   ├── git-annex
+│       │   │   └── master
+│       │   └── tags
+│       └── ria-layout-version
+├── error_logs
 └── ria-layout-version
 
 56 directories, 54 files

--- a/docs/beyond_basics/_examples/DL-101-147-120
+++ b/docs/beyond_basics/_examples/DL-101-147-120
@@ -1,11 +1,11 @@
 
-$ datalad clone ria+file:///home/me/myriastore#5d24f8fb-8339-4fe7-9b64-fec6af4e9676 myclone
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/myclone) 
-[INFO] Attempting to clone from file:///home/me/myriastore/5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676 to /home/me/dl-101/myclone 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/myclone) 
-[INFO] Configure additional publication dependency on "ria-backup-storage" 
+$ datalad clone ria+file:///home/me/myriastore#e3e70682-c209-4cac-629f-6fbed82c07cd myclone
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/myclone)
+[INFO] Attempting to clone from file:///home/me/myriastore/e3e/70682-c209-4cac-629f-6fbed82c07cd to /home/me/beyond_basics/myclone
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/myclone)
+[INFO] Configure additional publication dependency on "ria-backup-storage"
 configure-sibling(ok): . (sibling)
-install(ok): /home/me/dl-101/myclone (dataset)
+install(ok): /home/me/beyond_basics/myclone (dataset)
 action summary:
   configure-sibling (ok: 1)
   install (ok: 1)

--- a/docs/beyond_basics/_examples/DL-101-147-122
+++ b/docs/beyond_basics/_examples/DL-101-147-122
@@ -1,2 +1,2 @@
 
-$ ln -s /home/me/myriastore/fea/11e88-f41c-4447-8e34-17ea56f7ef92 /home/me/myriastore/alias/midterm_project
+$ ln -s /home/me/myriastore/d95/bafc8-f2a4-d27b-dcf4-bb99f4bea973 /home/me/myriastore/alias/midterm_project

--- a/docs/beyond_basics/_examples/DL-101-147-123
+++ b/docs/beyond_basics/_examples/DL-101-147-123
@@ -1,6 +1,6 @@
 $ tree /home/me/myriastore/alias
 /home/me/myriastore/alias
-├── dl-101 -> ../5d2/4f8fb-8339-4fe7-9b64-fec6af4e9676
-└── midterm_project -> /home/me/myriastore/fea/11e88-f41c-4447-8e34-17ea56f7ef92
+├── dl-101 -> ../e3e/70682-c209-4cac-629f-6fbed82c07cd
+└── midterm_project -> /home/me/myriastore/d95/bafc8-f2a4-d27b-dcf4-bb99f4bea973
 
 2 directories, 0 files

--- a/docs/beyond_basics/_examples/DL-101-147-124
+++ b/docs/beyond_basics/_examples/DL-101-147-124
@@ -1,10 +1,10 @@
 datalad clone ria+file:///home/me/myriastore#~midterm_project
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/midterm_project) 
-[INFO] Attempting to clone from file:///home/me/myriastore/alias/midterm_project to /home/me/dl-101/midterm_project 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/midterm_project) 
-[INFO] Configure additional publication dependency on "ria-backup-storage" 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/midterm_project)
+[INFO] Attempting to clone from file:///home/me/myriastore/alias/midterm_project to /home/me/beyond_basics/midterm_project
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/midterm_project)
+[INFO] Configure additional publication dependency on "ria-backup-storage"
 configure-sibling(ok): . (sibling)
-install(ok): /home/me/dl-101/midterm_project (dataset)
+install(ok): /home/me/beyond_basics/midterm_project (dataset)
 action summary:
   configure-sibling (ok: 1)
   install (ok: 1)

--- a/docs/beyond_basics/_examples/DL-101-147-125
+++ b/docs/beyond_basics/_examples/DL-101-147-125
@@ -3,7 +3,7 @@ $ tree
 .
 ├── books
 │   ├── bash_guide.pdf -> ../.git/annex/objects/WF/Gq/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf/MD5E-s1198170--0ab2c121bcf68d7278af266f6a399c5f.pdf
-│   ├── byte-of-python.pdf -> ../.git/annex/objects/z1/Q8/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf/MD5E-s4208954--ab3a8c2f6b76b18b43c5949e0661e266.pdf
+│   ├── byte-of-python.pdf -> ../.git/annex/objects/P5/qK/MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf/MD5E-s2693891--e61afe4b3c5d76c849c4e61f6547ed03.pdf
 │   ├── progit.pdf -> ../.git/annex/objects/G6/Gj/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf/MD5E-s12465653--05cd7ed561d108c9bcf96022bc78a92c.pdf
 │   └── TLCL.pdf -> ../.git/annex/objects/jf/3M/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf/MD5E-s2120211--06d1efcb05bb2c55cd039dab3fb28455.pdf
 ├── code

--- a/docs/beyond_basics/_examples/DL-101-147-127
+++ b/docs/beyond_basics/_examples/DL-101-147-127
@@ -1,6 +1,6 @@
 $ datalad get -n midterm_project
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/myclone/midterm_project) 
-[INFO] Attempting to clone from file:///home/me/myriastore/fea/11e88-f41c-4447-8e34-17ea56f7ef92 to /home/me/dl-101/myclone/midterm_project 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/myclone/midterm_project) 
-[INFO] Configure additional publication dependency on "ria-backup-storage" 
-install(ok): /home/me/dl-101/myclone/midterm_project (dataset) [Installed subdataset in order to get /home/me/dl-101/myclone/midterm_project]
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/myclone/midterm_project)
+[INFO] Attempting to clone from file:///home/me/myriastore/d95/bafc8-f2a4-d27b-dcf4-bb99f4bea973 to /home/me/beyond_basics/myclone/midterm_project
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/myclone/midterm_project)
+[INFO] Configure additional publication dependency on "ria-backup-storage"
+install(ok): /home/me/beyond_basics/myclone/midterm_project (dataset) [Installed subdataset in order to get /home/me/beyond_basics/myclone/midterm_project]

--- a/docs/beyond_basics/_examples/DL-101-149-01
+++ b/docs/beyond_basics/_examples/DL-101-149-01
@@ -1,10 +1,10 @@
 $ datalad clone https://github.com/datalad-datasets/human-connectome-project-openaccess.git hcp
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp) 
-[INFO] Attempting to clone from https://github.com/datalad-datasets/human-connectome-project-openaccess.git to /home/me/dl-101/HPC/hcp 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp)
+[INFO] Attempting to clone from https://github.com/datalad-datasets/human-connectome-project-openaccess.git to /home/me/beyond_basics/HPC/hcp
 [INFO] Start enumerating objects 
 [INFO] Start counting objects 
 [INFO] Start compressing objects 
 [INFO] Start receiving objects 
 [INFO] Start resolving deltas 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp) 
-install(ok): /home/me/dl-101/HPC/hcp (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp)
+install(ok): /home/me/beyond_basics/HPC/hcp (dataset)

--- a/docs/beyond_basics/_examples/DL-101-149-02
+++ b/docs/beyond_basics/_examples/DL-101-149-02
@@ -1,166 +1,166 @@
 $ cd hcp
 $ datalad get -n -r HCP1200/130*
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013) 
-[INFO] Attempting to clone from http://store.datalad.org/78a/4404e-2aa7-11ea-8c3f-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130013 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130013]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130013 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/876/c9c98-2aa7-11ea-85a1-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130013/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013)
+[INFO] Attempting to clone from http://store.datalad.org/78a/4404e-2aa7-11ea-8c3f-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130013
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130013]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130013
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/876/c9c98-2aa7-11ea-85a1-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130013/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/8b5/6089e-2aa7-11ea-85a1-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130013/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/8e0/91aae-2aa7-11ea-85a1-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130013/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130013/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114) 
-[INFO] Attempting to clone from http://store.datalad.org/9a5/0b340-2aa6-11ea-81a2-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130114 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130114]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130114 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/a71/ab0e4-2aa6-11ea-a248-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130114/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/8b5/6089e-2aa7-11ea-85a1-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/8e0/91aae-2aa7-11ea-85a1-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130013/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130013/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114)
+[INFO] Attempting to clone from http://store.datalad.org/9a5/0b340-2aa6-11ea-81a2-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130114
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130114]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130114
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/a71/ab0e4-2aa6-11ea-a248-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130114/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/aa1/d4284-2aa6-11ea-a248-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/T1w) 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/ac8/7ba5e-2aa6-11ea-a248-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130114/unprocessed 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w (dataset)
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130114/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316) 
-[INFO] Attempting to clone from http://store.datalad.org/411/a7f1a-38ff-11ea-8d6e-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130316 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130316 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130316]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130316 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/439/61042-38ff-11ea-be90-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130316/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/aa1/d4284-2aa6-11ea-a248-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/ac8/7ba5e-2aa6-11ea-a248-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130114/unprocessed
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130114/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316)
+[INFO] Attempting to clone from http://store.datalad.org/411/a7f1a-38ff-11ea-8d6e-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130316
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130316 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130316]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130316
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/439/61042-38ff-11ea-be90-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130316/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130316/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/452/2bbea-38ff-11ea-be90-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130316/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130316/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/46a/1cd80-38ff-11ea-be90-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130316/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130316/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130316/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417) 
-[INFO] Attempting to clone from http://store.datalad.org/da5/a3938-2aa2-11ea-b13f-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130417 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130417 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130417]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130417 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/e8f/5ce4e-2aa2-11ea-a418-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130417/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/452/2bbea-38ff-11ea-be90-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130316/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130316/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/46a/1cd80-38ff-11ea-be90-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130316/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130316/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130316/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130316/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417)
+[INFO] Attempting to clone from http://store.datalad.org/da5/a3938-2aa2-11ea-b13f-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130417
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130417 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130417]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130417
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/e8f/5ce4e-2aa2-11ea-a418-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130417/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/eb1/55924-2aa2-11ea-a418-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130417/T1w 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130417/MNINonLinear (dataset)
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/T1w) 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/ed2/969bc-2aa2-11ea-a418-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130417/unprocessed 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130417/T1w (dataset)
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130417/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130417/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518) 
-[INFO] Attempting to clone from http://store.datalad.org/57a/9ec38-2aa0-11ea-b570-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130518 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130518 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130518]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130518 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/63f/8a1aa-2aa0-11ea-bf71-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130518/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/eb1/55924-2aa2-11ea-a418-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130417/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130417/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/ed2/969bc-2aa2-11ea-a418-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130417/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130417/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130417/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130417/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518)
+[INFO] Attempting to clone from http://store.datalad.org/57a/9ec38-2aa0-11ea-b570-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130518
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130518 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130518]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130518
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/63f/8a1aa-2aa0-11ea-bf71-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130518/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130518/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/658/7d860-2aa0-11ea-bf71-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130518/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/T1w) 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/674/822f4-2aa0-11ea-bf71-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130518/unprocessed 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130518/T1w (dataset)
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130518/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130518/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619) 
-[INFO] Attempting to clone from http://store.datalad.org/f6a/43756-2a9d-11ea-8166-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130619 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130619 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130619]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130619 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/032/2a332-2a9e-11ea-a1e6-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130619/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/658/7d860-2aa0-11ea-bf71-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130518/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130518/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/674/822f4-2aa0-11ea-bf71-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130518/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130518/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130518/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130518/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619)
+[INFO] Attempting to clone from http://store.datalad.org/f6a/43756-2a9d-11ea-8166-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130619
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130619 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130619]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130619
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/032/2a332-2a9e-11ea-a1e6-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130619/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130619/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/04a/bbcde-2a9e-11ea-a1e6-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130619/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130619/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/064/8fd7c-2a9e-11ea-a1e6-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130619/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130619/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130619/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720) 
-[INFO] Attempting to clone from http://store.datalad.org/5a2/318b0-2a99-11ea-9cc0-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130720 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130720 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130720]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130720 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/700/ffce2-2a99-11ea-b8dd-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130720/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/MNINonLinear) 
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130619/MNINonLinear (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/04a/bbcde-2a9e-11ea-a1e6-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130619/T1w
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/064/8fd7c-2a9e-11ea-a1e6-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130619/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130619/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130619/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130619/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720)
+[INFO] Attempting to clone from http://store.datalad.org/5a2/318b0-2a99-11ea-9cc0-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130720
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130720 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130720]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130720
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/700/ffce2-2a99-11ea-b8dd-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130720/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/722/fef3c-2a99-11ea-b8dd-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130720/T1w 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130720/MNINonLinear (dataset)
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130720/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/76a/4579c-2a99-11ea-b8dd-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130720/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130720/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130720/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821) 
-[INFO] Attempting to clone from http://store.datalad.org/b85/e461a-2a95-11ea-bd37-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130821 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130821 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130821]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130821 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/c4c/0f862-2a95-11ea-b221-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130821/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/MNINonLinear) 
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/722/fef3c-2a99-11ea-b8dd-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130720/T1w
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130720/MNINonLinear (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/T1w)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130720/T1w (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/76a/4579c-2a99-11ea-b8dd-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130720/unprocessed
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130720/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130720/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821)
+[INFO] Attempting to clone from http://store.datalad.org/b85/e461a-2a95-11ea-bd37-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130821
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130821 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130821]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130821
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/c4c/0f862-2a95-11ea-b221-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130821/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130821/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/c7c/23094-2a95-11ea-b221-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130821/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130821/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/cb9/ea382-2a95-11ea-b221-002590496000 to /home/me/dl-101/HPC/hcp/HCP1200/130821/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130821/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130821/unprocessed (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922) 
-[INFO] Attempting to clone from http://store.datalad.org/100/a5212-2a93-11ea-b54a-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130922 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130922 (dataset) [Installed subdataset in order to get /home/me/dl-101/HPC/hcp/HCP1200/130922]
-[INFO] Ensuring presence of Dataset(/home/me/dl-101/HPC/hcp) to get /home/me/dl-101/HPC/hcp/HCP1200/130922 
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/MNINonLinear) 
-[INFO] Attempting to clone from http://store.datalad.org/1d8/e51cc-2a93-11ea-bc67-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130922/MNINonLinear 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/MNINonLinear) 
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130821/MNINonLinear (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/c7c/23094-2a95-11ea-b221-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130821/T1w
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/cb9/ea382-2a95-11ea-b221-002590496000 to /home/me/beyond_basics/HPC/hcp/HCP1200/130821/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130821/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130821/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130821/unprocessed (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922)
+[INFO] Attempting to clone from http://store.datalad.org/100/a5212-2a93-11ea-b54a-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130922
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130922 (dataset) [Installed subdataset in order to get /home/me/beyond_basics/HPC/hcp/HCP1200/130922]
+[INFO] Ensuring presence of Dataset(/home/me/beyond_basics/HPC/hcp) to get /home/me/beyond_basics/HPC/hcp/HCP1200/130922
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/MNINonLinear)
+[INFO] Attempting to clone from http://store.datalad.org/1d8/e51cc-2a93-11ea-bc67-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130922/MNINonLinear
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/MNINonLinear)
 [INFO] scanning for annexed files (this may take some time) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130922/MNINonLinear (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/T1w) 
-[INFO] Attempting to clone from http://store.datalad.org/239/fe7a6-2a93-11ea-bc67-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130922/T1w 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/T1w) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130922/T1w (dataset)
-[INFO] Cloning dataset to Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/unprocessed) 
-[INFO] Attempting to clone from http://store.datalad.org/25e/ee1ba-2a93-11ea-bc67-0025904abcb0 to /home/me/dl-101/HPC/hcp/HCP1200/130922/unprocessed 
-[INFO] Completed clone attempts for Dataset(/home/me/dl-101/HPC/hcp/HCP1200/130922/unprocessed) 
-install(ok): /home/me/dl-101/HPC/hcp/HCP1200/130922/unprocessed (dataset)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130922/MNINonLinear (dataset)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/T1w)
+[INFO] Attempting to clone from http://store.datalad.org/239/fe7a6-2a93-11ea-bc67-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130922/T1w
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/T1w)
+[INFO] Cloning dataset to Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/unprocessed)
+[INFO] Attempting to clone from http://store.datalad.org/25e/ee1ba-2a93-11ea-bc67-0025904abcb0 to /home/me/beyond_basics/HPC/hcp/HCP1200/130922/unprocessed
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130922/T1w (dataset)
+[INFO] Completed clone attempts for Dataset(/home/me/beyond_basics/HPC/hcp/HCP1200/130922/unprocessed)
+install(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130922/unprocessed (dataset)
 action summary:
   install (ok: 36)

--- a/docs/beyond_basics/_examples/DL-101-149-03
+++ b/docs/beyond_basics/_examples/DL-101-149-03
@@ -1,3 +1,3 @@
 $ cd ..
 $ datalad create dataset-to-copy-to
-create(ok): /home/me/dl-101/HPC/dataset-to-copy-to (dataset)
+create(ok): /home/me/beyond_basics/HPC/dataset-to-copy-to (dataset)

--- a/docs/beyond_basics/_examples/DL-101-149-04
+++ b/docs/beyond_basics/_examples/DL-101-149-04
@@ -1,7 +1,7 @@
 $ datalad copy-file \
    hcp/HCP1200/130013/T1w/Diffusion/bvals  \
    -d dataset-to-copy-to
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvals [/home/me/dl-101/HPC/dataset-to-copy-to/bvals]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvals [/home/me/beyond_basics/HPC/dataset-to-copy-to/bvals]
 save(ok): . (dataset)
 action summary:
   copy_file (ok: 1)

--- a/docs/beyond_basics/_examples/DL-101-149-05
+++ b/docs/beyond_basics/_examples/DL-101-149-05
@@ -1,4 +1,4 @@
 $ datalad copy-file \
    hcp/HCP1200/130013/T1w/Diffusion/bvecs \
    -t dataset-to-copy-to
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvecs [/home/me/dl-101/HPC/dataset-to-copy-to/bvecs]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvecs [/home/me/beyond_basics/HPC/dataset-to-copy-to/bvecs]

--- a/docs/beyond_basics/_examples/DL-101-149-07
+++ b/docs/beyond_basics/_examples/DL-101-149-07
@@ -1,4 +1,4 @@
 $ datalad copy-file \
    hcp/HCP1200/130013/T1w/Diffusion/bvecs \
    dataset-to-copy-to/anothercopyofbvecs
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvecs [/home/me/dl-101/HPC/dataset-to-copy-to/anothercopyofbvecs]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130013/T1w/Diffusion/bvecs [/home/me/beyond_basics/HPC/dataset-to-copy-to/anothercopyofbvecs]

--- a/docs/beyond_basics/_examples/DL-101-149-10
+++ b/docs/beyond_basics/_examples/DL-101-149-10
@@ -3,19 +3,19 @@ $ datalad copy-file hcp/HCP1200/130114/T1w/Diffusion/* \
  -r \
  -d dataset-to-copy-to \
  -t dataset-to-copy-to/130114/T1w/Diffusion
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/bvals [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/bvals]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/bvecs [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/bvecs]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/data.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/data.nii.gz]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_stdev_map [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_stdev_map]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_map [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_map]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_sqr_stdev_map [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_sqr_stdev_map]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_post_eddy_shell_alignment_parameters [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_post_eddy_shell_alignment_parameters]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_report [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_report]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_movement_rms [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_movement_rms]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_restricted_movement_rms [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_restricted_movement_rms]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/grad_dev.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/grad_dev.nii.gz]
-copy_file(ok): /home/me/dl-101/HPC/hcp/HCP1200/130114/T1w/Diffusion/nodif_brain_mask.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130114/T1w/Diffusion/nodif_brain_mask.nii.gz]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/bvals [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/bvals]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/bvecs [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/bvecs]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/data.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/data.nii.gz]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_stdev_map [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_stdev_map]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_map [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_map]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_sqr_stdev_map [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_n_sqr_stdev_map]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_post_eddy_shell_alignment_parameters [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_post_eddy_shell_alignment_parameters]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_report [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_outlier_report]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_movement_rms [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_movement_rms]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_restricted_movement_rms [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_restricted_movement_rms]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/grad_dev.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/grad_dev.nii.gz]
+copy_file(ok): /home/me/beyond_basics/HPC/hcp/HCP1200/130114/T1w/Diffusion/nodif_brain_mask.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130114/T1w/Diffusion/nodif_brain_mask.nii.gz]
 save(ok): . (dataset)
 action summary:
   copy_file (ok: 13)

--- a/docs/beyond_basics/_examples/DL-101-149-12
+++ b/docs/beyond_basics/_examples/DL-101-149-12
@@ -1,7 +1,7 @@
 $ cd dataset-to-copy-to
 $ datalad get bvals anothercopyofbvecs 130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters
 get(ok): bvals (file) [from datalad...]
-get(ok): 130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters (file) [from datalad...]
 get(ok): anothercopyofbvecs (file) [from datalad...]
+get(ok): 130114/T1w/Diffusion/eddylogs/eddy_unwarped_images.eddy_parameters (file) [from datalad...]
 action summary:
   get (ok: 3)

--- a/docs/beyond_basics/_examples/DL-101-149-14
+++ b/docs/beyond_basics/_examples/DL-101-149-14
@@ -1,12 +1,12 @@
 # inside of hcp
 $ find HCP1200/130013/T1w/ -maxdepth 1 -name T1w*.nii.gz \
   | datalad copy-file -d ../dataset-to-copy-to --specs-from -
-copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1w_acpc_dc.nii.gz]
-copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore_1.25.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1w_acpc_dc_restore_1.25.nii.gz]
-copy_file(ok): HCP1200/130013/T1w/T1wDividedByT2w.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1wDividedByT2w.nii.gz]
-copy_file(ok): HCP1200/130013/T1w/T1wDividedByT2w_ribbon.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1wDividedByT2w_ribbon.nii.gz]
-copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore_brain.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1w_acpc_dc_restore_brain.nii.gz]
-copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/T1w_acpc_dc_restore.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1w_acpc_dc.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore_1.25.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1w_acpc_dc_restore_1.25.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1wDividedByT2w.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1wDividedByT2w.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1wDividedByT2w_ribbon.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1wDividedByT2w_ribbon.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore_brain.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1w_acpc_dc_restore_brain.nii.gz]
+copy_file(ok): HCP1200/130013/T1w/T1w_acpc_dc_restore.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/T1w_acpc_dc_restore.nii.gz]
 save(ok): . (dataset)
 action summary:
   copy_file (ok: 6)

--- a/docs/beyond_basics/_examples/DL-101-149-17
+++ b/docs/beyond_basics/_examples/DL-101-149-17
@@ -1,13 +1,13 @@
 $ find HCP1200/130518/T1w -maxdepth 1 -name T1w*.nii.gz \
  | sed -e 's#\(HCP1200\)\(.*\)#\1\2\x0../dataset-to-copy-to\2#' \
  | datalad copy-file -d ../dataset-to-copy-to -r --specs-from -
-copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_1.25.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_1.25.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1wDividedByT2w.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1wDividedByT2w.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1wDividedByT2w_ribbon.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1wDividedByT2w_ribbon.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_brain.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_brain.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore.nii.gz]
-copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_1.05.nii.gz [/home/me/dl-101/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_1.05.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_1.25.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_1.25.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1wDividedByT2w.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1wDividedByT2w.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1wDividedByT2w_ribbon.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1wDividedByT2w_ribbon.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_brain.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_brain.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore.nii.gz]
+copy_file(ok): HCP1200/130518/T1w/T1w_acpc_dc_restore_1.05.nii.gz [/home/me/beyond_basics/HPC/dataset-to-copy-to/130518/T1w/T1w_acpc_dc_restore_1.05.nii.gz]
 save(ok): . (dataset)
 action summary:
   copy_file (ok: 7)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,9 +85,6 @@ autorunrecord_env = {
     'GIT_EDITOR': 'vim',
     # prevent progress bars - makes for ugly runrecords. See https://github.com/datalad-handbook/book/issues/390
     'DATALAD_UI_PROGRESSBAR': 'none',
-    # consistent starting point to suppress undesired randomness in, e.g.,
-    # UUID generation
-    'DATALAD_SEED': '0',
 }
 if 'CAST_DIR' in os.environ:
     autorunrecord_env['CAST_DIR'] = os.environ['CAST_DIR']


### PR DESCRIPTION
This Changeset is quite messy - originally I wanted to merely split up the clean targets in the Makefile according to the book structure (2d6be3b415503eea4d74f3766e78f638a09c22f0). This brought up the need to change the working directories of two sections in the Advanced part (0a69b9a3133462138618ab006e544edafb71fb37, d85df9db21fa7aa142f13772f7a26a99d30bce7a). It also brought to light that identical dataset UUID generation causes problems in the RIA section (77fa11a2993958aaa1b7cb7d4b7083396b78136a). 
And because the fix in autorunrecord for the latter included a change that created a need to annotate exit codes, this PR also contains exit code annotations for commands that fail on purpose (c633936c692ab9588ffd5397e7c94184adca5028). It still isn't done (this PR is the code equivalent of a side quest), but I wanted to make the current state transparent.