### PR TITLE
Move box content into dedicated file

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -123,19 +123,7 @@ Each of them is identified by a unique 40 character sequence, called a
    pair: show history; on Windows
 .. windows-wit:: Your Git log may be more extensive - use 'git log main' instead!
 
-   The output of :gitcmd:`log` shown in the handbook and the output you will see in your own datasets when executing the same commands may not always match -- many times you might see commits about a "git-annex adjusted branch" in your history.
-   This is expected, and if you want to read up more about this, please progress on to chapter :ref:`chapter_gitannex` and afterwards take a look at `this part of git-annex documentation <https://git-annex.branchable.com/design/adjusted_branches>`_.
-
-   In order to get a similar experience in your dataset, please add the name of your default :term:`branch` (it will likely have the name ``main`` or ``master``) to every ``git log`` command.
-   This should display the same output that the handbook displays.
-   The reason behind this is that datasets are using a special :term:`branch` to be functional on Windows.
-   This branch's history differs from the history that would be in the default branch.
-   With this workaround, you will be able to display the dataset history from the same branch that the handbook and all other operating system display.
-   Thus, whenever the handbook code snippet contains a line that starts with ``git log``, copy it and append the term ``main`` or ``master``, whichever is appropriate.
-
-   If you are eager to help to improve the handbook, you could do us a favor by reporting any places with mismatches between Git logs on Windows and in the handbook.
-   `Get in touch <https://github.com/datalad-handbook/book/issues/new>`_!
-
+   .. include:: topic/adjustedmode-log.rst
 
 Highlighted in this output is information about the author and about
 the time, as well as a :term:`commit message` that summarizes the

--- a/docs/basics/101-102-populate.rst
+++ b/docs/basics/101-102-populate.rst
@@ -49,16 +49,7 @@ are presented here, make sure to check the :windows-wit:`on peculiarities of its
 .. windows-wit:: Terminals other than Git Bash can't handle multi-line commands
    :name: ww-no-multiline-commands
 
-   In Unix shells, ``\`` can be used to split a command into several lines, for example to aid readability.
-   Standard Windows terminals (including the Anaconda prompt) do not support this.
-   They instead use the ``^`` character:
-
-   .. code-block:: bash
-
-     $ wget -q https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download ^
-     -O TLCL.pdf
-
-   If you are not using the Git Bash, you will either need to copy multi-line commands into a single line, or use ``^`` (make sure that there is **no space** afterwards) instead of ``\``.
+   .. include:: topic/terminal-linecontinuation.rst
 
 .. index::
    pair: download file; with wget
@@ -86,18 +77,7 @@ curl <ww-curl-instead-wget>`.
 .. windows-wit:: You can use curl instead of wget
    :name: ww-curl-instead-wget
 
-   Many versions of Windows do not ship with the tool ``wget``.
-   You can install it, but it may be easier to use the pre-installed ``curl`` command:
-
-   .. code-block:: bash
-
-      $ cd books
-      $ curl -L https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download \
-        -o TLCL.pdf
-      $ curl -L https://github.com/swaroopch/byte-of-python/releases/download/vadb91fc6fce27c58e3f931f5861806d3ccd1054c/byte-of-python.pdf \
-        -o byte-of-python.pdf
-      $ cd ../
-
+   .. include:: topic/curl-instead-wget.rst
 
 Let's see what happened. First of all, in the root of ``DataLad-101``, show the directory
 structure with tree:

--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -62,17 +62,7 @@ root of your ``DataLad-101`` dataset:
    pair: heredoc; on Windows in a terminal
 .. windows-wit:: Heredocs don't work under non-Git-Bash Windows terminals
 
-   Heredocs rely on Unix-type redirection and multi-line commands -- which is not supported on most native Windows terminals or the Anaconda prompt on Windows.
-   If you are using an Anaconda prompt or a Windows terminal other than Git Bash, instead of executing heredocs, please open up an editor and paste and save the text into it.
-
-   The relevant text in the snippet below would be:
-
-   .. code-block:: text
-
-      One can create a new dataset with 'datalad create [--description] PATH'.
-      The dataset is created empty
-
-   If you are using Git Bash, however, here docs will work just fine.   
+   .. include:: topic/heredoc-windows.rst
 
 .. index::
    pair: create heredoc; in a terminal

--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -148,7 +148,7 @@ Here is the repository structure:
    pair: display directory tree; on Windows
 .. windows-wit:: use tree
 
-   The Windows version of tree requires different parametrization, so please run ``tree`` instead of ``tree -d``.
+   .. include:: topic/tree-windows.rst
 
 .. runrecord:: _examples/DL-101-105-103
    :language: console

--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -73,38 +73,13 @@ will write it into the script.
 
 .. windows-wit:: Here's a script for Windows users
 
-   Please use an editor of your choice to create a file ``list_titles.sh`` inside of the ``code`` directory.
-   These should be the contents:
-
-   .. code-block:: bash
-
-       for i in recordings/longnow/Long_Now__Seminars*/*.mp3; do
-          # get the filename
-          base=$(basename "$i");
-          # strip the extension
-          base=${base%.mp3};
-          # date as yyyy-mm-dd
-          printf "${base%%__*}\t" | tr '_' '-';
-          # name and title without underscores
-          printf "${base#*__}\n" | tr '_' ' ';
-       done
-
-   Note that this is not identical to the one below -- it lacks a few ``\`` characters, which is a meaningful difference.
+   .. include:: topic/globscript1-windows.rst
 
 .. index::
    pair: hidden file name extensions; on Windows
 .. windows-wit:: Be mindful of hidden extensions when creating files!
 
-   By default, Windows does not show common file extensions when you view directory contents with a file explorer.
-   Instead, it only displays the base of the file name and indicates the file type with the display icon.
-   You can see if this is the case for you, too, by opening the ``books\`` directory in a file explorer, and checking if the file extension (``.pdf``) is a part of the file name displayed underneath its PDF icon.
-
-   Hidden file extensions can be a confusing source of errors, because some Windows editors (for example, Notepad) automatically add a ``.txt`` extension to your files -- when you save the script above under the name ``list_titles.sh``, your editor may add an extension (``list_titles.sh.txt``), and the file explorer displays your file as ``list_titles.sh`` (hiding the ``.txt`` extension).
-
-   To prevent confusion, configure the file explorer to always show you the file extension.
-   For this, open the Explorer, click on the "View" tab, and tick the box "File name extensions".
-
-   Beyond this, double check the correct naming of your file, ideally in the terminal.
+   .. include:: topic/hidden-extensions.rst
 
 .. runrecord:: _examples/DL-101-108-102
    :language: console

--- a/docs/basics/101-109-rerun.rst
+++ b/docs/basics/101-109-rerun.rst
@@ -34,21 +34,7 @@ with the following, fixed script:
 
 .. windows-wit:: Here's a script adjustment for Windows users
 
-   Please use an editor of your choice to replace the contents of ``list_titles.sh`` inside of the ``code`` directory with the following:
-
-   .. code-block:: bash
-
-       for i in recordings/longnow/Long_Now*/*.mp3; do
-          # get the filename
-          base=$(basename "$i");
-          # strip the extension
-          base=${base%.mp3};
-          # date as yyyy-mm-dd
-          printf "${base%%__*}\t" | tr '_' '-';
-          # name and title without underscores
-          printf "${base#*__}\n" | tr '_' ' ';
-       done
-
+   .. include:: topic/globscript2-windows.rst
 
 .. runrecord:: _examples/DL-101-109-102
    :language: console
@@ -178,18 +164,7 @@ of the dataset and the previous commit (called "``HEAD~1``" in Git terminology [
    pair: corresponding branch; in adjusted mode
 .. windows-wit:: please use 'datalad diff --from main --to HEAD~1'
 
-   While this example works on Unix file systems, it will not provide the same output on Windows.
-   This is due to different file handling on Windows.
-   When executing this command, you will see *all* files being modified between the most recent and the second-most recent commit.
-   On a technical level, this is correct given the underlying file handling on Windows, and chapter :ref:`chapter_gitannex` will shed light on why that is.
-
-   For now, to get the same output as shown in the code snippet below, use the following command where ``main`` (or ``master``) is the name of your default branch:
-
-   .. code-block:: bash
-
-      datalad diff --from main --to HEAD~1
-
-   The ``--from`` argument specifies a different starting point for the comparison - the ``main`` or :term:`master` :term:`branch`, which would be the starting point on most Unix-based systems.
+   .. include:: topic/adjustedmode-diff.rst
 
 .. index::
    pair: diff; Git command
@@ -275,9 +250,7 @@ give the file path to :gitcmd:`log` (prefixed by ``--``):
    pair: corresponding branch; in adjusted mode
 .. windows-wit:: use 'git log main -- recordings/podcasts.tsv'
 
-   A previous Windows Wit already advised to append ``main`` or ``master``, the common "default :term:`branch`", to any command that starts with ``git log``.
-   Here, the last part of the command specifies a file (``-- recordings/podcasts.tsv``).
-   Please append ``main`` or ``master`` to ``git log``, prior to the file specification.
+   .. include:: topic/adjustedmode-log-path.rst
 
 .. index::
    pair: show history for particular paths; with Git

--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -61,10 +61,7 @@ To resize one image to 400x400 px, the command would thus be
    single: installation; ImageMagick
 .. windows-wit:: Tool installation
 
-   `ImageMagick <https://imagemagick.org/index.php>`_ is not installed on Windows systems by default.
-   To use it, you need to install it, using the provided `Windows Binary Release on the Download page <https://imagemagick.org/script/download.php>`_.
-   During installation, it is important to install the tool into a place where it is easily accessible to your terminal, for example the ``Program Files`` folder.
-   Do also make sure to tick the box "install legacy commands" in the installation wizard.
+   .. include:: topic/installation-imagemagick.rst
 
 Remembering the last lecture on :dlcmd:`run`, you decide to plug this into
 :dlcmd:`run`. Even though this is not a script, it is a command, and you can wrap
@@ -171,18 +168,7 @@ If outputs already exist...
    pair: unlocked files; in adjusted mode
 .. windows-wit:: Good news! Here is something that is easier on Windows
 
-   The section below describes something that is very confusing for people that have just started with DataLad: Some files in a dataset can't be modified, and if one tries, it results in a "permission denied" error.
-   Why is that?
-   The remainder of this section and the upcoming chapter :ref:`chapter_gitannex` contain a procedural explanation.
-   However: This doesn't happen on Windows.
-   The "unlocking" that is necessary on almost all other systems to modify a file is already done on Windows.
-   Thus, all files in your dataset will be readily modifiable, sparing you the need to adjust to the unexpected behavior that is described below.
-   While it is easier, it isn't a "more useful" behavior, though.
-   A different Windows Wit in the next chapter will highlight how it rather is a suboptimal workaround.
-
-   Please don't skip the next section -- it is useful to know how datasets behave on other systems.
-   Just be mindful that you will not encounter the errors that the handbook displays next.
-   And while this all sounds quite cryptic and vague, an upcoming Windows Wit will provide more information.
+   .. include:: topic/adjustedmode-unlockedfiles.rst
 
 Looking at the resulting image, you wonder whether 400x400 might be a tiny bit to small.
 Maybe we should try to resize it to 450x450, and see whether that looks better?
@@ -257,9 +243,7 @@ Let us check out what it does:
    single: adjusted branch; unlocked files
 .. windows-wit:: What happens if I run this on Windows?
 
-   Nothing. All of the files in your dataset are always unlocked, and actually *can not* be locked at all.
-   Consequently, there will be nothing to show for ``datalad status`` afterwards (as shown a few paragraphs below).
-   This is due to a file system limitation, and will be explained in more detail in chapter :ref:`chapter_gitannex`.
+   .. include:: topic/adjustedmode-unlockedfiles2.rst
 
 .. runrecord:: _examples/DL-101-111-101
    :language: console
@@ -348,9 +332,7 @@ flag and see their magic, let's crop the second logo, ``logo_interval.jpg``:
    pair: unlocked files; in adjusted mode
 .. windows-wit:: Wait, would I need to specify outputs, too?
 
-   Given that nothing in your dataset is locked, is there a *need* for you to bother with creating ``--output`` flags?
-   Not for you personally, if you only stay on your Windows machine.
-   However, you will be doing others that you share your dataset with a favor if they are not using Windows -- should you or others want to rerun a run record, ``--output`` flags will make it work on all operating systems.
+   .. include:: topic/adjustedmode-unlockedfiles-output.rst
 
 .. runrecord:: _examples/DL-101-111-105
    :language: console

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -23,10 +23,7 @@ We'll take a look together, using the ``books/`` directory as an example:
    pair: tree; terminal command
 .. windows-wit:: This will look different to you
 
-   First of all, the Windows ``tree`` command lists only directories by default, unless you parametrize it with ``/f``.
-   And, secondly, even if you list the individual files, you would not see the :term:`symlink`\s shown below.
-   Due to insufficient support of symlinks on Windows, git-annex does not use them.
-   Please read on for a basic understanding of how git-annex usually works -- a Windows Wit at the end of this section will then highlight the difference in functionality on Windows.
+   .. include:: topic/tree-symlinks.rst
 
 .. runrecord:: _examples/DL-101-115-101
    :language: console
@@ -94,43 +91,7 @@ tree is also known as the *annex* of a dataset.
    :name: woa_objecttree
    :float:
 
-   Windows has insufficient support for :term:`symlink`\s and revoking write :term:`permissions` on files.
-   Therefore, :term:`git-annex` classifies it as a :term:`crippled file system` and has to stray from its default behavior.
-   While git-annex on Unix-based file operating systems stores data in the annex and creates a symlink in the data's original place, on Windows it moves data into the :term:`annex` and creates a *copy* of the data in its original place.
-
-   **Why is that?**
-   Data *needs* to be in the annex for version control and transport logistics -- the annex is able to store all previous versions of the data, and manage the transport to other storage locations if you want to publish your dataset.
-   But as the :ref:`Findoutmore in this section <fom-objecttree>` will show, the :term:`annex` is a non-human readable tree structure, and data thus also needs to exist in its original location.
-   Thus, it exists in both places: it has moved into the annex, and copied back into its original location.
-   Once you edit an annexed file, the most recent version of the file is available in its original location, and past versions are stored and readily available in the annex.
-   If you reset your dataset to a previous state (as is shown in the section :ref:`history`), the respective version of your data is taken from the annex and copied to replace the newer version, and vice versa.
-
-   **But doesn't a copy mean data duplication?**
-   Yes, absolutely!
-   And that is a big downside to DataLad and :term:`git-annex` on Windows.
-   If you have a dataset with annexed file contents (be that a dataset you created and populated yourself, or one that you cloned and got file contents with ``datalad get`` from), it will take up more space than on a Unix-based system.
-   How much more?
-   Every file that exists in your file hierarchy exists twice.
-   A fresh dataset with one version of each file is thus twice as big as it would be on a Linux computer.
-   Any past version of data does not exist in duplication.
-
-   **Step-by-step demonstration**:
-   Let's take a concrete example to explain the last point in more detail.
-   How much space, do you think, is taken up in your dataset by the resized ``salt_logo_small.jpg`` image?
-   As a reminder: It exists in two versions, a 400 by 400 pixel version (about 250Kb in size), and a 450 by 450 pixel version (about 310Kb in size).
-   The 400 by 400 pixel version is the most recent one.
-   The answer is: about 810Kb (~0.1Mb).
-   The most recent 400x400px version exists twice (in the annex and as a copy), and the 450x450px copy exists once in the annex.
-   If you would reset your dataset to the state when we created the 450x450px version, this file would instead exist twice.
-
-   .. index::
-      pair: unused; git-annex command
-      pair: dropunused; git-annex command
-
-   **Can I at least get unused or irrelevant data out of the dataset?**
-   Yes, either with convenience commands (e.g., ``git annex unused`` followed by ``git annex dropunused``), or by explicitly using ``drop`` on files (or their past versions) that you don't want to keep anymore.
-   Alternatively, you can transfer data you don't need but want to preserve to a different storage location.
-   Later parts of the handbook will demonstrate each of these alternatives.
+   .. include:: topic/adjustedmode-nosymlinks.rst
 
 For a demonstration that this file path is not complete gibberish,
 take the target path of any of the book's symlinks and
@@ -340,22 +301,4 @@ If so, please take a look into the Windows Wit below.
    pair: log; Git command
 .. windows-wit:: Accessing symlinked files from your Windows system
 
-   If you are using WSL2 you have access to a Linux kernel and POSIX file system, including symlink support.
-   Your DataLad experience has therefore been exactly as it has been for macOS or Linux users.
-   But one thing that bears the need for additional information is sharing files in dataset between your Linux and Windows system.
-
-   It's fantastic that files created under Linux can be shared to Windows and used by Windows tools.
-   Usually, you should be able to open an explorer and type ``\\wsl$\<distro>\<path>`` in the address bar to navigate to files under Linux, or type ``explorer.exe`` into the WSL2 terminal.
-   Some core limitations of Windows can't be overcome, though: Windows usually isn't capable of handling symlinks.
-   So while WSL2 can expose your dataset filled with symlinked files to Windows, your Windows tools can fail to open them.
-   How can this be fixed?
-
-   .. index::
-      pair: checkout; Git command
-      pair: check out particular version; with Git
-
-   Whenever you need to work with files from your datasets under Windows, you should *unlock* with ``datalad unlock``.
-   This operation copies the file from the annex back to its original location, and thus removes the symlink (and also returns write :term:`permissions` to the file).
-   Alternatively, use `git-annex adjust --unlock <https://git-annex.branchable.com/git-annex-adjust>`_ to switch to a new dataset :term:`branch` in which all files are unlocked.
-   The branch is called ``adjusted/<branchname>(unlocked)`` (e.g., if the original branch name was ``main``, the new, adjusted branch will be called ``adjusted/main(unlocked)``).
-   You can switch back to your original branch using ``git checkout <branchname>``.
+   .. include:: topic/wsl2-symlinkaccess.rst

--- a/docs/basics/101-121-siblings.rst
+++ b/docs/basics/101-121-siblings.rst
@@ -243,13 +243,7 @@ the former for a different lecture:
    pair: diff; DataLad command
 .. windows-wit:: Please use 'datalad diff --from main --to remotes/roommate/main'
 
-   Please use the following command instead:
-
-   .. code-block:: bash
-
-      datalad diff --from main --to remotes/roommate/main
-
-   This syntax specifies the :term:`main` :term:`branch` as a starting point for the comparison instead of the current ``adjusted/main(unlocked)`` branch.
+   .. include:: topic/adjustedmode-diff-remote.rst
 
 .. runrecord:: _examples/DL-101-121-108
    :language: console
@@ -269,13 +263,7 @@ that there is a difference in ``notes.txt``! Let's ask
    pair: diff; DataLad command
 .. windows-wit:: Please use 'git diff main..remotes/roommate/main'
 
-   Please use the following command instead:
-
-   .. code-block:: bash
-
-     git diff main..remotes/roommate/main
-
-   This is :term:`Git`\s syntax for specifying a comparison between two :term:`branch`\es.
+   .. include:: topic/adjustedmode-gitdiff-remote.rst
 
 .. runrecord:: _examples/DL-101-121-109
    :language: console

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -515,16 +515,7 @@ re-execution with :dlcmd:`rerun` easy.
    pair: python instead of python3; on Windows
 .. windows-wit:: You may need to use 'python', not 'python3'
 
-   If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called solely ``python``.
-   Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole):
-
-   .. code-block:: bash
-
-      datalad run -m "analyze iris data with classification analysis" ^
-       --input "input/iris.csv" ^
-       --output "pairwise_relationships.png" ^
-       --output "prediction_report.csv" ^
-       "python code/script.py {inputs} {outputs}"
+   .. include:: topic/py-or-py3.rst
 
 .. index::
    pair: run command with provenance capture; with DataLad
@@ -731,8 +722,7 @@ configure this repository as a sibling of the dataset:
    pair: typed credentials are not displayed; on Windows
 .. windows-wit:: Your shell will not display credentials
 
-   Don't be confused if you are prompted for your GitHub credentials, but can't seem to type -- the terminal protects your private information by not displaying what you type.
-   Simply type in what is requested, and press enter.
+   .. include:: topic/credential-nodisplay.rst
 
 .. code-block:: bash
 

--- a/docs/basics/topic/adjustedmode-diff-remote.rst
+++ b/docs/basics/topic/adjustedmode-diff-remote.rst
@@ -1,0 +1,7 @@
+Please use the following command instead:
+
+.. code-block:: bash
+
+  datalad diff --from main --to remotes/roommate/main
+
+This syntax specifies the :term:`main` :term:`branch` as a starting point for the comparison instead of the current ``adjusted/main(unlocked)`` branch.

--- a/docs/basics/topic/adjustedmode-diff.rst
+++ b/docs/basics/topic/adjustedmode-diff.rst
@@ -1,0 +1,12 @@
+While this example works on Unix file systems, it will not provide the same output on Windows.
+This is due to different file handling on Windows.
+When executing this command, you will see *all* files being modified between the most recent and the second-most recent commit.
+On a technical level, this is correct given the underlying file handling on Windows, and chapter :ref:`chapter_gitannex` will shed light on why that is.
+
+For now, to get the same output as shown in the code snippet below, use the following command where ``main`` (or ``master``) is the name of your default branch:
+
+.. code-block:: bash
+
+  datalad diff --from main --to HEAD~1
+
+The ``--from`` argument specifies a different starting point for the comparison - the ``main`` or :term:`master` :term:`branch`, which would be the starting point on most Unix-based systems.

--- a/docs/basics/topic/adjustedmode-gitdiff-remote.rst
+++ b/docs/basics/topic/adjustedmode-gitdiff-remote.rst
@@ -1,0 +1,7 @@
+Please use the following command instead:
+
+.. code-block:: bash
+
+ git diff main..remotes/roommate/main
+
+This is :term:`Git`\s syntax for specifying a comparison between two :term:`branch`\es.

--- a/docs/basics/topic/adjustedmode-log-path.rst
+++ b/docs/basics/topic/adjustedmode-log-path.rst
@@ -1,0 +1,3 @@
+A previous Windows Wit already advised to append ``main`` or ``master``, the common "default :term:`branch`", to any command that starts with ``git log``.
+Here, the last part of the command specifies a file (``-- recordings/podcasts.tsv``).
+Please append ``main`` or ``master`` to ``git log``, prior to the file specification.

--- a/docs/basics/topic/adjustedmode-log.rst
+++ b/docs/basics/topic/adjustedmode-log.rst
@@ -1,0 +1,12 @@
+The output of :gitcmd:`log` shown in the handbook and the output you will see in your own datasets when executing the same commands may not always match -- many times you might see commits about a "git-annex adjusted branch" in your history.
+This is expected, and if you want to read up more about this, please progress on to chapter :ref:`chapter_gitannex` and afterwards take a look at `this part of git-annex documentation <https://git-annex.branchable.com/design/adjusted_branches>`_.
+
+In order to get a similar experience in your dataset, please add the name of your default :term:`branch` (it will likely have the name ``main`` or ``master``) to every ``git log`` command.
+This should display the same output that the handbook displays.
+The reason behind this is that datasets are using a special :term:`branch` to be functional on Windows.
+This branch's history differs from the history that would be in the default branch.
+With this workaround, you will be able to display the dataset history from the same branch that the handbook and all other operating system display.
+Thus, whenever the handbook code snippet contains a line that starts with ``git log``, copy it and append the term ``main`` or ``master``, whichever is appropriate.
+
+If you are eager to help to improve the handbook, you could do us a favor by reporting any places with mismatches between Git logs on Windows and in the handbook.
+`Get in touch <https://github.com/datalad-handbook/book/issues/new>`_!

--- a/docs/basics/topic/adjustedmode-nosymlinks.rst
+++ b/docs/basics/topic/adjustedmode-nosymlinks.rst
@@ -1,0 +1,37 @@
+Windows has insufficient support for :term:`symlink`\s and revoking write :term:`permissions` on files.
+Therefore, :term:`git-annex` classifies it as a :term:`crippled file system` and has to stray from its default behavior.
+While git-annex on Unix-based file operating systems stores data in the annex and creates a symlink in the data's original place, on Windows it moves data into the :term:`annex` and creates a *copy* of the data in its original place.
+
+**Why is that?**
+Data *needs* to be in the annex for version control and transport logistics -- the annex is able to store all previous versions of the data, and manage the transport to other storage locations if you want to publish your dataset.
+But as the :ref:`Findoutmore in this section <fom-objecttree>` will show, the :term:`annex` is a non-human readable tree structure, and data thus also needs to exist in its original location.
+Thus, it exists in both places: it has moved into the annex, and copied back into its original location.
+Once you edit an annexed file, the most recent version of the file is available in its original location, and past versions are stored and readily available in the annex.
+If you reset your dataset to a previous state (as is shown in the section :ref:`history`), the respective version of your data is taken from the annex and copied to replace the newer version, and vice versa.
+
+**But doesn't a copy mean data duplication?**
+Yes, absolutely!
+And that is a big downside to DataLad and :term:`git-annex` on Windows.
+If you have a dataset with annexed file contents (be that a dataset you created and populated yourself, or one that you cloned and got file contents with ``datalad get`` from), it will take up more space than on a Unix-based system.
+How much more?
+Every file that exists in your file hierarchy exists twice.
+A fresh dataset with one version of each file is thus twice as big as it would be on a Linux computer.
+Any past version of data does not exist in duplication.
+
+**Step-by-step demonstration**:
+Let's take a concrete example to explain the last point in more detail.
+How much space, do you think, is taken up in your dataset by the resized ``salt_logo_small.jpg`` image?
+As a reminder: It exists in two versions, a 400 by 400 pixel version (about 250Kb in size), and a 450 by 450 pixel version (about 310Kb in size).
+The 400 by 400 pixel version is the most recent one.
+The answer is: about 810Kb (~0.1Mb).
+The most recent 400x400px version exists twice (in the annex and as a copy), and the 450x450px copy exists once in the annex.
+If you would reset your dataset to the state when we created the 450x450px version, this file would instead exist twice.
+
+.. index::
+  pair: unused; git-annex command
+  pair: dropunused; git-annex command
+
+**Can I at least get unused or irrelevant data out of the dataset?**
+Yes, either with convenience commands (e.g., ``git annex unused`` followed by ``git annex dropunused``), or by explicitly using ``drop`` on files (or their past versions) that you don't want to keep anymore.
+Alternatively, you can transfer data you don't need but want to preserve to a different storage location.
+Later parts of the handbook will demonstrate each of these alternatives.

--- a/docs/basics/topic/adjustedmode-unlockedfiles-output.rst
+++ b/docs/basics/topic/adjustedmode-unlockedfiles-output.rst
@@ -1,0 +1,3 @@
+Given that nothing in your dataset is locked, is there a *need* for you to bother with creating ``--output`` flags?
+Not for you personally, if you only stay on your Windows machine.
+However, you will be doing others that you share your dataset with a favor if they are not using Windows -- should you or others want to rerun a run record, ``--output`` flags will make it work on all operating systems.

--- a/docs/basics/topic/adjustedmode-unlockedfiles.rst
+++ b/docs/basics/topic/adjustedmode-unlockedfiles.rst
@@ -1,0 +1,12 @@
+The section below describes something that is very confusing for people that have just started with DataLad: Some files in a dataset can't be modified, and if one tries, it results in a "permission denied" error.
+Why is that?
+The remainder of this section and the upcoming chapter :ref:`chapter_gitannex` contain a procedural explanation.
+However: This doesn't happen on Windows.
+The "unlocking" that is necessary on almost all other systems to modify a file is already done on Windows.
+Thus, all files in your dataset will be readily modifiable, sparing you the need to adjust to the unexpected behavior that is described below.
+While it is easier, it isn't a "more useful" behavior, though.
+A different Windows Wit in the next chapter will highlight how it rather is a suboptimal workaround.
+
+Please don't skip the next section -- it is useful to know how datasets behave on other systems.
+Just be mindful that you will not encounter the errors that the handbook displays next.
+And while this all sounds quite cryptic and vague, an upcoming Windows Wit will provide more information.

--- a/docs/basics/topic/adjustedmode-unlockedfiles2.rst
+++ b/docs/basics/topic/adjustedmode-unlockedfiles2.rst
@@ -1,0 +1,3 @@
+Nothing. All of the files in your dataset are always unlocked, and actually *can not* be locked at all.
+Consequently, there will be nothing to show for ``datalad status`` afterwards (as shown a few paragraphs below).
+This is due to a file system limitation, and will be explained in more detail in chapter :ref:`chapter_gitannex`.

--- a/docs/basics/topic/credential-nodisplay.rst
+++ b/docs/basics/topic/credential-nodisplay.rst
@@ -1,0 +1,2 @@
+Don't be confused if you are prompted for your GitHub credentials, but can't seem to type -- the terminal protects your private information by not displaying what you type.
+Simply type in what is requested, and press enter.

--- a/docs/basics/topic/curl-instead-wget.rst
+++ b/docs/basics/topic/curl-instead-wget.rst
@@ -1,0 +1,11 @@
+Many versions of Windows do not ship with the tool ``wget``.
+You can install it, but it may be easier to use the pre-installed ``curl`` command:
+
+.. code-block:: bash
+
+  $ cd books
+  $ curl -L https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download \
+    -o TLCL.pdf
+  $ curl -L https://github.com/swaroopch/byte-of-python/releases/download/vadb91fc6fce27c58e3f931f5861806d3ccd1054c/byte-of-python.pdf \
+    -o byte-of-python.pdf
+  $ cd ../

--- a/docs/basics/topic/globscript1-windows.rst
+++ b/docs/basics/topic/globscript1-windows.rst
@@ -1,0 +1,17 @@
+Please use an editor of your choice to create a file ``list_titles.sh`` inside of the ``code`` directory.
+These should be the contents:
+
+.. code-block:: bash
+
+   for i in recordings/longnow/Long_Now__Seminars*/*.mp3; do
+      # get the filename
+      base=$(basename "$i");
+      # strip the extension
+      base=${base%.mp3};
+      # date as yyyy-mm-dd
+      printf "${base%%__*}\t" | tr '_' '-';
+      # name and title without underscores
+      printf "${base#*__}\n" | tr '_' ' ';
+   done
+
+Note that this is not identical to the script in the text -- it lacks a few ``\`` characters, which is a meaningful difference.

--- a/docs/basics/topic/globscript2-windows.rst
+++ b/docs/basics/topic/globscript2-windows.rst
@@ -1,0 +1,14 @@
+Please use an editor of your choice to replace the contents of ``list_titles.sh`` inside of the ``code`` directory with the following:
+
+.. code-block:: bash
+
+   for i in recordings/longnow/Long_Now*/*.mp3; do
+      # get the filename
+      base=$(basename "$i");
+      # strip the extension
+      base=${base%.mp3};
+      # date as yyyy-mm-dd
+      printf "${base%%__*}\t" | tr '_' '-';
+      # name and title without underscores
+      printf "${base#*__}\n" | tr '_' ' ';
+   done

--- a/docs/basics/topic/heredoc-windows.rst
+++ b/docs/basics/topic/heredoc-windows.rst
@@ -1,0 +1,11 @@
+Heredocs rely on Unix-type redirection and multi-line commands -- which is not supported on most native Windows terminals or the Anaconda prompt on Windows.
+If you are using an Anaconda prompt or a Windows terminal other than Git Bash, instead of executing heredocs, please open up an editor and paste and save the text into it.
+
+The relevant text in the snippet below would be:
+
+.. code-block:: text
+
+  One can create a new dataset with 'datalad create [--description] PATH'.
+  The dataset is created empty
+
+If you are using Git Bash, however, here docs will work just fine.   

--- a/docs/basics/topic/hidden-extensions.rst
+++ b/docs/basics/topic/hidden-extensions.rst
@@ -1,0 +1,10 @@
+By default, Windows does not show common file extensions when you view directory contents with a file explorer.
+Instead, it only displays the base of the file name and indicates the file type with the display icon.
+You can see if this is the case for you, too, by opening the ``books\`` directory in a file explorer, and checking if the file extension (``.pdf``) is a part of the file name displayed underneath its PDF icon.
+
+Hidden file extensions can be a confusing source of errors, because some Windows editors (for example, Notepad) automatically add a ``.txt`` extension to your files -- when you save the script above under the name ``list_titles.sh``, your editor may add an extension (``list_titles.sh.txt``), and the file explorer displays your file as ``list_titles.sh`` (hiding the ``.txt`` extension).
+
+To prevent confusion, configure the file explorer to always show you the file extension.
+For this, open the Explorer, click on the "View" tab, and tick the box "File name extensions".
+
+Beyond this, double check the correct naming of your file, ideally in the terminal.

--- a/docs/basics/topic/installation-imagemagick.rst
+++ b/docs/basics/topic/installation-imagemagick.rst
@@ -1,0 +1,4 @@
+`ImageMagick <https://imagemagick.org/index.php>`_ is not installed on Windows systems by default.
+To use it, you need to install it, using the provided `Windows Binary Release on the Download page <https://imagemagick.org/script/download.php>`_.
+During installation, it is important to install the tool into a place where it is easily accessible to your terminal, for example the ``Program Files`` folder.
+Do also make sure to tick the box "install legacy commands" in the installation wizard.

--- a/docs/basics/topic/py-or-py3.rst
+++ b/docs/basics/topic/py-or-py3.rst
@@ -1,0 +1,10 @@
+If executing the code below returns an exit code of 9009, there may be no ``python3`` -- instead, it is called solely ``python``.
+Please run the following instead (adjusted for line breaks, you should be able to copy-paste this as a whole):
+
+.. code-block:: bash
+
+  datalad run -m "analyze iris data with classification analysis" ^
+   --input "input/iris.csv" ^
+   --output "pairwise_relationships.png" ^
+   --output "prediction_report.csv" ^
+   "python code/script.py {inputs} {outputs}"

--- a/docs/basics/topic/terminal-linecontinuation.rst
+++ b/docs/basics/topic/terminal-linecontinuation.rst
@@ -1,0 +1,10 @@
+In Unix shells, ``\`` can be used to split a command into several lines, for example to aid readability.
+Standard Windows terminals (including the Anaconda prompt) do not support this.
+They instead use the ``^`` character:
+
+.. code-block:: bash
+
+ $ wget -q https://sourceforge.net/projects/linuxcommand/files/TLCL/19.01/TLCL-19.01.pdf/download ^
+ -O TLCL.pdf
+
+If you are not using the Git Bash, you will either need to copy multi-line commands into a single line, or use ``^`` (make sure that there is **no space** afterwards) instead of ``\``.

--- a/docs/basics/topic/tree-symlinks.rst
+++ b/docs/basics/topic/tree-symlinks.rst
@@ -1,0 +1,4 @@
+First of all, the Windows ``tree`` command lists only directories by default, unless you parametrize it with ``/f``.
+And, secondly, even if you list the individual files, you would not see the :term:`symlink`\s shown below.
+Due to insufficient support of symlinks on Windows, git-annex does not use them.
+Please read on for a basic understanding of how git-annex usually works -- a Windows Wit at the end of this section will then highlight the difference in functionality on Windows.

--- a/docs/basics/topic/tree-windows.rst
+++ b/docs/basics/topic/tree-windows.rst
@@ -1,0 +1,1 @@
+The Windows version of tree requires different parametrization, so please run ``tree`` instead of ``tree -d``.

--- a/docs/basics/topic/wsl2-symlinkaccess.rst
+++ b/docs/basics/topic/wsl2-symlinkaccess.rst
@@ -1,0 +1,19 @@
+If you are using WSL2 you have access to a Linux kernel and POSIX file system, including symlink support.
+Your DataLad experience has therefore been exactly as it has been for macOS or Linux users.
+But one thing that bears the need for additional information is sharing files in dataset between your Linux and Windows system.
+
+It's fantastic that files created under Linux can be shared to Windows and used by Windows tools.
+Usually, you should be able to open an explorer and type ``\\wsl$\<distro>\<path>`` in the address bar to navigate to files under Linux, or type ``explorer.exe`` into the WSL2 terminal.
+Some core limitations of Windows can't be overcome, though: Windows usually isn't capable of handling symlinks.
+So while WSL2 can expose your dataset filled with symlinked files to Windows, your Windows tools can fail to open them.
+How can this be fixed?
+
+.. index::
+  pair: checkout; Git command
+  pair: check out particular version; with Git
+
+Whenever you need to work with files from your datasets under Windows, you should *unlock* with ``datalad unlock``.
+This operation copies the file from the annex back to its original location, and thus removes the symlink (and also returns write :term:`permissions` to the file).
+Alternatively, use `git-annex adjust --unlock <https://git-annex.branchable.com/git-annex-adjust>`_ to switch to a new dataset :term:`branch` in which all files are unlocked.
+The branch is called ``adjusted/<branchname>(unlocked)`` (e.g., if the original branch name was ``main``, the new, adjusted branch will be called ``adjusted/main(unlocked)``).
+You can switch back to your original branch using ``git checkout <branchname>``.


### PR DESCRIPTION
This is a minimal test change to see how it looks.

The main goal is to trim the diff to the print version again, where content was moved and taken out of containers. This makes merged conflict-ladden and painful. With this approach, any content change would happen in the dedicated file, which can be used for boxes and sections alike. Associated index items must stay outside, because they are declared on the container.