### PR TITLE
Strip PATH listing from `wtf` when it has tmp dirs

### DIFF
--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -56,6 +56,8 @@ The output below shows an excerpt.
 .. runrecord:: _examples/DL-101-135-102
    :language: console
    :workdir: dl-101/DataLad-101
+   :linereplace:
+     ,PATH: /tmp/.*,PATH: REDACTED,
    :lines: 1-20
 
    $ datalad wtf

--- a/docs/basics/_examples/DL-101-135-102
+++ b/docs/basics/_examples/DL-101-135-102
@@ -63,7 +63,7 @@ $ datalad wtf
   - LANG: en_US.UTF-8
   - LANGUAGE: en_US:en
   - LC_CTYPE: en_US.UTF-8
-  - PATH: /tmp/dl-build-ckgs4jqw/git-annex.linux:VIRTUALENV/bin:/home/appveyor/.rvm/gems/ruby-2.7.2/bin:/home/appveyor/.rvm/gems/ruby-2.7.2@global/bin:/home/appveyor/.rvm/rubies/ruby-2.7.2/bin:/home/appveyor/.gvm/pkgsets/go1.19.2/global/bin:/home/appveyor/.gvm/gos/go1.19.2/bin:/home/appveyor/.gvm/pkgsets/go1.19.2/global/overlay/bin:/home/appveyor/.gvm/bin:/home/appveyor/.gvm/bin:/home/appveyor/.nvm/versions/node/v16.18.1/bin:/usr/lib/android-sdk/cmdline-tools/tools/bin:/usr/lib/android-sdk/cmdline-tools/latest/bin:/usr/lib/jvm/java-18-openjdk-amd64//bin:/opt/appveyor/build-agent:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/appveyor/.dotnet/tools:/home/appveyor/flutter/bin:/home/appveyor/.rvm/bin:/opt/mssql-tools/bin:/home/appveyor/vcpkg
+  - PATH: REDACTED
 ## extensions
   - container:
     - description: Containerized environments


### PR DESCRIPTION
Those have a random suffix and blow up the diff unneccessarily