### PR TITLE
Remove broken meta data tag that garbled html and social card rendering

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -27,11 +27,10 @@
   <meta property="twitter:image" content="https://handbook.datalad.org/_static/social-card-twitter.png">
   <meta property="twitter:image:alt" content="The DataLad Handbook logo with cute little beings playing with data">
   <meta property="og:image" content="https://handbook.datalad.org/_static/social-card.png">
-  <meta property="og:title" content="{{ title }}{{ titlesuffix }}">
   <meta property="og:type" content="article">
   {%- if metatags is defined %}
   {# FIXME: For some reason the `meta` dict is always empty. Extract the desc from the `metatags` text.  #}
-  <meta property="og:description" content="{{ metatags[15:-24] }}">
+  <meta property="og:description" content="{{ metatags[15:-23] }}">
   {%- endif %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #884.

The ``{{ title }}`` placeholder in ``layout.html`` exposes the 'section-number' individually in span element due to a feature request in Sphinx since Sphinx version 2.3.1 (sphinx-doc/sphinx#6613). This breaks a meta tag that includes the page title, spilling the title as a random string into the body of each page, and also spilling unrelated other HTML meta tags from the head into the body.

In practice, this leads to a rendering bug in the HTML version, and also, as this meta tag was originally used for social card support, in the social cards of any handbook links.

As the underlying problem won't be fixed on Sphinx side, this change removes the problematic meta tag entirely. I'm also decreasing the manual meta tag index that assembles the description in the social card from the available meta tags by one, but this is more or less a blind attempt as I don't fully understand its function or the counter (we kept this from the project we forked to start the handbook)

The full story is also in
https://github.com/datalad-handbook/book/issues/884#issuecomment-1363731369