### PR TITLE
Use proper terms for container concept

### DIFF
--- a/docs/basics/101-133-containersrun.rst
+++ b/docs/basics/101-133-containersrun.rst
@@ -78,29 +78,28 @@ While being a powerful tool, it is only rarely used on high performance computin
 .io/docs>`_.
 Both of these tools share core terminology:
 
-**Recipe**
-   A text file template that lists all required components of the computational environment.
+:term:`container recipe`
+   A text file that lists all required components of the computational environment.
    It is made by a human user.
 
-**Image**
+:term:`container image`
    This is *built* from the recipe file. It is a static filesystem inside a file,
    populated with the software specified in the recipe, and some initial configuration.
 
-**Container**
-  A running instance of an Image that you can actually use for your computations.
+:term:`container`
+  A running instance of an image that you can actually use for your computations.
   If you want to create and run your own software container, you start by writing
-  a recipe file and build an Image from it. Alternatively, you can can also *pull*
-  an Image built from a publicly shared recipe from the *Hub* of the tool you are using.
+  a recipe file and build an image from it. Alternatively, you can can also *pull*
+  an image built from a publicly shared recipe from the *Hub* of the tool you are using.
 
-**Hub**
+hub
   A storage resource to share and consume images. Examples are
-  `Singularity-Hub <https://singularity-hub.org>`_,
-  `Docker-Hub <https://hub.docker.com>`_, and `Amazon ECR <https://aws.amazon.com/ecr>`_ which hosts Docker Images.
+  :term:`Singularity-Hub`, :term:`Docker-Hub`, and `Amazon ECR <https://aws.amazon.com/ecr>`_ which hosts Docker images.
 
 Note that as of now, the ``datalad-container`` extension supports
 Singularity and Docker images.
 Singularity furthermore is compatible with Docker -- you can use
-Docker Images as a basis for Singularity Images, or run Docker Images with
+Docker images as a basis for Singularity images, or run Docker images with
 Singularity (even without having Docker installed).
 
 .. importantnote:: Additional requirement: Singularity
@@ -140,26 +139,26 @@ section :ref:`run` with the :dlcmd:`containers-run` command.
 Let's see this in action for the ``midterm_analysis`` dataset by rerunning
 the analysis you did for the midterm project within a Singularity container.
 We start by registering a container to the dataset.
-For this, we will pull an Image from Singularity hub. This Image was made
+For this, we will pull an image from Singularity hub. This image was made
 for the handbook, and it contains the relevant Python setup for
 the analysis. Its recipe lives in the handbook's
 `resources repository <https://github.com/datalad-handbook/resources>`_.
-If you're curious how to create a Singularity Image, the hidden
+If you're curious how to create a Singularity image, the hidden
 section below has some pointers:
 
 .. index::
    pair: build container image; with Singularity
-.. find-out-more:: How to make a Singularity Image
+.. find-out-more:: How to make a Singularity image
 
-   Singularity containers are build from Image files, often
+   Singularity containers are build from image files, often
    called "recipes", that hold a "definition" of the software container and its
    contents and components. The
    `singularity documentation <https://docs.sylabs.io/guides/3.4/user-guide/build_a_container.html>`_
-   has its own tutorial on how to build such Images from scratch.
-   An alternative to writing the Image file by hand is to use
+   has its own tutorial on how to build such images from scratch.
+   An alternative to writing the image file by hand is to use
    `Neurodocker <https://github.com/ReproNim/neurodocker>`_. This
    command-line program can help you generate custom Singularity recipes (and
-   also ``Dockerfiles``, from which Docker Images are build). A wonderful tutorial
+   also ``Dockerfiles``, from which Docker images are built). A wonderful tutorial
    on how to use Neurodocker is
    `this introduction <https://miykael.github.io/nipype_tutorial/notebooks/introduction_neurodocker.html>`_
    by Michael Notter.
@@ -179,7 +178,7 @@ section below has some pointers:
    pair: add container image to dataset; with DataLad
 
 The :dlcmd:`containers-add` command takes an arbitrary
-name to give to the container, and a path or url to a container Image:
+name to give to the container, and a path or url to a container image:
 
 .. runrecord:: _examples/DL-101-133-101
    :language: console
@@ -192,16 +191,16 @@ name to give to the container, and a path or url to a container Image:
 
 .. index::
    pair: hub; Docker
-.. find-out-more:: How do I add an Image from Docker-Hub, Amazon ECR, or a local container?
+.. find-out-more:: How do I add an image from Docker-Hub, Amazon ECR, or a local container?
 
-   Should the Image you want to use lie on Dockerhub, specify the ``--url``
+   Should the image you want to use lie on Dockerhub, specify the ``--url``
    option prefixed with ``docker://`` or ``dhub://`` instead of ``shub://``:
 
    .. code-block:: bash
 
       datalad containers-add midterm-software --url docker://adswa/resources:2
 
-   If your Image exists on Amazon ECR, use a ``dhub://`` prefix followed by the AWS ECR URL as in
+   If your image exists on Amazon ECR, use a ``dhub://`` prefix followed by the AWS ECR URL as in
 
    .. code-block:: bash
 
@@ -231,8 +230,8 @@ container under its name "midterm-software" in the dataset's configuration at
 
       $ cat .datalad/config
 
-   This recorded the Image's origin on Singularity-Hub, the location of the
-   Image in the dataset under ``.datalad/environments/<NAME>/image``, and it
+   This recorded the image's origin on Singularity-Hub, the location of the
+   image in the dataset under ``.datalad/environments/<NAME>/image``, and it
    specifies the way in which the container should be used: The line
 
    .. code-block:: bash
@@ -254,7 +253,7 @@ container under its name "midterm-software" in the dataset's configuration at
 
       datalad containers-add --call-fmt 'singularity exec -B {{pwd}} --cleanenv {img} {cmd}'
 
-   Note that the Image is saved under ``.datalad/environments`` and the
+   Note that the image is saved under ``.datalad/environments`` and the
    configuration is done in ``.datalad/config`` -- as these files are version
    controlled and shared with together with a dataset, your software
    container and the information where it can be reobtained from are linked
@@ -349,7 +348,7 @@ The complete command's structure looks like this:
 
    The command :dlcmd:`containers-remove` will remove a container
    from the dataset, if there exists a container with name given to the
-   command. Note that this will remove not only the Image from the dataset,
+   command. Note that this will remove not only the image from the dataset,
    but also the configuration for it in ``.datalad/config``.
 
 
@@ -365,7 +364,7 @@ Here is how the history entry looks like:
 
 If you would :dlcmd:`rerun` this commit, it would be re-executed in the
 software container registered to the dataset. If you would share the dataset
-with a friend and they would :dlcmd:`rerun` this commit, the Image would first
+with a friend and they would :dlcmd:`rerun` this commit, the image would first
 be obtained from its registered url, and thus your
 friend can obtain the correct execution environment automatically.
 

--- a/docs/basics/101-134-summary.rst
+++ b/docs/basics/101-134-summary.rst
@@ -29,8 +29,8 @@ for yourself why and how software containers can go hand-in-hand with DataLad:
   `datalad containers <https://docs.datalad.org/projects/container>`_
   can make this possible.
 
-- The command :dlcmd:`containers-add` registers an Image from a path or
-  url to your dataset.
+- The command :dlcmd:`containers-add` registers an :term:`container image` from a path or
+  URL to your dataset.
 
 - If you use :dlcmd:`containers-run` instead of :dlcmd:`run`,
   you can reproducibly execute a command of your choice *within* the software
@@ -55,8 +55,8 @@ includes the relevant software environment. This does not only make your analyse
 projects automatically reproducible, but automatically *computationally* reproducible -
 you can make sure that your analyses runs on any computer with Singularity,
 regardless of the software environment on this computer. Even if you are unsure how you can wrap up an
-environment into a software container Image at this point, you could make use of
-hundreds of publicly available Images on `Singularity-Hub <https://singularity-hub.org>`_ and
+environment into a software :term:`container image` at this point, you could make use of
+hundreds of publicly available images on `Singularity-Hub <https://singularity-hub.org>`_ and
 `Docker-Hub <https://hub.docker.com>`_.
 
 With this, you have also gotten a first glimpse into an extension of DataLad: A

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -109,17 +109,22 @@ Glossary
       Find out more at `docs.conda.io <https://docs.conda.io>`_.
       It overlaps with :term:`pip` in functionality, but it is advised to not use both tools simultaneously for package management.
 
-   container recipe
-      .. index:: ! Container concept; recipe
+   container
+      .. index:: ! Container concept; container
 
-      A text file template that lists all required components of the computational environment that a :term:`software container` should contain.
-      It is made by a human user.
+      A running instance of a :term:`container image` image that is ready to use.
 
    container image
       .. index:: ! Container concept; image
 
-      Container images are *built* from :term:`container recipe` files.
-      They are a static filesystem inside a file, populated with the software specified in the recipe, and some initial configuration.
+      A container image is *built* from a :term:`container recipe`.
+      It is a filesystem snapshot in a file, populated with software specified in the recipe, and some initial configuration.
+
+   container recipe
+      .. index:: ! Container concept; recipe
+
+      A text file that lists all required components of the computational environment that a :term:`software container` should contain.
+      It is made by a human user.
 
    crippled filesystem
       .. index::


### PR DESCRIPTION
Replaces the capitalization markup for `Image`.

Closes #1103