### PR TITLE
Remove index entries for chapters

### DIFF
--- a/docs/basics/basics-annex.rst
+++ b/docs/basics/basics-annex.rst
@@ -3,8 +3,6 @@
 Under the hood: git-annex
 -------------------------
 
-.. index:: ! Chapter; 3. git-annex
-
 .. figure:: ../artwork/src/security.svg
    :width: 50%
 

--- a/docs/basics/basics-collaboration.rst
+++ b/docs/basics/basics-collaboration.rst
@@ -3,8 +3,6 @@
 Collaboration
 -------------
 
-.. index:: ! Chapter; 4. Collaboration
-
 .. figure:: ../artwork/src/collaboration_sketch.svg
    :width: 50%
 

--- a/docs/basics/basics-configuration.rst
+++ b/docs/basics/basics-configuration.rst
@@ -4,8 +4,6 @@
 Tuning datasets to your needs
 -----------------------------
 
-.. index:: ! Chapter; 5. Configuration
-
 .. figure:: ../artwork/src/settings.svg
    :width: 50%
 

--- a/docs/basics/basics-containers.rst
+++ b/docs/basics/basics-containers.rst
@@ -3,8 +3,6 @@
 One step further
 ----------------
 
-.. index:: ! Chapter; 7. Software container
-
 .. figure:: ../artwork/src/forward.svg
    :width: 50%
 

--- a/docs/basics/basics-datasets.rst
+++ b/docs/basics/basics-datasets.rst
@@ -3,8 +3,6 @@
 DataLad datasets
 ----------------
 
-.. index:: ! Chapter; 1. DataLad datasets
-
 .. figure:: ../artwork/src/datasets.svg
    :width: 50%
 

--- a/docs/basics/basics-help.rst
+++ b/docs/basics/basics-help.rst
@@ -3,8 +3,6 @@
 Help yourself
 -------------
 
-.. index:: ! Chapter; 9. Help yourself
-
 .. figure:: ../artwork/src/help.svg
    :width: 50%
 

--- a/docs/basics/basics-run.rst
+++ b/docs/basics/basics-run.rst
@@ -4,8 +4,6 @@
 DataLad, run!
 -------------
 
-.. index:: ! Chapter; 2. DataLad Run
-
 .. figure:: ../artwork/src/keeptrack.svg
    :width: 50%
 

--- a/docs/basics/basics-thirdparty.rst
+++ b/docs/basics/basics-thirdparty.rst
@@ -3,8 +3,6 @@
 Third party infrastructure
 --------------------------
 
-.. index:: ! Chapter; 8. Third party infrastructure
-
 .. figure:: ../artwork/src/clouds.svg
    :width: 50%
 

--- a/docs/basics/basics-yoda.rst
+++ b/docs/basics/basics-yoda.rst
@@ -3,8 +3,6 @@
 Make the most out of datasets
 -----------------------------
 
-.. index:: ! Chapter; 6. Data analysis (YODA)
-
 .. figure:: ../artwork/src/img/yoda.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-advancedoptions.rst
+++ b/docs/beyond_basics/basics-advancedoptions.rst
@@ -3,8 +3,6 @@
 Advanced options
 ----------------
 
-.. index:: ! Chapter; 10. Advanced Options
-
 .. figure:: ../artwork/src/further.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-dataladinternals.rst
+++ b/docs/beyond_basics/basics-dataladinternals.rst
@@ -3,8 +3,6 @@
 DataLad internals
 -----------------
 
-.. index:: ! Chapter; 15. DataLad internals
-
 .. figure:: ../artwork/src/programmer.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-extensions.rst
+++ b/docs/beyond_basics/basics-extensions.rst
@@ -3,9 +3,6 @@
 DataLad Extensions
 ------------------
 
-
-.. index:: ! Chapter; 16. DataLad extensions
-
 .. figure:: ../artwork/src/universe.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-hpc.rst
+++ b/docs/beyond_basics/basics-hpc.rst
@@ -3,8 +3,6 @@
 Computing on clusters
 ---------------------
 
-.. index:: ! Chapter; 12. Computing on clusters
-
 .. figure:: ../artwork/src/cluster.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-retrospective.rst
+++ b/docs/beyond_basics/basics-retrospective.rst
@@ -3,8 +3,6 @@
 Better late than never
 ----------------------
 
-.. index:: ! Chapter; 13. Better late than never
-
 .. figure:: ../artwork/src/late.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-scaling.rst
+++ b/docs/beyond_basics/basics-scaling.rst
@@ -3,8 +3,6 @@
 Go big or go home
 -----------------
 
-.. index:: ! Chapter; 11. Go big or go home
-
 .. figure:: ../artwork/src/gobig.svg
    :width: 50%
 

--- a/docs/beyond_basics/basics-specialpurpose.rst
+++ b/docs/beyond_basics/basics-specialpurpose.rst
@@ -3,12 +3,8 @@
 Special purpose showrooms
 -------------------------
 
-.. index:: ! Chapter; 14. Special purpose showrooms
-
 .. figure:: ../artwork/src/functions.svg
    :width: 50%
-
-.. index:: ! Chapter; Special purpose showrooms
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This conflates the purpose of an index and a TOC. We have both and should not cross-populate information to keep things lean and clean.