### PR TITLE
Shorten blob URLs

### DIFF
--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -22,9 +22,9 @@ but you can not get mine."
 
 Consider, for example, that your room mate might have googled about DataLad
 a bit. In the depths of the web, he might have found useful additional information, such
-a script on `dataset nesting <https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1f08d0a54ab521586f27ee918b4441d69/content/asciicast/seamless_nested_repos.sh>`_.
+a script on `dataset nesting <https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1/content/asciicast/seamless_nested_repos.sh>`_.
 Because he found this very helpful in understanding dataset
-nesting concepts, he decided to download it `from GitHub <https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1f08d0a54ab521586f27ee918b4441d69/content/asciicast/seamless_nested_repos.sh>`_, and saved it in the ``code/`` directory.
+nesting concepts, he decided to download it from GitHub, and saved it in the ``code/`` directory.
 
 He does it using the datalad command :dlcmd:`download-url`
 that you experienced in section :ref:`createDS` already: This command will
@@ -49,7 +49,7 @@ and run the following command
      -d . \
      -m "Include nesting demo from datalad website" \
      -O code/nested_repos.sh \
-     https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1f08d0a54ab521586f27ee918b4441d69/content/asciicast/seamless_nested_repos.sh
+     https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1/content/asciicast/seamless_nested_repos.sh
 
 Run a quick datalad status:
 

--- a/docs/basics/_examples/DL-101-121-101
+++ b/docs/basics/_examples/DL-101-121-101
@@ -6,8 +6,8 @@ $ datalad download-url \
   -d . \
   -m "Include nesting demo from datalad website" \
   -O code/nested_repos.sh \
-  https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1f08d0a54ab521586f27ee918b4441d69/content/asciicast/seamless_nested_repos.sh
-[INFO] Downloading 'https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1✂SHA1/content/asciicast/seamless_nested_repos.sh' into '/home/me/dl-101/mock_user/DataLad-101/code/nested_repos.sh'
+  https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1/content/asciicast/seamless_nested_repos.sh
+[INFO] Downloading 'https://raw.githubusercontent.com/datalad/datalad.org/7e8e39b1/content/asciicast/seamless_nested_repos.sh' into '/home/me/dl-101/mock_user/DataLad-101/code/nested_repos.sh'
 download_url(ok): /home/me/dl-101/mock_user/DataLad-101/code/nested_repos.sh (file)
 add(ok): code/nested_repos.sh (file)
 save(ok): . (dataset)

--- a/docs/beyond_basics/101-182-catalog.rst
+++ b/docs/beyond_basics/101-182-catalog.rst
@@ -540,7 +540,7 @@ We'll ensure that the new custom logo is available locally:
    :cast: catalog_basics
    :notes: Get the custom logo
 
-   $  wget -q -O datalad_logo_funky.svg https://raw.githubusercontent.com/datalad/tutorials/5e5fc0a4761248e5cedbc491c357d423d14a2b21/notebooks/catalog_tutorials/test_data/datalad_logo_funky.svg
+   $  wget -q -O datalad_logo_funky.svg https://raw.githubusercontent.com/datalad/tutorials/5e5fc0a4/notebooks/catalog_tutorials/test_data/datalad_logo_funky.svg
 
 Now we can run all the necessary subcommands for the catalog generation process:
 

--- a/docs/beyond_basics/_examples/DL-101-182-113
+++ b/docs/beyond_basics/_examples/DL-101-182-113
@@ -1,1 +1,1 @@
-$  wget -q -O datalad_logo_funky.svg https://raw.githubusercontent.com/datalad/tutorials/5e5fc0a4761248e5cedbc491c357d423d14a2b21/notebooks/catalog_tutorials/test_data/datalad_logo_funky.svg
+$  wget -q -O datalad_logo_funky.svg https://raw.githubusercontent.com/datalad/tutorials/5e5fc0a4/notebooks/catalog_tutorials/test_data/datalad_logo_funky.svg


### PR DESCRIPTION
Github allows download using the first 8 significant chars of a sha1 alone.

Closes #1000