### PR TITLE
Update the DVC section

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,8 @@ environment:
   DTS: datalad_next
   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
   INSTALL_SYSPKGS: python3-virtualenv graphicsmagick-imagemagick-compat moreutils jq uidmap
-  INSTALL_GITANNEX: git-annex -m snapshot
+  INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+
 
 
 skip_commits:

--- a/docs/beyond_basics/101-168-dvc.rst
+++ b/docs/beyond_basics/101-168-dvc.rst
@@ -28,7 +28,7 @@ We demonstrate each step with DVC according to their tutorial, and then recreate
 The usecase :ref:`usecase_ML` demonstrates a similar analysis in a completely DataLad-centric fashion.
 If you want to, you can code along, or simply read through the presentation of DVC and DataLad commands.
 Some familiarity with DataLad can be helpful, but if you have never used DataLad, footnotes in each section can point you relevant chapters for more insights on a command or concept.
-If you have never used DVC, `its technical docs <https://dvc.org/doc/command-reference>`_ or `collection of third-party tutorials <https://github.com/iterative/dvc.org/issues/1749>`_ can answer further questions.
+If you have never used DVC, `its documentation <https://dvc.org/doc>`_ (including the `command reference <https://dvc.org/doc/command-reference>`_) can answer further questions.
 
 .. admonition:: If you are not a Git user
 
@@ -252,7 +252,7 @@ DataLad workflow
 
 DataLad has means to get data or data archives from web sources and store this availability information within :term:`git-annex`.
 This has several advantages:
-For one, the original S3 bucket is known and stored as a location to re-retrieve the data from.
+For one, the original OSF file URL is known and stored as a location to re-retrieve the data from.
 This enables reliable data access for yourself and others that you share the dataset with.
 Beyond this, the data is also automatically extracted and saved, and thus put under version control.
 Note that this strays slightly from DataLad's :ref:`YODA principles <yoda>` in a DataLad-centric workflow, where data should become a standalone, reusable dataset that would be linked as a subdataset into a study/analysis specific dataset.
@@ -271,7 +271,7 @@ Here, we stick to the project organization of DVC though.
      https://osf.io/d6qbz/download \
      -O 'data/raw/'
 
-At this point, the data is already version controlled [#f6]_, but the directory structure doesn't resemble that of the DVC dataset yet -- the extracted directory adds one unnecessary directory layer::
+At this point, the data is already version controlled [#f6]_, and we have the following directory tree::
 
     $ tree
     .
@@ -287,9 +287,6 @@ At this point, the data is already version controlled [#f6]_, but the directory 
     └── model
 
     29 directories
-
-To make the scripts work, we move the raw data up one level.
-This move needs to be saved.
 
 .. find-out-more:: How does DataLad represent modifications to data?
 
@@ -353,7 +350,7 @@ The ``-d`` option sets it as the default remote, which simplifies pushing later 
    :language: console
 
    ### DVC
-   $ dvc remote add -d remote_storage ../dvc_remote
+   $ dvc remote add -d remote_storage ../dvc-remote
 
 The location of the remote is written into a config file:
 
@@ -470,7 +467,7 @@ An alternative is to switch from copies to :term:`symlink`\s (as done by :term:`
 DataLad workflow
 """"""""""""""""
 
-Because the S3 bucket of the raw data is known and stored in the dataset, it strictly speaking isn't necessary to create a storage sibling to push the data to -- DataLad already treats the original S3 bucket as storage.
+Because the OSF archive containing the raw data is known and stored in the dataset, it strictly speaking isn't necessary to create a storage sibling to push the data to -- DataLad already treats the original web location as storage.
 Currently, the dataset can thus be shared via :term:`GitHub` or similar hosting services, and the data can be retrieved using :command:`datalad get`.
 
 .. find-out-more:: Really?
@@ -515,7 +512,7 @@ Currently, the dataset can thus be shared via :term:`GitHub` or similar hosting 
       ### DVC-DataLad2
       $ datalad get data/raw/val
 
-   The data was retrieved by re-downloading the original archive from S3 and extracting the required files.
+   The data was retrieved by re-downloading the original archive from OSF and extracting the required files.
 
 
 Here's an example of pushing a dataset to a local sibling nevertheless:
@@ -574,7 +571,7 @@ Data analysis
 ^^^^^^^^^^^^^
 
 DVC is tuned towards machine learning analyses and comes with convenience commands and workflow management to build, compare, and reproduce machine learning pipelines.
-The tutorial therefore runs an SGD classifier and a random forrest classifier on the data and compares the two models.
+The tutorial therefore runs an SGD classifier and a random forest classifier on the data and compares the two models.
 For this, the pre-existing preparation, training, and evaluation scripts are used on the data we have downloaded and version controlled in the previous steps.
 DVC has means to transform such a structured ML analysis into a workflow, reproduce this workflow on demand, and compare it across different models or parametrizations.
 
@@ -722,22 +719,22 @@ It now needs to be committed, tagged, and pushed:
    $ git commit -m "Add SGD pipeline"
    $ dvc commit
    $ git push --set-upstream origin sgd-pipeline
-   $ git tag -a sgd-pipeline -m "Trained SGD as DVC pipeline."
+   $ git tag -a sgd -m "Trained SGD as DVC pipeline."
    $ git push origin --tags
    $ dvc push
 
-**Model 2: random forrest classifier**
+**Model 2: random forest classifier**
 
-In order to explore a second model, a random forrest classifier, we start with a new branch.
+In order to explore a second model, a random forest classifier, we start with a new branch.
 
 .. runrecord:: _examples/DL-101-168-161
    :workdir: DVCvsDL/DVC
    :language: console
 
    ### DVC
-   $ git checkout -b random_forrest
+   $ git checkout -b random-forest
 
-To switch from SGD to a random forrest classifier, a few lines of code within ``train.py`` need to be changed.
+To switch from SGD to a random forest classifier, a few lines of code within ``train.py`` need to be changed.
 The following `here doc <https://en.wikipedia.org/wiki/Here_document>`_ changes the script accordingly (changes are highlighted):
 
 .. runrecord:: _examples/DL-101-168-162
@@ -811,7 +808,7 @@ You can reproduce a complete DVC pipeline file with the :command:`dvc repro <sta
    $ dvc repro evaluate
 
 DVC checks the dependencies of the pipeline and re-executes commands that need to be executed again.
-Compared to the branch ``sgd_pipeline``, the workspace in the current ``random_forrest`` branch contains a changed script (``src/train.py``), a changed trained classifier (``model/model.joblib``), and a changed metric (``metric/accuracy.json``).
+Compared to the branch ``sgd-pipeline``, the workspace in the current ``random-forest`` branch contains a changed script (``src/train.py``), a changed trained classifier (``model/model.joblib``), and a changed metric (``metric/accuracy.json``).
 All these changes need to be committed, tagged, and pushed now.
 
 .. runrecord:: _examples/DL-101-168-165
@@ -820,10 +817,10 @@ All these changes need to be committed, tagged, and pushed now.
 
    ### DVC
    $ git add --all
-   $ git commit -m "Train Random Forrest classifier"
+   $ git commit -m "Train Random Forest classifier"
    $ dvc commit
    $ git push --set-upstream origin random-forest
-   $ git tag -a random-forest -m "Random Forest classifier with 80.99% accuracy."
+   $ git tag -a randomforest -m "Random Forest classifier with 80.99% accuracy."
    $ git push origin --tags
    $ dvc push
 
@@ -922,7 +919,7 @@ Let's add a tag to declare that it belongs to the SGD classifier.
    ### DVC-DataLad
    $ datalad save --version-tag SGD
 
-Let's now change the training script to use a random forrest classifier as before:
+Let's now change the training script to use a random forest classifier as before:
 
 .. runrecord:: _examples/DL-101-168-176
    :workdir: DVCvsDL/DVC-DataLad
@@ -980,7 +977,7 @@ We need to save this change:
    :workdir: DVCvsDL/DVC-DataLad
    :language: console
 
-   $ datalad save -m "Switch to random forrest classification" code/train.py
+   $ datalad save -m "Switch to random forest classification" code/train.py
 
 Afterwards, we can rerun all run records between the tags ``ready-for-analysis`` and ``SGD`` using :command:`datalad rerun`.
 We could automatically compute this on a different branch if we wanted to by using the ``branch`` option:
@@ -989,7 +986,7 @@ We could automatically compute this on a different branch if we wanted to by usi
    :workdir: DVCvsDL/DVC-DataLad
    :language: console
 
-   $ datalad rerun --branch="randomforrest" -m "Recompute classification with random forrest classifier" ready-for-analysis..SGD
+   $ datalad rerun --branch="randomforest" -m "Recompute classification with random forest classifier" ready-for-analysis..SGD
 
 Done!
 The difference in accuracies between models could now for example be compared with a ``git diff``:
@@ -1017,8 +1014,9 @@ Even though there is no one-to-one correspondence between a DVC and a DataLad wo
       #$ git reset --hard b796ba195447268ebc51e20a778fb2db9f11e341
       #$ git push --force origin master
       ## delete the branches and tags
-      #$ git push origin :random_forrest :sgd-pipeline
-      #$ git tag -d random-forrest sgd-pipeline
+      ## note: tags & branches were renamed; if uncommenting, check GitHub repo first
+      #$ git push origin :random-forest :sgd-pipeline
+      #$ git tag -d randomforest sgd
 
 Summary
 ^^^^^^^

--- a/docs/beyond_basics/_examples/DL-101-168-121
+++ b/docs/beyond_basics/_examples/DL-101-168-121
@@ -1,3 +1,3 @@
 ### DVC
-$ dvc remote add -d remote_storage ../dvc_remote
+$ dvc remote add -d remote_storage ../dvc-remote
 Setting 'remote_storage' as a default remote.

--- a/docs/beyond_basics/_examples/DL-101-168-122
+++ b/docs/beyond_basics/_examples/DL-101-168-122
@@ -3,4 +3,4 @@ $ cat .dvc/config
 [core]
     remote = remote_storage
 ['remote "remote_storage"']
-    url = ../../dvc_remote
+    url = ../../dvc-remote

--- a/docs/beyond_basics/_examples/DL-101-168-124
+++ b/docs/beyond_basics/_examples/DL-101-168-124
@@ -1,5 +1,5 @@
 ### DVC
 $ git add .dvc/config
 $ git commit -m "add local remote"
-[master d37e9ea] add local remote
+[master e8392ea] add local remote
  1 file changed, 4 insertions(+)

--- a/docs/beyond_basics/_examples/DL-101-168-131
+++ b/docs/beyond_basics/_examples/DL-101-168-131
@@ -2,7 +2,7 @@
 # outside of a dataset
 $ datalad clone https://github.com/datalad-handbook/DVC-DataLad.git DVC-DataLad-2
 $ cd DVC-DataLad-2
-[INFO] Cloning dataset to Dataset(/home/me/DVCvsDL/DVC-DataLad-2)
+[INFO] Attempting a clone into /home/me/DVCvsDL/DVC-DataLad-2
 [INFO] Attempting to clone from https://github.com/datalad-handbook/DVC-DataLad.git to /home/me/DVCvsDL/DVC-DataLad-2
 [INFO] Start enumerating objects
 [INFO] Start counting objects
@@ -10,6 +10,7 @@ $ cd DVC-DataLad-2
 [INFO] Start receiving objects
 [INFO] Start resolving deltas
 [INFO] Completed clone attempts for Dataset(/home/me/DVCvsDL/DVC-DataLad-2)
+[INFO] scanning for annexed files (this may take some time)
 [INFO] Remote origin not usable by git-annex; setting annex-ignore
 [INFO] https://github.com/datalad-handbook/DVC-DataLad.git/config download failed: Not Found
 install(ok): /home/me/DVCvsDL/DVC-DataLad-2 (dataset)

--- a/docs/beyond_basics/_examples/DL-101-168-141
+++ b/docs/beyond_basics/_examples/DL-101-168-141
@@ -10,7 +10,7 @@ $ datalad push --to mysibling
 [INFO] Start writing objects
 [INFO] Start resolving deltas
 [INFO] Finished push of Dataset(/home/me/DVCvsDL/DVC-DataLad)
-publish(ok): . (dataset) [refs/heads/git-annex->mysibling:refs/heads/git-annex 31ba7f66..ff00e44d]
+publish(ok): . (dataset) [refs/heads/git-annex->mysibling:refs/heads/git-annex 02788fb6..53a238d5]
 publish(ok): . (dataset) [refs/heads/master->mysibling:refs/heads/master [new branch]]
 action summary:
   copy (ok: 2701)

--- a/docs/beyond_basics/_examples/DL-101-168-159
+++ b/docs/beyond_basics/_examples/DL-101-168-159
@@ -1,4 +1,4 @@
 ### DVC
 $ dvc metrics show
 Path                   accuracy
-metrics/accuracy.json  0.782
+metrics/accuracy.json  0.78074

--- a/docs/beyond_basics/_examples/DL-101-168-160
+++ b/docs/beyond_basics/_examples/DL-101-168-160
@@ -3,18 +3,17 @@ $ git add --all
 $ git commit -m "Add SGD pipeline"
 $ dvc commit
 $ git push --set-upstream origin sgd-pipeline
-$ git tag -a sgd-pipeline -m "Trained SGD as DVC pipeline."
+$ git tag -a sgd -m "Trained SGD as DVC pipeline."
 $ git push origin --tags
 $ dvc push
-[sgd-pipeline 9b91b57] Add SGD pipeline
+[sgd-pipeline 75992db] Add SGD pipeline
  5 files changed, 73 insertions(+)
  create mode 100644 dvc.lock
  create mode 100644 dvc.yaml
  create mode 100644 metrics/accuracy.json
-error: src refspec sgd-pipeline matches more than one
-error: failed to push some refs to '/home/me/pushes/data-version-control'
-fatal: tag 'sgd-pipeline' already exists
 To /home/me/pushes/data-version-control
- * [new tag]         random-forest -> random-forest
- * [new tag]         sgd-pipeline -> sgd-pipeline
+ * [new branch]      sgd-pipeline -> sgd-pipeline
+branch 'sgd-pipeline' set up to track 'origin/sgd-pipeline'.
+To /home/me/pushes/data-version-control
+ * [new tag]         sgd -> sgd
 3 files pushed

--- a/docs/beyond_basics/_examples/DL-101-168-161
+++ b/docs/beyond_basics/_examples/DL-101-168-161
@@ -1,3 +1,3 @@
 ### DVC
-$ git checkout -b random_forrest
-Switched to a new branch 'random_forrest'
+$ git checkout -b random-forest
+Switched to a new branch 'random-forest'

--- a/docs/beyond_basics/_examples/DL-101-168-165
+++ b/docs/beyond_basics/_examples/DL-101-168-165
@@ -1,14 +1,16 @@
 ### DVC
 $ git add --all
-$ git commit -m "Train Random Forrest classifier"
+$ git commit -m "Train Random Forest classifier"
 $ dvc commit
 $ git push --set-upstream origin random-forest
-$ git tag -a random-forest -m "Random Forest classifier with 80.99% accuracy."
+$ git tag -a randomforest -m "Random Forest classifier with 80.99% accuracy."
 $ git push origin --tags
 $ dvc push
-[random_forrest ca4aafc] Train Random Forrest classifier
- 3 files changed, 11 insertions(+), 17 deletions(-)
-Everything up-to-date
-fatal: tag 'random-forest' already exists
-Everything up-to-date
+[random-forest 8509e4d] Train Random Forest classifier
+  3 files changed, 11 insertions(+), 17 deletions(-)
+To /home/me/pushes/data-version-control
+ * [new branch]      random-forest -> random-forest
+branch 'random-forest' set up to track 'origin/random-forest'.
+ To /home/me/pushes/data-version-control
+   [new tag]         randomforest -> randomforest
 1 file pushed

--- a/docs/beyond_basics/_examples/DL-101-168-166
+++ b/docs/beyond_basics/_examples/DL-101-168-166
@@ -1,6 +1,6 @@
 ### DVC
 $ dvc metrics show -T
-Revision       Path                   accuracy
-workspace      metrics/accuracy.json  0.81876
-random-forest  metrics/accuracy.json  0.81876
-sgd-pipeline   metrics/accuracy.json  0.74271
+Revision      Path                   accuracy
+workspace     metrics/accuracy.json  0.81115
+randomforest  metrics/accuracy.json  0.81115
+sgd           metrics/accuracy.json  0.6654

--- a/docs/beyond_basics/_examples/DL-101-168-173
+++ b/docs/beyond_basics/_examples/DL-101-168-173
@@ -5,7 +5,7 @@ $ datalad run --message "Train an SGD classifier" \
    python code/train.py
 [INFO] Making sure inputs are available (this may take some time)
 [INFO] == Command start (output follows) =====
-VIRTUALENV/lib/python3.8/site-packages/sklearn/linear_model/_stochastic_gradient.py:704: ConvergenceWarning: Maximum number of iteration reached before convergence. Consider increasing max_iter to improve the fit.
+VIRTUALENV/lib/python3.8/site-packages/sklearn/linear_model/_stochastic_gradient.py:702: ConvergenceWarning: Maximum number of iteration reached before convergence. Consider increasing max_iter to improve the fit.
   warnings.warn(
 [INFO] == Command exit (modification check follows) =====
 run(ok): /home/me/DVCvsDL/DVC-DataLad (dataset) [python code/train.py]

--- a/docs/beyond_basics/_examples/DL-101-168-177
+++ b/docs/beyond_basics/_examples/DL-101-168-177
@@ -1,4 +1,4 @@
-$ datalad save -m "Switch to random forrest classification" code/train.py
+$ datalad save -m "Switch to random forest classification" code/train.py
 add(ok): code/train.py (file)
 save(ok): . (dataset)
 action summary:

--- a/docs/beyond_basics/_examples/DL-101-168-178
+++ b/docs/beyond_basics/_examples/DL-101-168-178
@@ -1,6 +1,6 @@
-$ datalad rerun --branch="randomforrest" -m "Recompute classification with random forrest classifier" ready-for-analysis..SGD
-[INFO] checkout commit e132438;
-[INFO] run commit 8b80b98; (Train an SGD clas...)
+$ datalad rerun --branch="randomforest" -m "Recompute classification with random forest classifier" ready-for-analysis..SGD
+[INFO] checkout commit fa4f16d;
+[INFO] run commit 1e265e4; (Train an SGD clas...)
 [INFO] Making sure inputs are available (this may take some time)
 [INFO] Unlocking files
 unlock(ok): model/model.joblib (file)
@@ -11,7 +11,7 @@ unlock(ok): model/model.joblib (file)
 run(ok): /home/me/DVCvsDL/DVC-DataLad (dataset) [python code/train.py]
 add(ok): model/model.joblib (file)
 save(ok): . (dataset)
-[INFO] run commit 77cfa2c; (Evaluate SGD clas...)
+[INFO] run commit 812bbc0; (Evaluate SGD clas...)
 [INFO] Making sure inputs are available (this may take some time)
 [INFO] == Command start (output follows) =====
 [INFO] == Command exit (modification check follows) =====

--- a/docs/beyond_basics/_examples/DL-101-168-179
+++ b/docs/beyond_basics/_examples/DL-101-168-179
@@ -1,10 +1,10 @@
 $ git diff SGD -- metrics/accuracy.json
 diff --git a/metrics/accuracy.json b/metrics/accuracy.json
-index 7e85b934..a95a869e 100644
+index 917ce2ce..9279f676 100644
 --- a/metrics/accuracy.json
 +++ b/metrics/accuracy.json
 @@ -1 +1 @@
--{"accuracy": 0.7870722433460076}
+-{"accuracy": 0.7084917617237009}
 \ No newline at end of file
-+{"accuracy": 0.8073510773130546}
++{"accuracy": 0.8149556400506971}
 \ No newline at end of file

--- a/docs/beyond_basics/_examples/DL-101-168-190
+++ b/docs/beyond_basics/_examples/DL-101-168-190
@@ -2,5 +2,6 @@
 #$ git reset --hard b796ba195447268ebc51e20a778fb2db9f11e341
 #$ git push --force origin master
 ## delete the branches and tags
-#$ git push origin :random_forrest :sgd-pipeline
-#$ git tag -d random-forrest sgd-pipeline
+## note: tags & branches were renamed; if uncommenting, check GitHub repo first
+#$ git push origin :random-forest :sgd-pipeline
+#$ git tag -d randomforest sgd


### PR DESCRIPTION
Minor fixes for things I noticed when preparing for a workshop. See commit messages for details.

Lacks run records, which prevents merge, but depends on appveyor succeeding (see below), so I leave this in draft mode. Otherwise quite complete.

Remaining todos and issues (help welcome):

- [x] Update run records. Some of the commits touch the `runrecord` directives and they will require updating the built [run records](https://handbook.datalad.org/en/latest/contributing.html#automatic-builds), preferably with artifacts from AppVeyor once it succeeds (see comment below).
- [x] Remove git errors when pushing tags. Currently, two outputs in the DVC workflow (ctrl-f in [this section](https://handbook.datalad.org/en/latest/beyond_basics/101-168-dvc.html#id13)) contain "error" and "fatal" messages coming from git. My first impression is that they are caused by being unable to push tags that already exist (but probably are attached to different commit ids). Might be a holdover from some previous run, or a cleaning error? There are some `.. only:: adminmode` directives that create a local push target to serve as origin, after all. (nothing critical by any means)