### PR TITLE
Reduce the syntax highlighting guess-work

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -24,7 +24,9 @@ concepts of DataLad datasets together by creating one.
 Find a nice place on your computer's file system to put a dataset for ``DataLad-101``,
 and create a fresh, empty dataset with the :dlcmd:`create` command.
 
-Note the command structure of :dlcmd:`create` (optional bits are enclosed in ``[ ]``)::
+Note the command structure of :dlcmd:`create` (optional bits are enclosed in ``[ ]``):
+
+.. code-block:: bash
 
   datalad create [--description "..."] [-c <config options>] PATH
 

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -46,7 +46,9 @@ are presented here, make sure to check the :windows-wit:`on peculiarities of its
 
    In Unix shells, ``\`` can be used to split a command into several lines, for example to aid readability.
    Standard Windows terminals (including the Anaconda prompt) do not support this.
-   They instead use the ``^`` character::
+   They instead use the ``^`` character:
+
+   .. code-block:: bash
 
      $ wget -q https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download ^
      -O TLCL.pdf
@@ -75,7 +77,9 @@ curl <ww-curl-instead-wget>`.
    :name: ww-curl-instead-wget
 
    Many versions of Windows do not ship with the tool ``wget``.
-   You can install it, but it may be easier to use the pre-installed ``curl`` command::
+   You can install it, but it may be easier to use the pre-installed ``curl`` command:
+
+   .. code-block:: bash
 
       $ cd books
       $ curl -L https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download \

--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -62,11 +62,13 @@ root of your ``DataLad-101`` dataset:
    Heredocs rely on Unix-type redirection and multi-line commands -- which is not supported on most native Windows terminals or the Anaconda prompt on Windows.
    If you are using an Anaconda prompt or a Windows terminal other than Git Bash, instead of executing heredocs, please open up an editor and paste and save the text into it.
 
-   The relevant text in the snippet below would be::
+   The relevant text in the snippet below would be:
+
+   .. code-block:: text
 
       One can create a new dataset with 'datalad create [--description] PATH'.
       The dataset is created empty
-      
+
    If you are using Git Bash, however, here docs will work just fine.   
 
 .. runrecord:: _examples/DL-101-103-101

--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -115,14 +115,18 @@ chapters in this handbook will demonstrate how useful this information can be.
    important to keep in mind whenever you do not execute the :dlcmd:`clone` command
    from the root of this dataset. Luckily, there is a shortcut: ``-d^`` will always
    point to root of the top-most dataset. For example, if you navigate into ``recordings``,
-   the command would be::
+   the command would be:
+
+   .. code-block:: bash
 
      datalad clone -d^ https://github.com/datalad-datasets/longnow-podcasts.git longnow
 
 .. find-out-more:: What if I do not install into an existing dataset?
 
    If you do not install into an existing dataset, you only need to omit the ``-d/--dataset``
-   option. You can try::
+   option. You can try:
+
+   .. code-block:: bash
   
      datalad clone https://github.com/datalad-datasets/longnow-podcasts.git
 

--- a/docs/basics/101-106-nesting.rst
+++ b/docs/basics/101-106-nesting.rst
@@ -104,7 +104,9 @@ we can set subdatasets to previous states, or *update* them.
    a Git command let's you run the command as if Git was started in this path
    instead of the current working directory.
    Thus, from the root of ``DataLad-101``, this command would have given you the
-   subdataset's history as well::
+   subdataset's history as well:
+
+   .. code-block:: bash
 
       $ git -C recordings/longnow log --oneline
 

--- a/docs/basics/101-107-summary.rst
+++ b/docs/basics/101-107-summary.rst
@@ -6,7 +6,9 @@ and making simple modifications *locally*.
 
 * An empty dataset can be created with the :dlcmd:`create` command. It's useful to add a description
   to the dataset and use the ``-c text2git`` configuration, but we will see later why.
-  This is the command structure::
+  This is the command structure:
+
+  .. code-block:: bash
 
     datalad create --description "here is a description" -c text2git PATH
 
@@ -19,7 +21,9 @@ and making simple modifications *locally*.
   exist in your dataset, specify the path to the precise file (change) that should be saved to history.
   Remember, if you run a :dlcmd:`save` without
   specifying a path, all untracked files and all file changes will be committed to the history together!
-  This is the command structure::
+  This is the command structure:
+
+  .. code-block:: bash
 
     datalad save -m "here is a commit message" [PATH]
 
@@ -46,7 +50,9 @@ and experienced the concept of modular nesting datasets.
 
 .. index:: ! datalad command; clone
 
-* A published dataset can be installed with the :dlcmd:`clone` command::
+* A published dataset can be installed with the :dlcmd:`clone` command:
+
+  .. code-block:: bash
 
      $ datalad clone [--dataset PATH] SOURCE-PATH/URL [DESTINATION PATH]
 

--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -74,7 +74,9 @@ will write it into the script.
 .. windows-wit:: Here's a script for Windows users
 
    Please use an editor of your choice to create a file ``list_titles.sh`` inside of the ``code`` directory.
-   These should be the contents::
+   These should be the contents:
+
+   .. code-block:: bash
 
        for i in recordings/longnow/Long_Now__Seminars*/*.mp3; do
           # get the filename

--- a/docs/basics/101-109-rerun.rst
+++ b/docs/basics/101-109-rerun.rst
@@ -33,7 +33,9 @@ with the following, fixed script:
 
 .. windows-wit:: Here's a script adjustment for Windows users
 
-   Please use an editor of your choice to replace the contents of ``list_titles.sh`` inside of the ``code`` directory with the following::
+   Please use an editor of your choice to replace the contents of ``list_titles.sh`` inside of the ``code`` directory with the following:
+
+   .. code-block:: bash
 
        for i in recordings/longnow/Long_Now*/*.mp3; do
           # get the filename
@@ -175,7 +177,9 @@ of the dataset and the previous commit (called "``HEAD~1``" in Git terminology [
    When executing this command, you will see *all* files being modified between the most recent and the second-most recent commit.
    On a technical level, this is correct given the underlying file handling on Windows, and chapter :ref:`chapter_gitannex` will shed light on why that is.
 
-   For now, to get the same output as shown in the code snippet below, use the following command where ``main`` (or ``master``) is the name of your default branch::
+   For now, to get the same output as shown in the code snippet below, use the following command where ``main`` (or ``master``) is the name of your default branch:
+
+   .. code-block:: bash
 
       datalad diff --from main --to HEAD~1
 

--- a/docs/basics/101-113-summary.rst
+++ b/docs/basics/101-113-summary.rst
@@ -20,7 +20,9 @@ command, and discovered the concept of *locked* content.
 
 * With any :dlcmd:`run`, specify a commit message, and whenever appropriate, specify its inputs
   to the executed command (using the ``-i``/``--input`` flag) and/or its output (using the ``-o``/
-  ``--output`` flag). The full command structure is::
+  ``--output`` flag). The full command structure is:
+
+  .. code-block:: bash
 
      $ datalad run -m "commit message here" --input "path/to/input/" --output "path/to/output" "command"
 

--- a/docs/basics/101-116-sharelocal.rst
+++ b/docs/basics/101-116-sharelocal.rst
@@ -326,7 +326,9 @@ it only installed the subdataset to retrieve the meta data about file availabili
 
 To explicitly install all potential subdatasets *recursively*, that is,
 all of the subdatasets inside it as well, one can give the
-``-r``/``--recursive`` option to :dlcmd:`get`::
+``-r``/``--recursive`` option to :dlcmd:`get`:
+
+.. code-block:: bash
 
   datalad get -n -r <subds>
 
@@ -344,7 +346,9 @@ a few dozen levels of nested subdatasets right away.
 
 However, there is a middle way [#f1]_: The ``--recursion-limit`` option let's
 you specify how many levels of subdatasets should be installed together
-with the first subdataset::
+with the first subdataset:
+
+.. code-block:: bash
 
   datalad get -n -r --recursion-limit 1 <subds>
 

--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -226,7 +226,9 @@ the former for a different lecture:
 
 .. windows-wit:: Please use datalad diff --from main --to remotes/roommate/master
 
-   Please use the following command instead::
+   Please use the following command instead:
+
+   .. code-block:: bash
 
       datalad diff --from main --to remotes/roommate/master
 
@@ -246,7 +248,9 @@ that there is a difference in ``notes.txt``! Let's ask
 
 .. windows-wit:: Please use git diff master..remotes/roommate/master
 
-   Please use the following command instead::
+   Please use the following command instead:
+
+   .. code-block:: bash
 
      git diff master..remotes/roommate/master
 

--- a/docs/basics/101-122-config.rst
+++ b/docs/basics/101-122-config.rst
@@ -46,7 +46,9 @@ Git configuration." the lecturer says.
 
 At one point in time, you likely followed instructions such as
 in :ref:`install` and configured your
-*Git identity* with the commands::
+*Git identity* with the commands:
+
+.. code-block:: bash
 
    git config --global --add user.name "Elena Piscopia"
    git config --global --add user.email elena@example.net
@@ -175,7 +177,9 @@ configuration to your repository's ``.git/config`` file, whereas ``--global``
 would apply it as a user specific configuration, and ``--system`` as a
 system-wide configuration.
 If you would want to change this existing line in your ``.git/config``
-file, you would replace ``--add`` with ``--replace-all`` such as in::
+file, you would replace ``--add`` with ``--replace-all`` such as in:
+
+.. code-block:: bash
 
    git config --local --replace-all core.editor "vim"
 

--- a/docs/basics/101-123-config2.rst
+++ b/docs/basics/101-123-config2.rst
@@ -39,7 +39,9 @@ you will recognize it as a reference to the type of
 key used by git-annex to identify and store file content in the object-tree.
 The first row, ``* annex.backend=MD5E``, therefore translates to "Everything in this
 directory should be hashed with a MD5E hash function".
-But what is the rest? We'll start with the last row::
+But what is the rest? We'll start with the last row:
+
+.. code-block:: bash
 
    * annex.largefiles=((mimeencoding=binary)and(largerthan=0))
 
@@ -75,7 +77,9 @@ However, rules can be even simpler. The second row simply takes a complete direc
 The second row, ``**/.git* annex.largefiles=nothing`` means that no
 ``.git`` repository in this directory or a subdirectory should be considered
 a "large file". This way, the ``.git`` repositories are protected from being annexed.
-If you had a single file (``myfile.pdf``) you would not want annexed, specifying a rule such as::
+If you had a single file (``myfile.pdf``) you would not want annexed, specifying a rule such as:
+
+.. code-block:: bash
 
    myfile.pdf annex.largefiles=nothing
 
@@ -91,7 +95,9 @@ and view this dataset's ``.gitattributes`` file:
 The relevant part is ``README.md annex.largefiles=nothing``.
 This instructs git-annex to specifically not annex ``README.md``.
 
-Lastly, if you wanted to configure a rule based on **size**, you could add a row such as::
+Lastly, if you wanted to configure a rule based on **size**, you could add a row such as:
+
+.. code-block:: bash
 
    ** annex.largefiles(largerthan=20kb)
 
@@ -538,7 +544,9 @@ Write a note about configurations in datasets into ``notes.txt``.
          has MIME type ``text/plain`` as does a bash script (``.sh``), a Python
          script has MIME type ``text/x-python``, a ``.jpg`` file is ``image/jpg``, and
          a ``.pdf`` file has MIME type ``application/pdf``. You can find out the MIME type
-         of a file by running::
+         of a file by running:
+
+         .. code-block:: bash
 
             $ file --mime-type path/to/file
 
@@ -546,7 +554,9 @@ Write a note about configurations in datasets into ``notes.txt``.
          "portable" -- shared copies of your dataset will retain these configurations.
          You could however also set largefiles rules in your ``.git/config`` file. Rules
          specified in there take precedence over rules in ``.gitattributes``. You can set
-         them using the :gitcmd:`config` command::
+         them using the :gitcmd:`config` command:
+
+         .. code-block:: bash
 
             $ git config annex.largefiles 'largerthan=100kb and not (include=*.c or include=*.h)'
 

--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -120,7 +120,9 @@ Applying procedures
 but also *executes* procedures. If given the name of
 a procedure, this command will apply the procedure to
 the current dataset, or the dataset that is specified
-with the ``-d/--dataset`` flag::
+with the ``-d/--dataset`` flag:
+
+.. code-block:: bash
 
    datalad run-procedure [-d <PATH>] cfg_text2git
 
@@ -131,7 +133,9 @@ However, some procedures shipped with DataLad or its extensions with a
 with the ``-c/--cfg-proc <name>`` option in a :dlcmd:`create`
 command. This is a peculiarity of these procedures because, by convention,
 all of these procedures are written to not require arguments.
-The command structure looks like this::
+The command structure looks like this:
+
+.. code-block:: bash
 
    datalad create -c text2git DataLad-101
 
@@ -146,7 +150,9 @@ could thus be applied within a :dlcmd:`create` as
 .. find-out-more:: Applying multiple procedures
 
    If you want to apply several configurations at once, feel free to do so,
-   for example like this::
+   for example like this:
+
+   .. code-block:: bash
 
       $ datalad create -c yoda -c text2git
 
@@ -233,7 +239,9 @@ was applied.
                 dataset-procedures = relative/path/from/dataset-root
 
     - By default, DataLad will call a procedure with a standard template
-      defined by a format string::
+      defined by a format string:
+
+      .. code-block:: bash
 
          interpreter {script} {ds} {arguments}
 

--- a/docs/basics/101-125-summary.rst
+++ b/docs/basics/101-125-summary.rst
@@ -15,9 +15,11 @@ your horizon about configurations of datasets:
   therefore distributed. More specialized scopes take precedence over more global scopes.
 
 - Almost all configurations can be set with the :gitcmd:`config`.
-  Its structure looks like this::
+  Its structure looks like this:
 
-   git config --local/--global/--system --add/remove-all/--list section.[subsection.]variable "value"
+  .. code-block:: bash
+
+     git config --local/--global/--system --add/remove-all/--list section.[subsection.]variable "value"
 
 - The ``.git/config`` configuration file is not version controlled, other
   configuration files (``.gitmodules``, ``.gitattributes``, ``.datalad/config``)

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -25,7 +25,9 @@ a Python API for DataLad's functionality that you can read about in :ref:`a Find
     Thus, DataLad's functionality can also be used within interactive Python sessions
     or Python scripts.
     All of DataLad's user-oriented commands are exposed via ``datalad.api``.
-    Thus, any command can be imported as a stand-alone command like this::
+    Thus, any command can be imported as a stand-alone command like this:
+
+    .. code-block:: python
 
        >>> from datalad.api import <COMMAND>
 
@@ -42,11 +44,15 @@ a Python API for DataLad's functionality that you can read about in :ref:`a Find
     of DataLad lists an overview of all commands, but naming is congruent to the
     command line interface. The only functionality that is not available at the
     command line is ``datalad.api.Dataset``, DataLad's core Python data type.
-    Just like any other command, it can be imported like this::
+    Just like any other command, it can be imported like this:
+
+    .. code-block:: python
 
        >>> from datalad.api import Dataset
 
-    or like this::
+    or like this:
+
+    .. code-block:: python
 
        >>> import datalad.api as dl
        >>> dl.Dataset()
@@ -56,7 +62,9 @@ a Python API for DataLad's functionality that you can read about in :ref:`a Find
     stand-alone commands, all of DataLad's functionality is also available via
     `methods <https://docs.python.org/3/tutorial/classes.html#method-objects>`_
     of this class. Thus, these are two equally valid ways to create a new
-    dataset with DataLad in Python::
+    dataset with DataLad in Python:
+
+    .. code-block:: python
 
        >>> from datalad.api import create, Dataset
        # create as a stand-alone command
@@ -76,7 +84,9 @@ a Python API for DataLad's functionality that you can read about in :ref:`a Find
     ``-d/--dataset`` option in their command-line equivalent. You can specify
     the ``dataset=`` argument with a path (string) to your dataset (such as
     ``dataset='.'`` for the current directory, or ``dataset='path/to/ds'`` to
-    another location). Alternatively, you can pass a ``Dataset`` instance to it::
+    another location). Alternatively, you can pass a ``Dataset`` instance to it:
+
+    .. code-block:: python
 
         >>> from datalad.api import save, Dataset
         # use save with dataset specified as a path
@@ -418,7 +428,9 @@ point with the ``--version-tag`` option of :dlcmd:`save`.
    was added.
    Later we can use this tag to identify the point in time at which
    the analysis setup was ready -- much more intuitive than a 40-character shasum!
-   This is handy in the context of a :dlcmd:`rerun` for example::
+   This is handy in the context of a :dlcmd:`rerun` for example:
+
+   .. code-block:: bash
 
       $ datalad rerun --since ready4analysis
 
@@ -450,7 +462,9 @@ re-execution with :dlcmd:`rerun` easy.
 .. windows-wit:: You may need to use "python", not "python3"
 
    If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called solely ``python``.
-   Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole)::
+   Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole):
+
+   .. code-block:: bash
 
       datalad run -m "analyze iris data with classification analysis" ^
        --input "input/iris.csv" ^
@@ -735,11 +749,15 @@ an additional :gitcmd:`push`  with the ``--tags`` option is required:
     on a per-sibling basis in ``.git/config`` in the ``remote.*.push``
     configuration. If you had a :term:`sibling` "github", the following
     configuration would push all tags that start with a ``v`` upon a
-    :dlcmd:`push --to github`::
+    :dlcmd:`push --to github`:
+
+    .. code-block:: bash
 
        $ git config --local remote.github.push 'refs/tags/v*'
 
-    This configuration would result in the following entry in ``.git/config``::
+    This configuration would result in the following entry in ``.git/config``:
+
+    .. code-block:: bash
 
        [remote "github"]
              url = git@github.com/adswa/midtermproject.git
@@ -854,7 +872,9 @@ reproduce your data science project easily from scratch (take a look into the :r
 
 .. [#f1] Note that you could have applied the YODA procedure not only right at
          creation of the dataset with ``-c yoda``, but also after creation
-         with the :dlcmd:`run-procedure` command::
+         with the :dlcmd:`run-procedure` command:
+
+         .. code-block:: bash
 
            $ cd midterm_project
            $ datalad run-procedure cfg_yoda

--- a/docs/basics/101-132-advancednesting.rst
+++ b/docs/basics/101-132-advancednesting.rst
@@ -190,20 +190,26 @@ dataset, i.e., ``DataLad-101``, as the dataset to save to:
 
    If you want to save the current state of the subdataset into the superdataset
    (as necessary here), start a ``save`` from the superdataset and have the
-   ``-d/--dataset`` option point to its root::
+   ``-d/--dataset`` option point to its root:
+
+   .. code-block:: bash
 
       # in the root of the superds
       $ datalad save -d . -m "update subdataset"
 
    If you are in the superdataset, and you want to save an unsaved modification
    in a subdataset to the *subdatasets* history, let ``-d/--dataset`` point to
-   the subdataset::
+   the subdataset:
+
+   .. code-block:: bash
 
       # in the superds
       $ datalad save -d path/to/subds -m "modified XY"
 
    The recursive option allows you to save any content underneath the specified
-   directory, and recurse into any potential subdatasets::
+   directory, and recurse into any potential subdatasets:
+
+   .. code-block:: bash
 
       $ datalad save . --recursive
 

--- a/docs/basics/101-133-containersrun.rst
+++ b/docs/basics/101-133-containersrun.rst
@@ -170,7 +170,9 @@ name to give to the container, and a path or url to a container Image:
 .. find-out-more:: How do I add an Image from Dockerhub, Amazon ECR, or a local container?
 
    Should the Image you want to use lie on Dockerhub, specify the ``--url``
-   option prefixed with ``docker://`` or ``dhub://`` instead of ``shub://``::
+   option prefixed with ``docker://`` or ``dhub://`` instead of ``shub://``:
+
+   .. code-block:: bash
 
       datalad containers-add midterm-software --url docker://adswa/resources:2
 
@@ -181,7 +183,9 @@ name to give to the container, and a path or url to a container Image:
           datalad containers-add --url dhub://12345678.dkr.ecr.us-west-2.amazonaws.com/maze-code/data-import:latest data-import
 
    If you want to add a container that exists locally, specify the path to it
-   like this::
+   like this:
+
+   .. code-block:: bash
 
        datalad containers-add midterm-software --url path/to/container
 
@@ -217,7 +221,9 @@ container under its name "midterm-software" in the dataset's configuration at
    This can be useful to, for example, automatically bind-mount the current working directory in the container.
    In the alternative call format, the placeholders ``{img}``, ``{cmd}``, and ``{img_dspath}`` (a relative path to the dataset containing the image) are available.
    In all other cases with variables that use curly brackets, you need to escape them with another curly bracket.
-   Here is an example call format that bind-mounts the current working directory (and thus the dataset) automatically::
+   Here is an example call format that bind-mounts the current working directory (and thus the dataset) automatically:
+
+   .. code-block:: bash
 
       datalad containers-add --call-fmt 'singularity exec -B {{pwd}} --cleanenv {img} {cmd}'
 
@@ -256,7 +262,9 @@ dataset, we can execute commands in this environment. Let us for example try to 
 the :dlcmd:`run` command from the section :ref:`yoda_project` as a
 :dlcmd:`containers-run` command.
 
-The previous ``run`` command looked like this::
+The previous ``run`` command looked like this:
+
+.. code-block:: bash
 
    $ datalad run -m "analyze iris data with classification analysis" \
      --input "input/iris.csv" \
@@ -284,7 +292,9 @@ is ``container-name``. At this point, though, the ``--container-name``
 flag is even *optional* because there is only a single container registered to the dataset.
 But if your dataset contains more than one container you will *need* to specify
 the name of the container you want to use in your command.
-The complete command's structure looks like this::
+The complete command's structure looks like this:
+
+.. code-block:: bash
 
    $ datalad containers-run --name <containername> [-m ...] [--input ...] [--output ...] <COMMAND>
 

--- a/docs/basics/101-134-summary.rst
+++ b/docs/basics/101-134-summary.rst
@@ -12,9 +12,11 @@ The last two sections have first of all extended your knowledge on dataset nesti
 
 - Once the subdataset evolves, the superdataset recognizes this as a ``modification``
   of the subdatasets version state. If you want to record this, you need to
-  :dlcmd:`save` it in the superdataset::
+  :dlcmd:`save` it in the superdataset:
 
-   $ datalad save -m "a short summary of changes in subds" <path to subds>
+  .. code-block:: bash
+
+    $ datalad save -m "a short summary of changes in subds" <path to subds>
 
 But more than nesting concepts, they have also extended your knowledge on
 reproducible analyses with :dlcmd:`run` and you have experienced

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -186,11 +186,15 @@ To get extensive information on what :dlcmd:`status` does underneath the hood, y
 
    The log level can also be set (for different scopes) using the ``datalad.log.level`` configuration variable, or the corresponding environment variable ``DATALAD_LOG_LEVEL``.
 
-   To set the log level for a single command, for example, set it in front of the command::
+   To set the log level for a single command, for example, set it in front of the command:
+
+   .. code-block:: bash
 
        $ DATALAD_LOG_LEVEL=debug datalad status
 
-   And to set the log level for the rest of the shell session, export it::
+   And to set the log level for the rest of the shell session, export it:
+
+   .. code-block:: bash
 
        $ export DATALAD_LOG_LEVEL=debug
        $ datalad status
@@ -198,7 +202,9 @@ To get extensive information on what :dlcmd:`status` does underneath the hood, y
 
    You can find out a bit more on environment variable :ref:`in the Findoutmore on environment variables <fom-envvar>`.
 
-   The configuration variable can be used to set the log level on a user (global) or system-wide level with the :gitcmd:`config` command::
+   The configuration variable can be used to set the log level on a user (global) or system-wide level with the :gitcmd:`config` command:
+
+   .. code-block:: bash
 
       $ git config --global datalad.log.level debug
 
@@ -252,7 +258,9 @@ Output produced by Git
 **Unset Git identity**
 
 If you have not configured your Git identity, you will
-see warnings like this when running any DataLad command::
+see warnings like this when running any DataLad command:
+
+.. code-block:: bash
 
    [WARNING] It is highly recommended to configure git first (set both user.name and user.email) before using DataLad.
 
@@ -263,7 +271,9 @@ To set your Git identity, go back to section :ref:`installconfig`.
 
 One error you can run into when publishing dataset contents is that your
 :dlcmd:`push` to a sibling is rejected.
-One example is this::
+One example is this:
+
+.. code-block:: bash
 
    $ datalad push --to public
     [ERROR  ] refs/heads/main->public:refs/heads/main [rejected] (non-fast-forward) [publish(/home/me/dl-101/DataLad-101)]
@@ -276,7 +286,9 @@ know about. It can be fixed by updating from the sibling first with a
 
 .. _nonbarepush:
 
-Here is a different push rejection::
+Here is a different push rejection:
+
+.. code-block:: bash
 
    $ datalad push --to roommate
     publish(ok): . (dataset) [refs/heads/git-annex->roommate:refs/heads/git-annex 023a541..59a6f8d]
@@ -305,7 +317,9 @@ on ``receive.denyCurrentBranch`` for more.
 
 **Detached HEADs**
 
-One warning that you may encounter during an installation of a dataset is::
+One warning that you may encounter during an installation of a dataset is:
+
+.. code-block:: bash
 
     [INFO   ] Submodule HEAD got detached. Resetting branch main to point to 046713bb. Original location was 47e53498
 
@@ -320,7 +334,9 @@ Output produced by git-annex
 
 **Unusable annexes**
 
-Upon installation of a dataset, you may see::
+Upon installation of a dataset, you may see:
+
+.. code-block:: bash
 
    [INFO    ]     Remote origin not usable by git-annex; setting annex-ignore
    [INFO    ]     This could be a problem with the git-annex installation on the
@@ -334,7 +350,9 @@ many reasons, but as long as there are other remotes you can access the
 data from, you are fine.
 
 A similar warning message may appear when adding a sibling that is a pure Git
-:term:`remote`, for example a repository on GitHub::
+:term:`remote`, for example a repository on GitHub:
+
+.. code-block:: bash
 
    [INFO ] Failed to enable annex remote github, could be a pure git or not
    accessible
@@ -359,7 +377,9 @@ Other errors
 ^^^^^^^^^^^^
 
 Sometimes, registered subdatasets URLs have an :term:`SSH` instead of :term:`https` address, for example ``git@github.com:datalad-datasets/longnow-podcasts.git`` instead of ``https://github.com/datalad-datasets/longnow-podcasts.git``.
-If one does not have an SSH key configured for the required service (e.g., GitHub, or a server), installing or getting the subdataset and its contents fails, with messages starting similar to this::
+If one does not have an SSH key configured for the required service (e.g., GitHub, or a server), installing or getting the subdataset and its contents fails, with messages starting similar to this:
+
+.. code-block:: bash
 
    [INFO   ] Cloning https://github.com/psychoinformatics-de/paper-remodnav.git/remodnav [2 other candidates] into '/home/.../remodnav'
    Permission denied (publickey).

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -100,7 +100,9 @@ together with the file name change, you could give both the
 new and the deleted file as a path specification to
 :dlcmd:`save`, even if it feels unintuitive to
 save a change that is marked as a deletion in a
-:dlcmd:`status`::
+:dlcmd:`status`:
+
+.. code-block:: bash
 
    datalad save -m "rename file" oldname newname
 
@@ -784,7 +786,9 @@ section.
       # attempt a datalad update
       $ datalad update
 
-   Here we go::
+   Here we go:
+
+   .. code-block:: text
 
       'fatal: '../mock_user/DataLad-101' does not appear to be a git repository
        fatal: Could not read from remote repository.
@@ -1178,7 +1182,7 @@ If for whatever reason you at one point tried to remove a DataLad dataset,
 whether with a GUI or the command line call ``rm -rf <directory>``, you likely
 have seen permission denied errors such as
 
-.. code-block::
+.. code-block: bash
 
     rm: cannot remove '<directory>/.git/annex/objects/Mz/M1/MD5E-s422982--2977b5c6ea32de1f98689bc42613aac7.jpg/MD5E-s422982--2977b5c6ea32de1f98689bc42613aac7.jpg': Permission denied
     rm: cannot remove '<directory>/.git/annex/objects/FP/wv/MD5E-s543180--6209797211280fc0a95196b0f781311e.jpg/MD5E-s543180--6209797211280fc0a95196b0f781311e.jpg': Permission denied
@@ -1190,7 +1194,9 @@ stored in the object tree of git-annex. If you want, you can re-read the section
 :ref:`symlink` to find out how git-annex revokes write permission for the user
 to protect the file content given to it. To remove a dataset with annexed content
 one has to regain write permissions to everything in the dataset. This is done
-with the Unix ``chmod`` command::
+with the Unix ``chmod`` command:
+
+.. code-block:: bash
 
     chmod -R u+w <dataset>
 

--- a/docs/basics/101-137-history.rst
+++ b/docs/basics/101-137-history.rst
@@ -173,7 +173,9 @@ DataLad in the editor)!
    message". To apply this action and reword the top-most commit message in this list
    (``8503f26 Add note on adding siblings``, three commits back in the history),
    exchange the word ``pick`` in the beginning of the line with the word
-   ``reword`` or simply ``r`` like this::
+   ``reword`` or simply ``r`` like this:
+
+   .. code-block:: bash
 
       r 8503f26 Add note on adding siblings
 
@@ -214,7 +216,9 @@ This is a task for the :gitcmd:`reset` command. It essentially allows to
 undo commits by resetting the history of a dataset to an earlier version.
 :gitcmd:`reset` comes with several *modes* that determine the
 exact behavior it, but the relevant one for this aim is ``--mixed`` [#f3]_.
-Specifying the command::
+Specifying the command:
+
+.. code-block:: bash
 
    git reset --mixed COMMIT
 
@@ -487,7 +491,9 @@ prior :gitcmd:`checkout` (note that the output is shortened for brevity and show
 The cat-file command is very versatile, and
 `it's documentation <https://git-scm.com/docs/git-cat-file>`_ will list all
 of its functionality. To use it to see the contents of a file at a previous
-state as done above, this is how the general structure looks like::
+state as done above, this is how the general structure looks like:
+
+.. code-block:: bash
 
    $ git cat-file --textconv SHASUM:<path/to/file>
 
@@ -632,7 +638,9 @@ be reverted.
 
 .. find-out-more:: Reverting more than a single commit
 
-   You can also specify a range of commits like this::
+   You can also specify a range of commits like this:
+
+   .. code-block:: bash
 
       $ git revert OLDER_SHASUM..NEWERSHASUM
 

--- a/docs/basics/101-139-dropbox.rst
+++ b/docs/basics/101-139-dropbox.rst
@@ -32,7 +32,7 @@ from a large number of commercial providers [#f2]_.
   configuration of the dataset we want to publish). The interactive dialog is
   outlined below, and all parts that require user input are highlighted.
 
-.. code-block::
+.. code-block:: text
    :emphasize-lines: 7-8, 22, 26, 30, 36
 
    $ rclone config
@@ -80,7 +80,7 @@ from a large number of commercial providers [#f2]_.
   in the interactive prompt. Accepting will bring you back into the terminal
   to the final configuration prompts:
 
-.. code-block:: bash
+.. code-block:: text
    :emphasize-lines: 12, 26
 
    Got code
@@ -114,7 +114,9 @@ from a large number of commercial providers [#f2]_.
   It is a wrapper around rclone_ that makes any   destination supported by rclone usable with :term:`git-annex`.
   If you are on a recent version of Debian or Ubuntu (or have enabled the `NeuroDebian <https://neuro.debian.net>`_ repository), you can get it conveniently via your package manager, e.g., with ``sudo apt-get install git-annex-remote-rclone``.
   Alternatively, ``git clone`` the `git-annex-remote-rclone <https://github.com/git-annex-remote-rclone/git-annex-remote-rclone>`_ repository to your machine (do not clone it into ``DataLad-101`` but somewhere else on your computer), and copy the path to this repository into your ``$PATH`` variable. If you
-  clone into ``/home/user-bob/repos``, the command would look like this [#f3]_::
+  clone into ``/home/user-bob/repos``, the command would look like this [#f3]_:
+
+  .. code-block:: bash
 
      $ git clone https://github.com/DanielDent/git-annex-remote-rclone.git
      $ export PATH="/home/user-bob/repos/git-annex-remote-rclone:$PATH"
@@ -247,7 +249,9 @@ the annexed files (e.g., by sharing an access link), here is what they would
 have to do:
 
 If the repository is on GitHub, a :dlcmd:`clone` with the URL
-will install the dataset::
+will install the dataset:
+
+.. code-block:: bash
 
    $ datalad clone https://github.com/<user-name>/DataLad-101.git
    [INFO   ] Cloning https://github.com/<user-name>/DataLad-101.git [1 other candidates] into '/Users/awagner/Documents/DataLad-101'
@@ -256,7 +260,9 @@ will install the dataset::
    |         datalad siblings -d "/Users/awagner/Documents/DataLad-101" enable -s dropbox-for-friends
    install(ok): /Users/awagner/Documents/DataLad-101 (dataset)
 
-Pay attention to one crucial information in this output::
+Pay attention to one crucial information in this output:
+
+.. code-block:: bash
 
    [INFO   ] access to 1 dataset sibling dropbox-for-friends not auto-enabled, enable with:
    |         datalad siblings -d "/Users/<user-name>/Documents/DataLad-101" enable -s dropbox-for-friends
@@ -276,14 +282,18 @@ the same as before:
 - install git-annex-remote-rclone_ (as described above).
 
 After this is done, you can execute what DataLad's output message suggests
-to "enable" this special remote (inside of the installed ``DataLad-101``)::
+to "enable" this special remote (inside of the installed ``DataLad-101``):
+
+.. code-block:: bash
 
    $ datalad siblings -d "/Users/awagner/Documents/DataLad-101" \
      enable -s dropbox-for-friends
    .: dropbox-for-friends(?) [git]
 
 And once this is done, you can get any annexed file contents, for example the
-books, or the cropped logos from chapter :ref:`chapter_run`::
+books, or the cropped logos from chapter :ref:`chapter_run`:
+
+.. code-block:: bash
 
    $ datalad get books/TLCL.pdf
    get(ok): /home/some/other/user/DataLad-101/books/TLCL.pdf (file) [from dropbox-for-friends]

--- a/docs/basics/101-139-gin.rst
+++ b/docs/basics/101-139-gin.rst
@@ -62,7 +62,9 @@ Afterwards, add this repository as a sibling of your dataset. To do this, use th
 :dlcmd:`siblings add` command and the SSH URL of the repository as shown below.
 Note that since this is the first time you will be connecting to the GIN server
 via SSH, you will likely be asked to confirm to connect. This is a safety measure,
-and you can type "yes" to continue::
+and you can type "yes" to continue:
+
+.. code-block:: text
 
     $ datalad siblings add -d . \
       --name gin \
@@ -258,7 +260,9 @@ Then, follow these steps:
 - First, create a new repository on Gin (see step by step instructions above).
 - In your to-be-published dataset, add this repository as a sibling, this time setting `--url` and `--pushurl` arguments explicitly. Make sure to configure a :term:`SSH` URL as a ``--pushurl`` but a :term:`HTTPS` URL as a ``url``.
   Please also note that the :term:`HTTPS` URL written after ``--url`` DOES NOT have the ``.git`` suffix.
-  Here is the command::
+  Here is the command:
+
+.. code-block:: bash
 
      $ datalad siblings add \
       -d . \
@@ -268,7 +272,9 @@ Then, follow these steps:
 
 - Locally, run ``git config --unset-all remote.gin.annex-ignore`` to prevent :term:`git-annex` from ignoring this new dataset
 - Push your data to the repository on Gin (``datalad push --to gin``). This pushes the actual state of the repository, including content, but also adjusts the :term:`git-annex` configuration.
-- Configure this sibling as a "common data source". Use the same name as previously in ``--name`` (to indicate which sibling you are configuring) and give a new, different, name after ``--as-common-datasrc``::
+- Configure this sibling as a "common data source". Use the same name as previously in ``--name`` (to indicate which sibling you are configuring) and give a new, different, name after ``--as-common-datasrc``:
+
+.. code-block:: bash
 
    $ datalad siblings configure \
       --name gin \
@@ -292,7 +298,9 @@ Afterwards, :dlcmd:`get` retrieves files from Gin, even if the dataset has been 
          and `client <https://gin.g-node.org/G-Node/Info/wiki/GinUsageTutorial>`_ are
          useful tools with a variety of features that are worthwhile to check out, as well.
 
-.. [#f3] Alternatively, you can configure the siblings url with :gitcmd:`config`::
+.. [#f3] Alternatively, you can configure the siblings url with :gitcmd:`config`:
+
+         .. code-block:: bash
 
            $ git config -f .gitmodules --replace-all  submodule.midterm_project.url https://github.com/adswa/midtermproject
 

--- a/docs/basics/101-139-gitlfs.rst
+++ b/docs/basics/101-139-gitlfs.rst
@@ -9,36 +9,48 @@ A free GitHub subscription allows up to `1GB of free storage and up to 1GB of ba
 As such, it might be sufficient for some use cases, and could be configured
 quite easily.
 
-In order to store annexed dataset contents on GitHub, we need first to create a repository on GitHub::
+In order to store annexed dataset contents on GitHub, we need first to create a repository on GitHub:
+
+.. code-block:: bash
 
     $ datalad create-sibling-github test-github-lfs --access-protocol ssh
     .: github(-) [git@github.com:yarikoptic/test-github-lfs.git (git)]
     'git@github.com:yarikoptic/test-github-lfs.git' configured as sibling 'github' for <Dataset path=/tmp/test-github-lfs>
 
-and then initialize a :term:`special remote` of type ``git-lfs``, pointing to the same GitHub repository::
+and then initialize a :term:`special remote` of type ``git-lfs``, pointing to the same GitHub repository:
+
+.. code-block:: bash
 
     $ git annex initremote github-lfs type=git-lfs url=git@github.com:yarikoptic/test-github-lfs autoenable=true encryption=none embedcreds=no
 
 If you would like to compress data in Git LFS, you need to take a detour via
 encryption during :gitannexcmd:`initremote` -- this has compression as a
-convenient side effect. Here is an example initialization::
+convenient side effect. Here is an example initialization:
+
+.. code-block:: bash
 
    $ git annex initremote --force github-lfs type=git-lfs url=git@github.com:yarikoptic/test-github-lfs autoenable=true encryption=shared
 
-With this single step it becomes possible to transfer contents to GitHub::
+With this single step it becomes possible to transfer contents to GitHub:
+
+.. code-block:: bash
 
     $ git annex copy --to=github-lfs file.dat
     copy file.dat (to github-lfs...)
     ok
     (recording state in git...)
 
-and the entire dataset to the same GitHub repository::
+and the entire dataset to the same GitHub repository:
+
+.. code-block:: bash
 
     $ datalad push --to=github
     [INFO   ] Publishing <Dataset path=/tmp/test-github-lfs> to github
     publish(ok): . (dataset) [pushed to github: ['[new branch]', '[new branch]']]
 
-Alternatively, to make publication even easier for you, the dataset provider, you can establish a :term:`publication dependency` such that a :dlcmd:`push` performs the data transfer to ``git-lfs`` automatically::
+Alternatively, to make publication even easier for you, the dataset provider, you can establish a :term:`publication dependency` such that a :dlcmd:`push` performs the data transfer to ``git-lfs`` automatically:
+
+.. code-block:: bash
 
    $ datalad siblings configure -s github --publish-depends github-lfs
    # afterwards, only datalad push is needed to publish dataset contents and history

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -158,7 +158,9 @@ Often, you can specifically select which set of permissions a specific token has
 
 For creating and updating repositories with DataLad commands it is usually sufficient to grant only repository-related permissions.
 However, broader permission sets may also make sense.
-Should you employ GitHub workflows, for example, a token without "workflow" scope could not push changes to workflow files, resulting in errors like this one::
+Should you employ GitHub workflows, for example, a token without "workflow" scope could not push changes to workflow files, resulting in errors like this one:
+
+.. code-block:: bash
 
     [remote rejected] (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/benchmarks.yml` without `workflow` scope)]
 
@@ -227,7 +229,9 @@ Due to the distinction between groups and projects, GitLab allows two different 
 * **collection**:
   A new group is created for the dataset. The root dataset (the topmost superdataset) is placed in a "project" project inside this group, and all nested subdatasets are represented inside the group using a "flat" layout [#f4]_. This layout is the default.
 
-Consider the ``DataLad-101`` dataset, a superdataset with a several subdatasets in the following layout::
+Consider the ``DataLad-101`` dataset, a superdataset with a several subdatasets in the following layout:
+
+.. code-block:: bash
 
     /home/me/dl-101/DataLad-101    # dataset
     ├── books/
@@ -287,7 +291,7 @@ Publishing datasets recursively
 When publishing a series of datasets recursively, the ``--project`` argument can not be used anymore - otherwise, all datasets in the hierarchy would attempt to create the same group or project over and over again.
 Instead, one configures the root level dataset, and the names for underlying datasets will be derived from this configuration:
 
-.. code-block::
+.. code-block:: bash
 
    # do the configuration for the top-most dataset
    # either configure with Git

--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -32,7 +32,9 @@ or storage of datasets [#f1]_, or a regular clone.
    .. index:: ! datalad command; create-sibling-ria
 
    - Add an existing repository as a sibling with the :dlcmd:`siblings`
-     command. Here are common examples::
+     command. Here are common examples:
+
+     .. code-block:: bash
 
         # to a remote repository
         $ datalad siblings add --name github-repo --url <url.to.github>
@@ -55,7 +57,9 @@ or storage of datasets [#f1]_, or a regular clone.
 
 In order to publish dataset content, DataLad needs to know to which sibling
 content shall be pushed. This can be specified with the ``--to`` option directly
-from the command line::
+from the command line:
+
+.. code-block:: bash
 
    $ datalad push --to <sibling>
 
@@ -142,7 +146,9 @@ targets are configured throughout the dataset hierarchy.
    update to the public dataset is pushed, apart from pushing only the ``master``
    branch, all branches starting with the section identifier ``sct`` are pushed
    automatically as well. This configuration was achieved by specifying these branches
-   (using :term:`globbing` with ``*``) in the ``push`` specification of this :term:`remote`::
+   (using :term:`globbing` with ``*``) in the ``push`` specification of this :term:`remote`:
+
+   .. code-block:: bash
 
       $ git config --local remote.public.push 'refs/heads/sct*'
 

--- a/docs/basics/101-146-gists.rst
+++ b/docs/basics/101-146-gists.rst
@@ -79,7 +79,9 @@ Alternatively, to get very comprehensive output, you can use
 
 The output will be returned as json, and the key ``has_content`` indicates local
 content availability (``true`` or ``false``). To filter through it, the command
-line tool `jq <https://stedolan.github.io/jq>`_ works well::
+line tool `jq <https://stedolan.github.io/jq>`_ works well:
+
+.. code-block:: bash
 
    $ datalad -f json status --recursive --annex all | jq '. | select(.has_content == true).path'
 
@@ -150,7 +152,9 @@ Datasets can be either GitRepos (i.e., sole Git repositories; this happens when
 they are created with the ``--no-annex`` flag, for example), or AnnexRepos
 (i.e., datasets that contain an annex). Information on what kind of repository it
 is is stored in the dataset report of :dlcmd:`wtf` under the key ``repo``.
-Here is a one-liner to get this info::
+Here is a one-liner to get this info:
+
+.. code-block:: bash
 
    $ datalad -f'{infos[dataset][repo]}' wtf
 
@@ -180,7 +184,9 @@ A sketch of how to implement a sibling for backups is below:
 In order to push not only the current branch, but refs, add the option
 ``--publish-by-default "refs/*"`` to the :dlcmd:`create-sibling` call.
 Should you want to back up all annexed data, even past versions of files, use
-:gitannexcmd:`sync` to push to the sibling::
+:gitannexcmd:`sync` to push to the sibling:
+
+.. code-block:: bash
 
    $ git annex sync --all --content <sibling-name>
 
@@ -201,7 +207,9 @@ Example: consider retrieving all ``ribbon.nii.gz`` files for all subjects in the
 :ref:`usecase_HCP_dataset`).
 If all subject-subdatasets are installed (e.g., with ``datalad get -n -r`` for
 a recursive installation without file retrieval), :term:`globbing` with the
-shell works fine::
+shell works fine:
+
+.. code-block:: bash
 
    $ datalad get HCP1200/*/T1W/ribbon.nii.gz
 
@@ -209,13 +217,17 @@ The Gist :ref:`parallelize` can show you how to parallelize this.
 If the subdatasets are not yet installed, globbing will not work, because the
 shell can't expand non-existent paths. As an alternative, you can pipe the output
 of an (arbitrarily complex) :dlcmd:`search` command into
-:dlcmd:`get`::
+:dlcmd:`get`:
+
+.. code-block:: bash
 
    $ datalad -f '{path}' -c datalad.search.index-egrep-documenttype=all search 'path:.*T1w.*\.nii.gz' | xargs -n 100 datalad get
 
 However, if you know the file locations within the dataset hierarchy and they
 are predictably named and consistent, you can create a file containing all paths to
-be retrieved and pipe that into :dlcmd:`get` as well::
+be retrieved and pipe that into :dlcmd:`get` as well:
+
+.. code-block:: bash
 
    # create file with all file paths
    $ for sub in HCP1200/*; do echo ${sub}/T1w/ribbons.nii.gz; done > toget.txt

--- a/docs/basics/101-180-FAQ.rst
+++ b/docs/basics/101-180-FAQ.rst
@@ -142,7 +142,9 @@ How can I convert/import/transform an existing Git or git-annex repository into 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can transform any existing Git or git-annex repository of yours into a
-DataLad dataset by running::
+DataLad dataset by running:
+
+.. code-block:: bash
 
    $ datalad create -f
 
@@ -198,7 +200,9 @@ If you do not want to copy-and-paste these snippets yourself, you can run
         Get the dataset
         ^^^^^^^^^^^^^^^
 
-        A DataLad dataset can be ``cloned`` by running::
+        A DataLad dataset can be ``cloned`` by running:
+
+        .. code-block:: bash
 
            datalad clone <url>
 
@@ -210,7 +214,9 @@ If you do not want to copy-and-paste these snippets yourself, you can run
         Retrieve dataset content
         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-        After cloning a dataset, you can retrieve file contents by running::
+        After cloning a dataset, you can retrieve file contents by running:
+
+        .. code-block:: bash
 
            datalad get <path/to/directory/or/file>
 
@@ -220,7 +226,9 @@ If you do not want to copy-and-paste these snippets yourself, you can run
         DataLad datasets can contain other datasets, so called *subdatasets*. If you
         clone the top-level dataset, subdatasets do not yet contain metadata and
         information on the identity of files, but appear to be empty directories. In
-        order to retrieve file availability metadata in subdatasets, run::
+        order to retrieve file availability metadata in subdatasets, run:
+
+        .. code-block:: bash
 
            datalad get -n <path/to/subdataset>
 
@@ -234,7 +242,9 @@ If you do not want to copy-and-paste these snippets yourself, you can run
 
         DataLad datasets can be updated. The command ``datalad update`` will *fetch*
         updates and store them on a different branch (by default
-        ``remotes/origin/master``). Running::
+        ``remotes/origin/master``). Running:
+
+        .. code-block:: bash
 
            datalad update --merge
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -26,7 +26,9 @@ systems. They do not cover the various :term:`DataLad extension`'s that need to 
 
    DataLad requires Python 3.6, or a more recent version, to be installed on
    your system. The easiest way to verify that this is the case is to open a
-   terminal and type :shcmd:`python` to start a Python session::
+   terminal and type :shcmd:`python` to start a Python session:
+
+   .. code-block:: bash
 
      $ python
      Python 3.9.1+ (default, Jan 20 2021, 14:49:22)
@@ -194,7 +196,9 @@ First, install the homebrew package manager, which requires `Xcode
 <https://apps.apple.com/us/app/xcode/id497799835>`_ to be installed from the
 Mac App Store.
 
-Next, install datalad and its dependencies::
+Next, install datalad and its dependencies:
+
+.. code-block:: bash
 
    $ brew install datalad
 
@@ -208,7 +212,9 @@ Python's package manager <fom-macosx-pip>`.
 
    If Git/git-annex are installed already (via brew), DataLad can also be
    installed via Python's package manager ``pip``, which should be installed
-   by default on your system::
+   by default on your system:
+
+   .. code-block:: bash
 
      $ pip install datalad
 
@@ -216,7 +222,9 @@ Python's package manager <fom-macosx-pip>`.
    completion` to find out which is installed.
 
    Recent macOS versions may warn after installation that scripts were installed
-   into locations that were not on ``PATH``::
+   into locations that were not on ``PATH``:
+
+   .. code-block:: text
 
      The script chardetect is installed in
      '/Users/MYUSERNAME/Library/Python/3.7/bin' which is not on PATH.
@@ -400,7 +408,9 @@ a user's home directory:
 
    $ pip install --user datalad
 
-On some systems, in particular macOS, you may need to call ``pip3`` instead of ``pip``::
+On some systems, in particular macOS, you may need to call ``pip3`` instead of ``pip``:
+
+.. code-block:: bash
 
    $ pip3 install datalad
    # or, in case of a "permission denied error":

--- a/docs/usecases/encrypted_annex.rst
+++ b/docs/usecases/encrypted_annex.rst
@@ -89,7 +89,7 @@ Remote server: encrypted deposition
 On the remote server, we start by creating a DataLad dataset to track the deposition of raw data.
 Since encryption is enabled for git-annex :term:`special remote`\s (thus only applies to annexed files), we stay with the default dataset configuration, which annexes all files.
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad create incoming_data
    $ cd incoming data
@@ -104,7 +104,7 @@ Then, we create a local :term:`Remote Indexed Archive (RIA) store` as a :term:`s
 The created sibling is called ``entrystore`` in the example below, but by default, a RIA sibling consists of two parts, with ``entrystore`` being only one of them.
 The other, which by default uses the sibling name with a ``-storage`` suffix ("``entrystore-storage``"), is an automatically created :term:`special remote` to store annexed files in.
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad create-sibling-ria \
      --new-store-ok --name entrystore \
@@ -116,7 +116,7 @@ We choose regular public key encryption with shared filename encryption (``share
 In this method, access to *public* keys is required to store files in the remote, but a *private* key is required for retrieval.
 So if we only store our public key on the machine, an intruder will have no means to decrypt the data even if they gain access to the server.
 
-.. code:: bash
+.. code-block:: bash
 
    $ git annex enableremote \
       entrystore-storage \
@@ -130,7 +130,7 @@ with ``keyid+=...``.
 
 With this setup, whenever a new data file is uploaded into the dataset on the server, this file needs to be saved, pushed to encrypted storage, and finally, the unencrypted file needs to be dropped:
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad save -m "Adding new file" entry-file-name.dat
    $ datalad push --to entrystore entry-file-name.dat
@@ -148,20 +148,20 @@ Local machine: Decryption
 
 In order to retrieve the encrypted data securely from the remote server and perform processing on unencrypted data, we start once again by creating a DataLad dataset:
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad create derived_data
    $ cd derived_data
 
 We then install the dataset from the RIA store on the remote server as a subdataset with input data using :dlcmd:`clone` and an :term:`SSH` URL to the dataset in the RIA store.
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad clone -d . ria+ssh://... inputs
 
 Next, we can retrieve all data:
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad get inputs
 
@@ -184,7 +184,7 @@ without having to re-encrypt data.
 File content and names are encrypted with a symmetric cipher, which is itself encrypted using GPG and stored encrypted in the git repository.
 See `git-annex's documentation <https://git-annex.branchable.com/encryption>`__ for more details.
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad create-sibling-ria \
        --new-store-ok --name localstore \
@@ -197,7 +197,7 @@ See `git-annex's documentation <https://git-annex.branchable.com/encryption>`__ 
 
 We repeat the same for the input subdataset, so that we can maintain a local copy of the raw data.
 
-.. code:: bash
+.. code-block:: bash
 
    $ cd input
    $ datalad create-sibling-ria \
@@ -214,14 +214,14 @@ Here, we will use the second option.
 For this reason, we need to declare the current clones "dead" to git-annex before pushing, so that subsequent clones from the RIA store won't consider this location for obtaining files.
 Since we gave the super- and subdataset's siblings the same name, "``localstore``", we can use ``push --recursive``.
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad foreach-dataset git annex dead here
    $ datalad push --recursive --to localstore
 
 And in the end we can clean up by removing the temporary clone:
 
-.. code:: bash
+.. code-block:: bash
 
    $ cd ..
    $ datalad drop --recursive --what all --dataset derived_data
@@ -248,7 +248,7 @@ copy / derived dataset, we would start by cloning the derived dataset
 from the local RIA, and getting the input subdataset (without getting
 contents yet):
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad clone \
       ria+file:///data/project/entrystore#~derived \
@@ -260,7 +260,7 @@ Our next step would be to obtain files from the remote server that we
 don't yet have locally. At this moment it is a good idea to stop and
 consider what the input dataset "knows" about other locations:
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad siblings -d inputs
    .: here(+) [git]
@@ -282,7 +282,7 @@ Let's add it then (note that when working with ``datalad
 siblings`` or ``git remote`` commands, we cannot use the
 ``ria+ssh://...#~alias`` URL, and need to use the actual SSH URL and filesystem path).
 
-.. code:: bash
+.. code-block:: bash
 
    $ cd inputs
    $ git remote add entrystore \
@@ -291,7 +291,7 @@ siblings`` or ``git remote`` commands, we cannot use the
 Now we can obtain updates from the entrystore sibling (pair). We may
 choose to fetch only, to see what is new before merging:
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad update --sibling entrystore --how fetch
    $ datalad diff --from main --to entrystore/main
@@ -301,7 +301,7 @@ right there. Since there are new files, we will integrate the changes
 (since we didn't change the input dataset locally, there is no practical
 difference in using ``ff-only`` versus ``merge``).
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad update --sibling entrystore --how merge
 
@@ -310,7 +310,7 @@ difference in using ``ff-only`` versus ``merge``).
    The results of the ``diff`` command include files that were not changed, so to look for changes we need to filter them by state;
    e.g. if we only expect additions, we can do this:
 
-	.. code:: python
+	.. code-block:: python
 
 		 added_files = subds.diff(
 		   fr='main',
@@ -320,7 +320,7 @@ difference in using ``ff-only`` versus ``merge``).
 
 Now that we have the latest version of the subdataset, we can repeat the update procedure (note that this time we push to ``origin``)
 
-.. code:: bash
+.. code-block:: bash
 
    $ datalad save -m "Updated subdataset"
    $ datalad run ...


### PR DESCRIPTION
Use `.. code-block:: <language>` consistently, not `::`

Closes #1011