### PR TITLE
Turn the "eternal" handbook date into symbols

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,9 @@ autorunrecord_basedir = '/home/me'
 autorunrecord_line_replace = [
     # trailing space removal
     (r'[ ]+$', ''),
+    # turn our "eternal" date time into symbols
+    (r'Tue Jun 18 16:13:00 2019 +0000', '🗓🕓'),
+    (r'2019-06-18 16:13', '🗓🕓'),
     # strip the keydir for MD5(E) or SHA1(E) annex keys
     # the keydir is identical to the annex key name, but consumes
     # a lot of space. we replace it with a UTF scissors icon

--- a/docs/latex/fontpkg.sty
+++ b/docs/latex/fontpkg.sty
@@ -4,6 +4,8 @@
 \usepackage{microtype}
 
 % provide definition for Unicode character ✂ (U+2702) we use for truncation
-\usepackage{marvosym}
+\usepackage{fontawesome}
 \usepackage{newunicodechar}
-\newunicodechar{✂}{\Rightscissors}
+\newunicodechar{✂}{\faScissors}
+\newunicodechar{🗓}{\faCalendar}
+\newunicodechar{🕓}{\faClockO}


### PR DESCRIPTION
We fix the committer date in the handbook for reasons of reproducibility (no random shasum changes, simply because we execute code at a different time). Hence the dates/times shown do not really make sense (they appear constant, even across multiple steps of a procedure. This appears odd.

This changeset replace the timestamps with symbolic placeholders.

Their meaning still needs to be described in the intro.

Ping #1009