### PR TITLE
Include requirements-devel in contributing guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -52,6 +52,7 @@ If you want to be able to build the book locally, though, please follow these in
    $ cd book
    # install required software
    $ pip install -r requirements.txt
+   $ pip install -r requirements-devel.txt
    $ pip install -e .
 
 - install ``librsvg2-bin`` (a tool to render ``.svgs``) with your package manager
@@ -83,7 +84,7 @@ Once this is configured, you can build the book locally by running ``make build`
 of the repository, and open it in your browser, for example with
 ``firefox docs/_build/html/index.html``.
 
-In case you need to remove the build files, you can just run make ``clean-build``.
+In case you need to remove the build files, you can just run ``make clean-build``.
 
 Automatic builds
 """"""""""""""""


### PR DESCRIPTION
The project uses requirements and requirements-devel, the latter of which contains datalad-container and Python packages used in the examples. This commit includes both in installation instructions.

Another one-line change adds consistency in putting make in verbatim.

Side note: I had to play around a bit to make the build happen on my Fedora PC and found out that the best solution is to remove only the run records that my changes touched (and not use the entire clean-build or clean-beyond-basics), otherwise the run would take long and eventually fail due to some installation-specific issues (e.g. credentials, IIRC hcp, in beyond-basics; or containers in basics). In the end, I felt that using the appveyor build may be the best way forward for me. But all this wasn't hard to figure out based on the provided information, so probably no need to expanding on that in the contributing guide.