### PR TITLE
Declare / update RTD build environment (Ubuntu 22.04)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 submodules:
   include: all
   recursive: true
@@ -22,6 +27,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: requirements.txt


### PR DESCRIPTION
This change adds the "build" configuration option for ReadTheDocs, and requires Ubuntu 22.04 LTS.

Python verison is also included in the "build" section, as old way of declaration is deprecated. We use this opportunity to bump Python to v3.9 (matching current debian stable) as 3.7 nears its EOL.

The change is prompted by build failure, after requirements pulled in urllib3 v2.0.x, which removed support for OpenSSL versions earlier than 1.1.1. Build error indicated openssl 1.0.2n which would imply we might even have been on 18.04 (?). Fixes #954