### PR TITLE
Stop excessive colonization

### DIFF
--- a/docs/basics/101-141-push.rst
+++ b/docs/basics/101-141-push.rst
@@ -1,7 +1,7 @@
 .. _push:
 
-Overview: The datalad push command
-----------------------------------
+The datalad push command
+------------------------
 
 Previous sections on publishing DataLad datasets  have each
 shown you crucial aspects of the functions of dataset publishing with


### PR DESCRIPTION
I think the heading works just as fine without the prefix. Shorter is better.