### PR TITLE
replace 'subject' with 'brain'

### DIFF
--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -69,7 +69,7 @@ If you already have a small DataLad dataset to practice with, feel free to use i
 during the rest of the walkthrough. If you do not have data, no problem! As a general
 introduction, the steps below will download a small public neuroimaging dataset,
 and transform it into a DataLad dataset. We'll use the `MoAEpilot <https://www.fil.ion.ucl.ac.uk/spm/data/auditory>`_
-dataset containing anatomical and functional images from a single subject, as well as some metadata.
+dataset containing anatomical and functional images from a single brain, as well as some metadata.
 
 In the first step, we create a new directory called ``neuro-data-s3``, we download and extract the data,
 and then we move the extracted contents into our new directory:

--- a/docs/intro/howto.rst
+++ b/docs/intro/howto.rst
@@ -1,7 +1,7 @@
 .. _howto:
 
 ****************
-The Command Line
+The command line
 ****************
 
 .. index:: ! terminal, ! shell, ! command Line


### PR DESCRIPTION
This replaces one instance of the jargon "subject" in the Basics of the handbook in response to #1055. There are more instances in specialized neuro usecases or advanced parts such as the section on the HCP dataset