### PR TITLE
Avoid declaring an `output/` directory as mandatory

### DIFF
--- a/docs/basics/101-127-yoda.rst
+++ b/docs/basics/101-127-yoda.rst
@@ -47,10 +47,10 @@ common shape a data science project may take after a while:
     │   └── main_script_DONTUSE.py
     ├── data/
     │   ├── data_updated/
-    │   │    └── dataset1/
-    │   │        ├── datafile_a
+    │   │   └── dataset1/
+    │   │       └── datafile_a
     │   ├── dataset1/
-    │   │   ├── datafile_a
+    │   │    └── datafile_a
     │   ├── outputs/
     │   │   ├── figures/
     │   │   │   ├── figures_new.py
@@ -128,7 +128,7 @@ computational environments, results, ...) in dedicated directories. For example:
 - Store scripts or **code** used for the analysis of data in a dedicated ``code/``
   directory, outside of the data component of the dataset.
 
-- Collect **results** of an analysis in a dedicated ``outputs/`` directory, and
+- Collect **results** of an analysis in a dedicated place, outside of the ``inputs/`` directory, and
   leave the input data of an analysis untouched by your computations.
 
 - Include a place for complete **execution environments**, such as
@@ -161,9 +161,8 @@ superdataset of a very comprehensive data analysis project complying to the YODA
     │       │   └── datafile_a
     │       └── dataset2/
     │           └── datafile_a
-    ├── outputs/                    # outputs away from the input data
-    │   └── important_results/
-    │       └── figures/
+    ├── important_results/          # outputs away from the input data
+    │   └── figures/
     ├── CHANGELOG.md                # notes for fellow humans about your project
     ├── HOWTO.md
     └── README.md


### PR DESCRIPTION
It is only important that outputs are not placed into the `inputs/` directory.

Using an `output/` directory is OK, though. However, it can become awkward, if such a data module is used as input to another. File paths, seen from the YODA root would then be: `inputs/outputs/something.dat`

This is a non-invasive change that accounts enough for this aspect, IMHO.