### PR TITLE
Update datalad-catalog demo site URL

### DIFF
--- a/docs/beyond_basics/101-182-catalog.rst
+++ b/docs/beyond_basics/101-182-catalog.rst
@@ -14,7 +14,7 @@ This extension takes your favorite datasets and metadata, and generates a static
 
 For quick access to more resources, have a look at:
 
-- The `live demo catalog <https://datalad.github.io/datalad-catalog>`_
+- The `live demo catalog <https://datalad-catalog.netlify.app/>`_
 - A 3-minute `explainer video <https://youtu.be/4GERwj49KFc>`_
 - The `datalad-catalog documentation <https://docs.datalad.org/projects/catalog>`_
 - The `source repository <https://github.com/datalad/datalad-catalog>`_ for an up-to-date overview of functionality


### PR DESCRIPTION
The demo site was moved from github pages to netlify

Note, close https://github.com/datalad/datalad-catalog/issues/422 when this is merged.