### PR TITLE
Fix wrong branch name in link to cheatsheet

### DIFF
--- a/docs/basics/101-136-cheatsheet.rst
+++ b/docs/basics/101-136-cheatsheet.rst
@@ -11,7 +11,7 @@ DataLad cheat sheet
    sections are linked to chapters or technical docs.
 
    .. figure:: ../artwork/src/datalad-cheatsheet_p1.png
-      :target: https://github.com/datalad-handbook/artwork/raw/main/src/datalad-cheatsheet.pdf
+      :target: https://github.com/datalad-handbook/artwork/raw/master/src/datalad-cheatsheet.pdf
 
 .. only:: latex
 
@@ -19,4 +19,4 @@ DataLad cheat sheet
       :width: 80%
 
       A high-resolution version of this cheatsheet is available for download
-      at https://github.com/datalad-handbook/artwork/raw/main/src/datalad-cheatsheet.pdf
+      at https://github.com/datalad-handbook/artwork/raw/master/src/datalad-cheatsheet.pdf


### PR DESCRIPTION
Clicking on the image in the handbook leads to a 404. This PR fixes the link.