### PR TITLE
add short sentence on datalad via easybuild

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -240,6 +240,11 @@
       "orcid": "0000-0002-4579-003X"
     },
     {
+      "name": "Kuhlmann, Justus Theodor",
+      "affiliation": "Universität Münster",
+      "orcid": "0000-0001-5291-1939"
+    },
+    {
       "name": "Hanke, Michael",
       "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
       "orcid": "0000-0001-6398-6370"

--- a/docs/beyond_basics/101-169-cluster.rst
+++ b/docs/beyond_basics/101-169-cluster.rst
@@ -18,6 +18,8 @@ DataLad installation on a cluster
 
 Users of a compute cluster generally do not have administrative privileges (sudo rights) and thus cannot install software as easily as on their own, private machine.
 In order to get DataLad and its underlying tools installed, you can either `bribe (kindly ask) your system administrator <https://hsto.org/getpro/habr/post_images/02e/e3b/369/02ee3b369a0326760a160004aca631dc.jpg>`_ [#f1]_ or install everything for your own user only following the instructions in the paragraph :ref:`norootinstall` of the :ref:`installation page <install>`.
+If you opt for the first, your administrator can install Datalad version 0.18.4 via `EasyBuild <https://github.com/easybuilders>`, which is a tool for building software reprobucibly and is common on clusters that use a module system.
+The caveat this introduces, of course, is that you will need to load the module everytime you want to use datalad on your cluster.
 
 
 .. rubric:: Footnotes

--- a/docs/beyond_basics/101-169-cluster.rst
+++ b/docs/beyond_basics/101-169-cluster.rst
@@ -19,7 +19,7 @@ DataLad installation on a cluster
 Users of a compute cluster generally do not have administrative privileges (sudo rights) and thus cannot install software as easily as on their own, private machine.
 In order to get DataLad and its underlying tools installed, you can either `bribe (kindly ask) your system administrator <https://hsto.org/getpro/habr/post_images/02e/e3b/369/02ee3b369a0326760a160004aca631dc.jpg>`_ [#f1]_ or install everything for your own user only following the instructions in the paragraph :ref:`norootinstall` of the :ref:`installation page <install>`.
 If you opt for the first, your administrator can install Datalad version 0.18.4 via `EasyBuild <https://github.com/easybuilders>`, which is a tool for building software reprobucibly and is common on clusters that use a module system.
-The caveat this introduces, of course, is that you will need to load the module everytime you want to use datalad on your cluster.
+The caveat this introduces, of course, is that you will need to load the module every time you want to use DataLad on your cluster.
 
 
 .. rubric:: Footnotes


### PR DESCRIPTION
Hey,

as mentioned in #1117, I added a small note in the cluster section of the handbook, that datalad may be installed per Easybuild.
