### PR TITLE
Complete workflow to rebuild runrecords

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,23 +50,11 @@ shallow_clone: false
 
 
 environment:
-  # we do not have an adequate setup for SSH-based tests right now
-  #DATALAD_TESTS_SSH: 1
+  DTS: datalad_next
+  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+  INSTALL_SYSPKGS: python3-virtualenv graphicsmagick-imagemagick-compat moreutils
+  INSTALL_GITANNEX: git-annex -m snapshot
 
-  # Do not use `image` as a matrix dimension, to have fine-grained control over
-  # what tests run on which platform
-  # The ID variable had no impact, but sorts first in the CI run overview
-  # an intelligible name can help to locate a specific test run
-  matrix:
-    # List a CI run for each platform first, to have immediate access when there
-    # is a need for debugging
-
-    - ID: Ubu20
-      DTS: datalad_next
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      INSTALL_SYSPKGS: python3-virtualenv
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
 
 skip_commits:
   files:
@@ -75,7 +63,6 @@ skip_commits:
 # it is OK to specify paths that may not exist for a particular test run
 cache:
   # pip cache
-  - C:\Users\appveyor\AppData\Local\pip\Cache -> .appveyor.yml
   - /home/appveyor/.cache/pip -> .appveyor.yml
 
 
@@ -90,6 +77,9 @@ init:
   # Identity setup
   - git config --global user.email "team@datalad.org"
   - git config --global user.name "DataLad bot"
+  # enable credential store
+  - git config --global credential.helper store
+  - printf "https://%s:x-oauth-basic@github.com\n" ${GH_TOKEN} > "${HOME}/.git-credentials"
   # bootstrap handbook user
   - sudo mkdir /home/me
   - sudo chown $USER:$USER /home/me
@@ -98,6 +88,9 @@ init:
 
 
 install:
+  # Missing system software
+  - "[ -n \"$INSTALL_SYSPKGS\" ] && ( sudo apt-get update -qq -y && sudo apt-get install -qq --no-install-recommends -y ${INSTALL_SYSPKGS}; ) || true"
+  # in case of a snapshot installation, use the following approach to adjust
   # If a particular Python version is requested, use env setup (using the
   # appveyor provided environments/installation). Note, these are broken
   # on the ubuntu images
@@ -106,12 +99,9 @@ install:
   # use of python/pip executables below
   - "[ \"x$PY\" != x ] && . ${HOME}/venv${PY}/bin/activate || virtualenv -p 3 ${HOME}/dlvenv && . ${HOME}/dlvenv/bin/activate; ln -s \"$VIRTUAL_ENV\" \"${HOME}/VENV\""
   # deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
-  - python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
-  # Missing system software
-  - "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || { sudo apt-get update -y && sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS}; } ) || true"
-  # in case of a snapshot installation, use the following approach to adjust
+  - chronic python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
   # the PATH as necessary
-  - "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
+  - "[ -n \"${INSTALL_GITANNEX}\" ] && chronic datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
   # add location of datalad installer results to PATH
   - "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
 
@@ -121,9 +111,11 @@ install:
 
 
 build_script:
-  - python -m pip install -r requirements.txt
-  - python -m pip install -r requirements-devel.txt
-  - python -m pip install .
+  - chronic python -m pip install -r requirements.txt
+  - chronic python -m pip install -r requirements-devel.txt
+  - chronic python -m pip install .
+  # pull all submodules
+  - chronic datalad get . -r -n
 
 
 #after_build:
@@ -136,18 +128,28 @@ before_test:
 
 
 test_script:
+  # Wipe out runrecords to trigger rebuild
+  #- rm -f docs/basics/_examples/DL-101-*
+  - rm -f docs/basics/_examples/DL-101-101-101
   - make build
 
 
-#on_success:
-#
-
+on_success:
+  - printf "\n#\n#\n#\n# Runrecord diff\n#\n"
+  - git diff -- docs
+  - printf "\n\n\n\n"
+  - git diff -- docs > runrecord_diff.txt
+  - appveyor PushArtifact runrecord_diff.txt
+  - printf "\n#\n# Diff download\n%s\n\n" "https://ci.appveyor.com/api/projects/mih/book/artifacts/runrecord_diff.txt"
 
 #on_failure:
 #
 
+artifacts:
+  - path: runrecord_diff.txt
+    name: runrecord updates from rebuilding code snippets
+    type: File
 
 on_finish:
   # conditionally block the exit of a CI run for direct debugging
-  - sh: while [ -f ~/BLOCK ]; do sleep 5; done
-  - cmd: powershell.exe while ((Test-Path "C:\Users\\appveyor\\Desktop\\BLOCK.txt")) { Start-Sleep 5 }
+  - while [ -f ~/BLOCK ]; do sleep 5; done

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,153 @@
+# This CI setup provides a largely homogeneous configuration across all
+# major platforms (Windows, MacOS, and Linux). The aim of this test setup is
+# to create a "native" platform experience, using as few cross-platform
+# helper tools as possible.
+#
+# On Linux/Mac a virtualenv is used for testing. The effective virtual env
+# is available under ~/VENV.
+#
+# All workers support remote login. Login details are shown at the top of each
+# CI run log.
+#
+# - Linux/Mac workers (via SSH):
+#
+#   - A permitted SSH key must be defined in an APPVEYOR_SSH_KEY environment
+#     variable (via the appveyor project settings)
+#
+#   - SSH login info is given in the form of: 'appveyor@67.225.164.xx -p 22xxx'
+#
+#   - Login with:
+#
+#     ssh -o StrictHostKeyChecking=no <LOGIN>
+#
+#   - to prevent the CI run from exiting, `touch` a file named `BLOCK` in the
+#     user HOME directory (current directory directly after login). The session
+#     will run until the file is removed (or 60 min have passed)
+#
+# - Windows workers (via RDP):
+#
+#   - An RDP password should be defined in an APPVEYOR_RDP_PASSWORD environment
+#     variable (via the appveyor project settings), or a random password is used
+#     every time
+#
+#   - RDP login info is given in the form of IP:PORT
+#
+#   - Login with:
+#
+#     xfreerdp /cert:ignore /dynamic-resolution /u:appveyor /p:<PASSWORD> /v:<LOGIN>
+#
+#   - to prevent the CI run from exiting, create a textfile named `BLOCK` on the
+#     Desktop (a required .txt extension will be added automatically). The session
+#     will run until the file is removed (or 60 min have passed)
+#
+#   - in a terminal execute, for example, `C:\datalad_debug.bat 39` to set up the
+#     environment to debug in a Python 3.8 session (should generally match the
+#     respective CI run configuration).
+
+
+# do not make repository clone cheap: interfers with versioneer
+shallow_clone: false
+
+
+environment:
+  # we do not have an adequate setup for SSH-based tests right now
+  #DATALAD_TESTS_SSH: 1
+
+  # Do not use `image` as a matrix dimension, to have fine-grained control over
+  # what tests run on which platform
+  # The ID variable had no impact, but sorts first in the CI run overview
+  # an intelligible name can help to locate a specific test run
+  matrix:
+    # List a CI run for each platform first, to have immediate access when there
+    # is a need for debugging
+
+    - ID: Ubu20
+      DTS: datalad_next
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+
+skip_commits:
+  files:
+    - changelog.d/
+
+# it is OK to specify paths that may not exist for a particular test run
+cache:
+  # pip cache
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> .appveyor.yml
+  - /home/appveyor/.cache/pip -> .appveyor.yml
+
+
+# turn of support for MS project build support (not needed)
+build: off
+
+
+# init cannot use any components from the repo, because it runs prior to
+# cloning it
+init:
+  - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+  # Identity setup
+  - git config --global user.email "team@datalad.org"
+  - git config --global user.name "DataLad bot"
+  # bootstrap handbook user
+  - sudo mkdir /home/me
+  - sudo chown $USER:$USER /home/me
+  - HOME=/home/me git config --global user.name "Elena Piscopia"
+  - HOME=/home/me git config --global user.email "elena@example.net"
+
+
+install:
+  # If a particular Python version is requested, use env setup (using the
+  # appveyor provided environments/installation). Note, these are broken
+  # on the ubuntu images
+  # https://help.appveyor.com/discussions/problems/28217-appveyor-ubunu-image-with-python3-lzma-module
+  # Otherwise create a virtualenv using the default Python 3, to enable uniform
+  # use of python/pip executables below
+  - "[ \"x$PY\" != x ] && . ${HOME}/venv${PY}/bin/activate || virtualenv -p 3 ${HOME}/dlvenv && . ${HOME}/dlvenv/bin/activate; ln -s \"$VIRTUAL_ENV\" \"${HOME}/VENV\""
+  # deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
+  - python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
+  # Missing system software
+  - "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || { sudo apt-get update -y && sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS}; } ) || true"
+  # in case of a snapshot installation, use the following approach to adjust
+  # the PATH as necessary
+  - "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
+  # add location of datalad installer results to PATH
+  - "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
+
+
+#before_build:
+#
+
+
+build_script:
+  - python -m pip install -r requirements.txt
+  - python -m pip install -r requirements-devel.txt
+  - python -m pip install .
+
+
+#after_build:
+#
+
+
+before_test:
+  # simple call to see if datalad and git-annex are installed properly
+  - datalad wtf
+
+
+test_script:
+  - make build
+
+
+#on_success:
+#
+
+
+#on_failure:
+#
+
+
+on_finish:
+  # conditionally block the exit of a CI run for direct debugging
+  - sh: while [ -f ~/BLOCK ]; do sleep 5; done
+  - cmd: powershell.exe while ((Test-Path "C:\Users\\appveyor\\Desktop\\BLOCK.txt")) { Start-Sleep 5 }

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,10 @@
 # install python packages that are relevant to build all handbook examples
 datalad-container
+pytest
 seaborn
 pandas
 scikit-learn
 scikit-image
+# https://github.com/mwaskom/seaborn/issues/3192
+numpy < 1.24
 dvc

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,5 @@
 # install python packages that are relevant to build all handbook examples
 datalad-container
-nose
 seaborn
 pandas
 scikit-learn

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -3,6 +3,6 @@ datalad-container
 nose
 seaborn
 pandas
-sklearn
+scikit-learn
 scikit-image
 dvc


### PR DESCRIPTION
In less than 1k log lines, this makes a (full) rebuild of the handbook, including execution of runrecords.
 
It uses the standard build setup documented for the handbook.

Any resulting diff to the `doc/` directory (i.e. updated runrecords) is visualized at the end of the log, and is made available for download at a URL that is also shown at the very end.
    
With this diff contributors/maintainers can decide to incorporate the changes, in full or partially into their PRs.