### PR TITLE
Fix toggling by using jquery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,7 @@ extensions = [
     'dataladhandbook_support',
     'notfound.extension',
     'sphinx_copybutton',
+    'sphinxcontrib.jquery',
 ]
 
 # configure sphinx-copybutton

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ sphinxcontrib-websupport
 sphinx-notfound-page
 sphinx-copybutton<0.4
 urllib3
+sphinxcontrib-jquery
 sphinxcontrib-svg2pdfconverter
 -e git+https://github.com/mih/autorunrecord.git@main#egg=autorunrecord
 # install our own directives


### PR DESCRIPTION
More recent versions of Sphinx stopped shipping jquery, which is required for toggling boxes and the page progress bar. Instead, we're now using a dedicated sphinx extension sphinxcontrib.jquery

fixes #1071 