### PR TITLE
In Basics, remove 'below' when refering to things that can float away

### DIFF
--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -43,8 +43,7 @@ Note the command structure of :dlcmd:`create` (optional bits are enclosed in ``[
 
       datalad create --description "course on DataLad-101 on my private laptop" -c text2git DataLad-101
 
-   If you want, use the above command instead of the :dlcmd:`create` command below
-   to provide a description. Its use will not be immediately clear, the chapter
+   If you want, use the above command instead to provide a description. Its use will not be immediately clear, the chapter
    :ref:`chapter_collaboration` will show you where this description
    ends up and how it may be useful.
 

--- a/docs/basics/101-101-create.rst
+++ b/docs/basics/101-101-create.rst
@@ -43,8 +43,8 @@ Note the command structure of :dlcmd:`create` (optional bits are enclosed in ``[
 
       datalad create --description "course on DataLad-101 on my private laptop" -c text2git DataLad-101
 
-   If you want, use the above command instead to provide a description. Its use will not be immediately clear, the chapter
-   :ref:`chapter_collaboration` will show you where this description
+   If you want, use the above command instead to provide a description. Its use will not be immediately clear now, but the chapter
+   :ref:`chapter_collaboration` shows where this description
    ends up and how it may be useful.
 
 Let's start:

--- a/docs/basics/101-103-modify.rst
+++ b/docs/basics/101-103-modify.rst
@@ -18,7 +18,7 @@ Let's write a short summary of how to create a DataLad dataset from scratch:
 
 This is meant to be a note you would take in an educational course.
 You can take this note and write it to a file with an editor of your choice.
-The code below, however, contains this note within the start and end part of a
+The code snippet, however, contains this note within the start and end part of a
 `heredoc <https://en.wikipedia.org/wiki/Here_document>`_.
 You can also copy the full code snippet, starting
 from ``cat << EOT > notes.txt``, including the ``EOT`` in the last line, in your
@@ -27,7 +27,7 @@ terminal to write this note from the terminal (without any editor) into ``notes.
 .. index:: here-document, heredoc
 .. find-out-more:: How does a heredoc (here-document) work?
 
-   The code snippet below makes sure to write lines of text into a
+   The code snippet makes sure to write lines of text into a
    file (that so far does not exist) called ``notes.txt``.
 
    To do this, the content of the "document" is wrapped in between
@@ -55,7 +55,7 @@ terminal to write this note from the terminal (without any editor) into ``notes.
    you create and modify a ``.txt`` file over the course of the Basics part of this
    handbook.
 
-Running the command below will create ``notes.txt`` in the
+Running this command will create ``notes.txt`` in the
 root of your ``DataLad-101`` dataset:
 
 .. index:: heredoc
@@ -108,7 +108,7 @@ But now, let's see how *changing* tracked content works.
 Modify this file by adding another note. After all, you already know how to use
 :dlcmd:`save`, so write a short summary on that as well.
 
-Again, the example below uses Unix commands (``cat`` and redirection, this time however
+Again, the example uses Unix commands (``cat`` and redirection, this time however
 with ``>>`` to *append* new content to the existing file)
 to accomplish this, but you can take any editor of your choice.
 

--- a/docs/basics/101-105-install.rst
+++ b/docs/basics/101-105-install.rst
@@ -75,7 +75,7 @@ the podcasts as a *subdataset* of ``DataLad-101``. Because we are in the root
 of the ``DataLad-101`` dataset, the pointer to the dataset is a ``.`` (which is Unix'
 way of saying "current directory").
 
-As before with long commands, we line break the code below with a ``\``. You can
+As before with long commands, we line break the code with a ``\``. You can
 copy it as it is presented here into your terminal, but in your own work you
 can write commands like this into a single line.
 

--- a/docs/basics/101-106-nesting.rst
+++ b/docs/basics/101-106-nesting.rst
@@ -117,7 +117,7 @@ we can set subdatasets to previous states, or *update* them.
 In the upcoming sections, we'll experience the perks of dataset nesting
 frequently, and everything that might seem vague at this point will become
 clearer. To conclude this demonstration,
-figure :numref:`fignesting` illustrates the current state of our dataset, ``DataLad-101``, with its nested subdataset.
+:numref:`fignesting` illustrates the current state of our dataset, ``DataLad-101``, with its nested subdataset.
 
 .. _fignesting:
 .. figure:: ../artwork/src/virtual_dstree_dl101.svg

--- a/docs/basics/101-106-nesting.rst
+++ b/docs/basics/101-106-nesting.rst
@@ -117,8 +117,9 @@ we can set subdatasets to previous states, or *update* them.
 In the upcoming sections, we'll experience the perks of dataset nesting
 frequently, and everything that might seem vague at this point will become
 clearer. To conclude this demonstration,
-the figure below illustrates the current state of our dataset, ``DataLad-101``, with its nested subdataset.
+figure :numref:`fignesting` illustrates the current state of our dataset, ``DataLad-101``, with its nested subdataset.
 
+.. _fignesting:
 .. figure:: ../artwork/src/virtual_dstree_dl101.svg
    :width: 70%
 

--- a/docs/basics/101-108-run.rst
+++ b/docs/basics/101-108-run.rst
@@ -68,8 +68,7 @@ Inside of ``DataLad-101/code``, create a simple shell script ``list_titles.sh``.
 This script will carry out a simple task:
 It will loop through the file names of the ``.mp3`` files and
 write out speaker names and talk titles in a very basic fashion.
-The content of this script is written below -- the ``cat`` command
-will write it into the script.
+The ``cat`` command will write the script content into ``code/list_titles.sh``.
 
 .. windows-wit:: Here's a script for Windows users
 

--- a/docs/basics/101-115-symlinks.rst
+++ b/docs/basics/101-115-symlinks.rst
@@ -294,7 +294,7 @@ Cross-OS filesharing with symlinks (WSL2 only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Are you using DataLad on the Windows Subsystem for Linux?
-If so, please take a look into the Windows Wit below.
+If so, please take a look into the Windows Wit.
 
 .. index::
    pair: access WSL2 symlinked files; on Windows

--- a/docs/basics/101-116-sharelocal.rst
+++ b/docs/basics/101-116-sharelocal.rst
@@ -289,8 +289,8 @@ you have to run a somewhat unexpected command:
 
    $ datalad get -n recordings/longnow
 
-The section below will elaborate on :dlcmd:`get` and the
-``-n/--no-data`` option, but for now, let's first see what has changed after
+Before we look further into :dlcmd:`get` and the
+``-n/--no-data`` option, let's first see what has changed after
 running the above command (excerpt):
 
 .. runrecord:: _examples/DL-101-116-108

--- a/docs/basics/101-119-sharelocal4.rst
+++ b/docs/basics/101-119-sharelocal4.rst
@@ -125,7 +125,7 @@ dataset to your own ``DataLad-101`` dataset:
 
 PS: You might wonder what a plain :dlcmd:`update` command with no option does.
 If you are a Git-user and know about branches and merging you can read the
-``Note for Git-users`` below. However, a thorough explanation
+``Note for Git-users``. However, a thorough explanation
 and demonstration will be in the next section.
 
 .. index::

--- a/docs/basics/101-124-procedures.rst
+++ b/docs/basics/101-124-procedures.rst
@@ -208,8 +208,7 @@ was applied.
    write their own ones in addition, and deploy them on individual machines,
    or ship them within DataLad datasets. This allows to
    automate routine configurations or tasks in a dataset, or share configurations that would otherwise not "stick" to the dataset.
-   Some general rules for creating a custom procedure are outlined
-   below:
+   Here are some general rules for creating a custom procedure:
 
    - A procedure can be any executable. Executables must have the
      appropriate permissions and, in the case of a script,

--- a/docs/basics/101-130-yodaproject.rst
+++ b/docs/basics/101-130-yodaproject.rst
@@ -767,7 +767,7 @@ command.
     proportion of the previous handbook content as a prerequisite. In order to be
     not too overwhelmingly detailed, the upcoming sections will approach
     :dlcmd:`push` from a "learning-by-doing" perspective:
-    You will see a first :dlcmd:`push` to GitHub below, and the :ref:`Findoutmore on the published dataset <fom-midtermclone>`
+    First, you will see a :dlcmd:`push` to GitHub, and the :ref:`Findoutmore on the published dataset <fom-midtermclone>`
     at the end of this section will already give a practical glimpse into the
     difference between annexed contents and contents stored in Git when pushed
     to GitHub. The chapter :ref:`chapter_thirdparty` will extend on this,
@@ -791,7 +791,7 @@ command.
    $ datalad push --to github
 
 Thus, you have now published your dataset's history to a public place for others
-to see and clone. Below we will explore how this may look and feel for others.
+to see and clone. Now we will explore how this may look and feel for others.
 
 There is one important detail first, though: By default, your tags will not be published.
 Thus, the tag ``ready4analysis`` is not pushed to GitHub, and currently this
@@ -849,7 +849,7 @@ reproduce your data science project easily from scratch (take a look into the :r
    Therefore, you decide to install this dataset into a new location on your
    computer, just to get a feel for it.
 
-   Replace the ``url`` in the :dlcmd:`clone` command below with the path
+   Replace the ``url`` in the :dlcmd:`clone` command with the path
    to your own ``midtermproject`` GitHub repository, or clone the "public"
    ``midterm_project`` repository that is available via the Handbook's GitHub
    organization at `github.com/datalad-handbook/midterm_project <https://github.com/datalad-handbook/midterm_project>`_:

--- a/docs/basics/101-135-help.rst
+++ b/docs/basics/101-135-help.rst
@@ -137,7 +137,7 @@ This allows you to gain more insights into the actions DataLad and its underlyin
 
 :term:`Debugging` and :term:`logging` are not as complex as these terms may sound if you have never consciously debugged.
 Procedurally, it can be as easy as adding an additional flag to a command call, and cognitively, it can be as easy as engaging your visual system in a visual search task for the color red or the word "error", or reading more DataLad output than you're used to.
-The paragraphs below start with the general concepts, and collect concrete debugging strategies for different problems.
+We will start with the general concepts, and then collect concrete debugging strategies for different problems.
 
 .. _logging:
 

--- a/docs/basics/101-136-cheatsheet.rst
+++ b/docs/basics/101-136-cheatsheet.rst
@@ -7,7 +7,7 @@ DataLad cheat sheet
 
 .. only:: html
 
-   Click on the image below to obtain a PDF version of the cheat sheet. Individual
+   Click on the image to obtain a PDF version of the cheat sheet. Individual
    sections are linked to chapters or technical docs.
 
    .. figure:: ../artwork/src/datalad-cheatsheet_p1.png

--- a/docs/basics/101-139-figshare.rst
+++ b/docs/basics/101-139-figshare.rst
@@ -45,10 +45,13 @@ An interactive prompt will ask you to supply authentication credentials, and gui
 
 
 
-The screenshot below shows how the ``DataLad-101`` dataset looks like in exported form:
+The screenshot in :numref:`figfigshare` shows how the ``DataLad-101`` dataset looks like in exported form:
 
+.. _figfigshare:
 .. figure:: ../artwork/src/figshare_screenshot.png
    :width: 50%
+
+   The dataset export on Figshare
 
 You could then extend the dataset with metadata, obtain a `DOI <https://www.doi.org/driven_by_DOI.html>`_ for it and make it citable, and point others to it in order to download it as an archive of files.
 

--- a/docs/basics/101-139-hostingservices.rst
+++ b/docs/basics/101-139-hostingservices.rst
@@ -218,14 +218,16 @@ GitLab's organization consists of *projects* and *groups*.
 Projects are single repositories, and groups can be used to manage one or more projects at the same time.
 In order to use ``create-sibling-gitlab``, a user **must** `create a group <https://docs.gitlab.com/ee/user/group/#create-a-group>`_ via the web interface, or specify a pre-existing group, because `GitLab does not allow root-level groups to be created via their API <https://docs.gitlab.com/ee/api/groups.html#new-group>`_.
 Only when there already is a "parent" group DataLad and other tools can create sub-groups and projects automatically.
-In the screenshots below, a new group ``my-datalad-root-level-group`` is created right underneath the user account.
+In the screenshots :numref:`fig-rootgroup-gitlab1` and :numref:`fig-rootgroup-gitlab2`, a new group ``my-datalad-root-level-group`` is created right underneath the user account.
 The group name as shown in the URL bar is what DataLad needs in order to create sibling datasets.
 
+.. _fig-rootgroup-gitlab1:
 .. figure:: ../artwork/src/gitlab-rootgroup.png
    :width: 80%
 
    Webinterface to create a root-level group on GitLab.
 
+.. _fig-rootgroup-gitlab2:
 .. figure:: ../artwork/src/gitlab-rootgroup2.png
    :width: 80%
 

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -211,7 +211,7 @@ to "Buckets" to see your newly created bucket. It should only have a single
 
 Lastly, for git-annex to be able to download files from the bucket without requiring your
 AWS credentials, it needs to know where to find the bucket. We do this by setting the bucket
-URL, which takes a standard format incorporating the bucket name and location (see the code blocl below).
+URL, which takes a standard format incorporating the bucket name and location (see the code block below).
 Alternatively, this URL can also be copied from your AWS console.
 
 .. code-block:: bash


### PR DESCRIPTION
just a drop in the ocean