### PR TITLE
Fix current linkcheck failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,6 +180,10 @@ linkcheck_ignore = [
     'https://twitter.com/datalad',
     # maybe a user-agent issue? github.com/sphinx-doc/sphinx//issues/10343
     'https://github.com/datalad/datalad-extension-template/generate',
+    # (temporary?) SSL certificate error
+    'https://fcon_1000.projects.nitrc.org/*',
+    # local link fails to resolve, maybe because its a build artifact?
+    '../_images/intro-v1-cover.jpg',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ chardet
 docutils
 idna
 imagesize
-Jinja2 < 3.1
+Jinja2
 MarkupSafe
 packaging
 Pygments


### PR DESCRIPTION
Both work in principle, but the link checker runs into an SSL error for the first, and fails to resolve the second link pointing to an eventual build artifact. This change ignores both types of URLs. SSL error should be retried after a bit of time.

This PR also resolves a vulnerability.