### PR TITLE
fix typo in GIN page

### DIFF
--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -131,7 +131,7 @@ repository's ``https`` url. This does not require a user account on Gin.
    * Browser bar: ``https://gin.g-node.org/<user>/<repo>``
    * Copy-paste "HTTPS clone": ``https://gin.g-node.org/<user>/<repo>.git``
 
-   A dataset cloned from ``https://gin.g-node.org/<user>/<repoy>.git``, however, can not retrieve annexed files!
+   A dataset cloned from ``https://gin.g-node.org/<user>/<repo>.git``, however, can not retrieve annexed files!
 
 .. runrecord:: _examples/DL-101-139-107
    :language: console


### PR DESCRIPTION
I wished we called our repositories `repoy`: it sounds cuter. ;-p