### PR TITLE
BF: replace hardcoded figure number with numref

### DIFF
--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -216,13 +216,16 @@ The usecase :ref:`usecase_reproducible_paper` contains a step-by-step instructio
 how to build and share such a reproducible paper, if you want to learn
 more.
 
+
+
 .. figure:: ../artwork/src/img/dataset_modules.svg
    :width: 100%
+   :name: dataset_modules
    :alt: Modular structure of a data analysis project
 
    Data are modular components that can be re-used easily.
 
-The directory tree above and Figure 6.2 highlight different aspects
+The directory tree above and :numref:`dataset_modules` highlight different aspects
 of this principle. The directory tree illustrates the structure of
 the individual pieces on the file system from the point of view of
 a single top-level dataset with a particular purpose. It for example
@@ -234,7 +237,7 @@ compute outputs, and the code and outputs are captured,
 version-controlled, and linked to the input data. Each input data in turn
 is a (potentially nested) subdataset, but this is not visible
 in the directory hierarchy.
-Figure 6.2, in comparison, emphasizes a process view on a project and
+:numref:`dataset_modules`, in comparison, emphasizes a process view on a project and
 the nested structure of input subdataset:
 You can see how the preprocessed data that serves as an input for
 the analysis datasets evolves from raw data to


### PR DESCRIPTION
This PR closes https://github.com/datalad-handbook/book/issues/824

Looks like the hardcoded figure number (6.2, from https://github.com/datalad-handbook/book/pull/820/commits/d1033b5c5e81839f4a85f9695f0ff1f5ebb42d40) was also incorrect (if I read the context correctly) - it should be Fig 6.1.

I searched for other instances of hardcoded figure numbers in the book but couldn't find any.