### PR TITLE
Add a dedicated section on copyright and licenses

### DIFF
--- a/docs/book_appendix.rst
+++ b/docs/book_appendix.rst
@@ -13,6 +13,7 @@ Appendix
    contributing
    teaching
    acknowledgements
+   licenses
 
 .. raw:: latex
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,7 @@ Appendix
    contributing
    teaching
    acknowledgements
+   licenses
    intro/user_types
    OHBMposter
    usecases/openneuro

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -1,0 +1,51 @@
+.. index:: copyright, licenses
+
+Copyright and licenses
+----------------------
+
+This handbook is made available under the terms of the `Creative Commons Attribution-ShareAlike 4.0 International Public License (CC-BY-SA)`_.
+The copyright holders for the book content are the respective individual contributors of particular content, as recorded in the version history of the handbook's Git repository.
+
+This book may contain copyrighted and/or trademarked materials, the use of which may not have been specifically authorized by the respective owner.
+These are included for educational purposes in an effort to explain issues relevant to decentralized data management and other topics covered in this book.
+We believe that this constitutes a "fair use" of the materials as provided for in section 107 of the US Copyright Law.
+Use of these materials that go beyond "fair use" may require permissions to be obtained from the respective owner.
+These copyright/trademark holders are not affiliated with the authors or any of the authors’ representatives.
+They do not sponsor or endorse the contents, materials, or processes discussed within this book.
+
+The remainder of this sections amends the general copyright and license declaration of the book with additional information on used 3rd-party materials.
+
+.. the following content descriptions shall also work in an offline/paper
+   context, hence need to use references to book structures rather then
+   deep-links to some file content
+
+unDraw illustrations
+~~~~~~~~~~~~~~~~~~~~
+
+The handbook includes numerous illustrations obtained from Katerina Limpitsouni's https://undraw.co project, covered by the following terms:
+
+   Copyright 2023 Katerina Limpitsouni
+
+   All images, assets and vectors published on unDraw can be used for free.
+   You can use them for noncommercial and commercial purposes.
+   You do not need to ask permission from or provide credit to the creator or unDraw.
+
+   More precisely, unDraw grants you an nonexclusive, worldwide copyright license to download, copy, modify, distribute, perform, and use the assets provided from unDraw for free, including for commercial purposes, without permission from or attributing the creator or unDraw.
+   This license does not include the right to compile assets, vectors or images from unDraw to replicate a similar or competing service, in any form or distribute the assets in packs or otherwise.
+   This extends to automated and non-automated ways to link, embed, scrape, search or download the assets included on the website without our consent.
+
+   Regarding brand logos that are included:
+
+   Are registered trademarks of their respected owners.
+   Are included on a promotional basis and do not represent an association with unDraw or its users.
+   Do not indicate any kind of endorsement of the trademark holder towards unDraw, nor vice versa.
+   Are provided with the sole purpose to represent the actual brand/service/company that has registered the trademark and must not be used otherwise.
+
+
+YODA illustration
+~~~~~~~~~~~~~~~~~
+
+The "YODA" cartoon used in chapter :ref:`chapter_yoda` is derived from https://openclipart.org/detail/227445/yoda, which was made available under `CC0`_ terms.
+
+.. _Creative Commons Attribution-ShareAlike 4.0 International Public License (CC-BY-SA): https://creativecommons.org/licenses/by-sa/4.0
+.. _CC0: http://creativecommons.org/publicdomain/zero/1.0


### PR DESCRIPTION
All other information is only available in the sources. Including them in the book itself has the advantage that appropriate term declarations are also available in each (offline) PDF.

The content in the PR may not be complete. I only went through the content that is included in the print version, and focused on graphics. However, the text is phrased in a way that should not imply a comprehensive assessment.