### PR TITLE
Remove unecessary Windows version specification where possible

### DIFF
--- a/docs/code_from_chapters/ABCD.rst
+++ b/docs/code_from_chapters/ABCD.rst
@@ -117,7 +117,7 @@ To demonstrate this, we make two unrelated changes: adding a new file (a comic d
    If the ``wget`` command above fails for you, you could
 
    * Install a Windows version of wget
-   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows 10 builds include ``curl`` natively)
+   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows builds include ``curl`` natively)
    * Download and save the image from your web browser
 
 Here's a project title that we echo into the README::

--- a/docs/code_from_chapters/DLBasicsMPI.rst
+++ b/docs/code_from_chapters/DLBasicsMPI.rst
@@ -114,7 +114,7 @@ Let's make another change to the dataset, by adding a new file (a webcomic, down
    If the ``wget`` command above fails for you, you could
 
    * Install a Windows version of wget
-   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows 10 builds include ``curl`` natively)
+   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows builds include ``curl`` natively)
    * Download and save the image from your web browser
 
 With this change, there are two modifications in your dataset, a modified file and an untracked file::

--- a/docs/code_from_chapters/usecase_ml_code.rst
+++ b/docs/code_from_chapters/usecase_ml_code.rst
@@ -107,7 +107,7 @@ Let's make another change to the dataset, by adding a new file (a webcomic, down
    If the ``wget`` command above fails for you, you could
 
    * Install a Windows version of wget
-   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows 10 builds include ``curl`` natively)
+   * Use the following ``curl`` command: ``curl https://imgs.xkcd.com/comics/compiling.png --output compiling.png`` (recent Windows builds include ``curl`` natively)
    * Download and save the image from your web browser
 
 With this change, there are two modifications in your dataset, a modified file and an untracked file::

--- a/docs/intro/narrative.rst
+++ b/docs/intro/narrative.rst
@@ -133,11 +133,11 @@ You can decide for yourself whether you want to check them out:
    the book when there is no better alternative, and executing those commands will
    suffice to follow along.
 
-If you are a Windows 10 user with a native (i.e., not `Windows Subsystem for Linux (WSL) <https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux>`_-based DataLad installation, pay close attention to the special notes in so-called "Windows-Wits":
+If you are a Windows user with a native (i.e., not `Windows Subsystem for Linux (WSL) <https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux>`_-based DataLad installation, pay close attention to the special notes in so-called "Windows-Wits":
 
 .. windows-wit:: For Windows users only
 
-   A range of file system issues can affect the behavior of DataLad or its underlying tools on Windows 10.
+   A range of file system issues can affect the behavior of DataLad or its underlying tools on Windows.
    If necessary, the handbook provides workarounds for problems, explanations, or at least apologies for those inconveniences.
    If you want to help us make the handbook or DataLad better for Windows users, please `get in touch <https://github.com/datalad-handbook/book/issues/new>`_ -- every little improvement or bug report can help.
 

--- a/docs/intro/windows.rst
+++ b/docs/intro/windows.rst
@@ -35,7 +35,7 @@ Usually, the *longer* the `hash` that is created, the more fail-safe it is.
 For a general idea about the length of hashes, consider that many tools including :term:`git-annex` use ``SHA256`` (a 64 characters long hash) as their default.
 As git-annex represents files with their content hash as their name, and places them into a directory of the same name, half of the total path length is already used up with a ``SHA256`` hash.
 Datasets thus adjust this default to a 32 character hash [#f2]_, but still, if you place a DataLad dataset into a deeply nested directory location, you may run into issues due to hitting the path length limit [#f3]_.
-You *can* enable long paths in recent builds of Windows 10, `but it requires some tweaking <https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later>`_.
+You *can* enable long paths in recent builds of Windows, `but it requires some tweaking <https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later>`_.
 
 Windows also doesn't really come with a decent :term:`terminal`.
 It is easy to get a nice and efficient terminal set up on macOS or Linux, it is harder on Windows.
@@ -129,7 +129,7 @@ The Windows Subsystem for Linux (version 2)
 
 If you want to have a taste of Unix on your own computer, but in the most safe and reversible way, or have essential software that only runs under Windows and really need to keep a Windows Operating System, then the Windows Subsystem for Linux (WSL2) may be a solution.
 `Microsoft acknowledges that a lot of software is assuming that the environment in which they run behaves like Linux, and has added a real Linux kernel to Windows with the WSL2 <https://learn.microsoft.com/en-us/windows/wsl/faq>`_.
-If you enable WSL2 on your Windows 10 computer, you have access to a variety of Linux distributions in the Microsoft store, and you can install them with a single click.
+If you enable WSL2 on your Windows computer, you have access to a variety of Linux distributions in the Microsoft store, and you can install them with a single click.
 The Linux distribution(s) of your choice becomes an icon on your task bar, and you can run windows and Linux in parallel.
 
 


### PR DESCRIPTION
It is only kept in three instances:
- As an installation header (because at the moment its Windows 10 and 11 where datalad can be installed, not prior versions)
- In references to minimal Windows versions that introduced a certain feature (e.g., long paths)
- in the information about the windows version with which we tested the handbook under windows