### PR TITLE
standardize here document to heredoc

### DIFF
--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -19,7 +19,7 @@ Let's write a short summary of how to create a DataLad dataset from scratch:
 This is meant to be a note you would take in an educational course.
 You can take this note and write it to a file with an editor of your choice.
 The code below, however, contains this note within the start and end part of a
-`here document <https://en.wikipedia.org/wiki/Here_document>`_.
+`herdoc <https://en.wikipedia.org/wiki/Here_document>`_.
 You can also copy the full code snippet, starting
 from ``cat << EOT > notes.txt``, including the ``EOT`` in the last line, in your
 terminal to write this note from the terminal (without any editor) into ``notes.txt``.

--- a/docs/usecases/ml-analysis.rst
+++ b/docs/usecases/ml-analysis.rst
@@ -205,7 +205,7 @@ Note how, in accordance to the :ref:`YODA principles <yoda>`, the script only co
        main(repo_path)
    EOT
 
-Executing the `here document <https://en.wikipedia.org/wiki/Here_document>`_ in the code block above has created a script ``code/prepare.py``:
+Executing the `heredoc <https://en.wikipedia.org/wiki/Here_document>`_ in the code block above has created a script ``code/prepare.py``:
 
 .. runrecord:: _examples/ml-108
    :language: console


### PR DESCRIPTION
I find that it is less ambiguous when used as a single word - otherwise, people unfamiliar with the concept might misinterpret the term as broken sentence structure or grammar

Fixes #1093