### PR TITLE
Update installation.rst for GIt for windows install

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -110,9 +110,10 @@ Git:
     directory, but configure the following settings (they are distributed over
     multiple dialogs):
 
-    - Enable *Use a TrueType font in all console windows*
+    
     - Select *Git from the command line and also from 3rd-party software*
     - *Enable file system caching*
+    - *Select Use external OpenSSH*
     - *Enable symbolic links*
 
 


### PR DESCRIPTION
delete option that do not exist anymore
add option about openssh, as of  https://github.com/datalad/datalad/issues/5829#issuecomment-1068773537