### PR TITLE
Consistently use single quotes as command markup in box titles

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -33,7 +33,7 @@ Note the command structure of :dlcmd:`create` (optional bits are enclosed in ``[
 
 .. index::
    pair: set description for dataset location; with DataLad
-.. find-out-more:: What is the description option of datalad-create?
+.. find-out-more:: What is the description option of 'datalad create'?
 
    The optional ``--description`` flag allows you to provide a short description of
    the *location* of your dataset, for example with
@@ -121,7 +121,7 @@ Each of them is identified by a unique 40 character sequence, called a
    pair: log; Git command
    pair: corresponding branch; in adjusted mode
    pair: show history; on Windows
-.. windows-wit:: Your Git log may be more extensive - use "git log main" instead!
+.. windows-wit:: Your Git log may be more extensive - use 'git log main' instead!
 
    The output of :gitcmd:`log` shown in the handbook and the output you will see in your own datasets when executing the same commands may not always match -- many times you might see commits about a "git-annex adjusted branch" in your history.
    This is expected, and if you want to read up more about this, please progress on to chapter :ref:`chapter_gitannex` and afterwards take a look at `this part of git-annex documentation <https://git-annex.branchable.com/design/adjusted_branches>`_.

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -156,7 +156,7 @@ If you ever forget to specify a message, or made a typo, not all is lost. A
 
 .. index::
    pair: amend commit message; with Git
-.. find-out-more:: "Oh no! I forgot the -m option for datalad-save!"
+.. find-out-more:: "Oh no! I forgot the -m option for 'datalad save'!"
    :name: fom-amend-save
    :float:
 

--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -178,7 +178,7 @@ evolved over time. That's quite neat, isn't it?
    pair: log; Git command
    pair: get help; with Git
    pair: filter history; with Git
-.. find-out-more:: git log has many more useful options
+.. find-out-more:: 'git log' has many more useful options
 
    ``git log``, as many other ``Git`` commands, has a good number of options
    which you can discover if you run ``git log --help``.  Those options could

--- a/docs/basics/101-109-rerun.rst
+++ b/docs/basics/101-109-rerun.rst
@@ -176,7 +176,7 @@ of the dataset and the previous commit (called "``HEAD~1``" in Git terminology [
    pair: show dataset modification; on Windows with DataLad
    pair: diff; DataLad command
    pair: corresponding branch; in adjusted mode
-.. windows-wit:: please use datalad diff --from main --to HEAD~1
+.. windows-wit:: please use 'datalad diff --from main --to HEAD~1'
 
    While this example works on Unix file systems, it will not provide the same output on Windows.
    This is due to different file handling on Windows.
@@ -273,7 +273,7 @@ give the file path to :gitcmd:`log` (prefixed by ``--``):
    pair: show history for particular paths; on Windows with Git
    pair: log; Git command
    pair: corresponding branch; in adjusted mode
-.. windows-wit:: use "git log main -- recordings/podcasts.tsv"
+.. windows-wit:: use 'git log main -- recordings/podcasts.tsv'
 
    A previous Windows Wit already advised to append ``main`` or ``master``, the common "default :term:`branch`", to any command that starts with ``git log``.
    Here, the last part of the command specifies a file (``-- recordings/podcasts.tsv``).

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -505,7 +505,7 @@ the ``--input`` and ``--output`` specification done before.
 
 .. index::
    pair: run command with curly brackets; with DataLad run
-.. find-out-more:: ... wait, what if I need a curly bracket in my datalad run call?
+.. find-out-more:: ... wait, what if I need a curly bracket in my 'datalad run' call?
 
    If your command call involves a ``{`` or ``}`` character, you will need to escape
    this brace character by doubling it, i.e., ``{{`` or ``}}``.

--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -241,7 +241,7 @@ the former for a different lecture:
    pair: corresponding branch; in adjusted mode
    pair: show dataset modification for particular path; on Windows with DataLad
    pair: diff; DataLad command
-.. windows-wit:: Please use datalad diff --from main --to remotes/roommate/main
+.. windows-wit:: Please use 'datalad diff --from main --to remotes/roommate/main'
 
    Please use the following command instead:
 
@@ -267,7 +267,7 @@ that there is a difference in ``notes.txt``! Let's ask
    pair: corresponding branch; in adjusted mode
    pair: show dataset modification; on Windows with Git
    pair: diff; DataLad command
-.. windows-wit:: Please use git diff main..remotes/roommate/main
+.. windows-wit:: Please use 'git diff main..remotes/roommate/main'
 
    Please use the following command instead:
 

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -513,7 +513,7 @@ re-execution with :dlcmd:`rerun` easy.
 
 .. index::
    pair: python instead of python3; on Windows
-.. windows-wit:: You may need to use "python", not "python3"
+.. windows-wit:: You may need to use 'python', not 'python3'
 
    If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called solely ``python``.
    Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole):

--- a/docs/basics/101-132-advancednesting.rst
+++ b/docs/basics/101-132-advancednesting.rst
@@ -57,7 +57,7 @@ interested in this, checkout the :ref:`dedicated Findoutmore <fom-status>`.
 .. index::
    pair: status; DataLad command
    pair: check dataset for modification; with DataLad
-.. find-out-more:: More on datalad status
+.. find-out-more:: More on 'datalad status'
    :name: fom-status
    :float:
 
@@ -194,7 +194,7 @@ dataset, i.e., ``DataLad-101``, as the dataset to save to:
 
 .. index::
    pair: save modification in nested dataset; with DataLad
-.. find-out-more:: More on how save can operate on nested datasets
+.. find-out-more:: More on how 'datalad save' can operate on nested datasets
 
    In a superdataset with subdatasets, :dlcmd:`save` by default
    tries to figure out on its own which dataset's history of all available

--- a/docs/basics/101-136-filesystem.rst
+++ b/docs/basics/101-136-filesystem.rst
@@ -278,7 +278,7 @@ the best option to turn to.
 
 .. index::
    pair: fix; git-annex command
-.. gitusernote:: git annex fix
+.. gitusernote:: 'datalad save' internals: 'git annex fix' 
 
    A :dlcmd:`save` command internally uses a :gitcmd:`commit` to save changes to a dataset.
    :gitcmd:`commit` in turn triggers a :gitannexcmd:`fix`

--- a/docs/usecases/HCP_dataset.rst
+++ b/docs/usecases/HCP_dataset.rst
@@ -319,7 +319,7 @@ and identified via their :term:`dataset ID`.
 The :dlcmd:`clone` command can understand this layout and install
 datasets from a RIA store based on their ID.
 
-.. find-out-more:: How would a datalad clone from a RIA store look like?
+.. find-out-more:: How would a 'datalad clone' from a RIA store look like?
 
    In order to get a dataset from a RIA store, :dlcmd:`clone` needs
    a RIA URL. It is build from the following components:


### PR DESCRIPTION
in response to https://github.com/datalad-handbook/book/issues/1092