### PR TITLE
Update S3 example URLs to new formats

### DIFF
--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -261,7 +261,7 @@ Alternatively, this URL can also be copied from your AWS console.
 .. code-block:: console
 
    $ git annex enableremote public-s3 \
-   publicurl="https://$BUCKET.s3-eu-west-1.amazonaws.com"
+   publicurl="https://$BUCKET.s3.eu-west-1.amazonaws.com"
    enableremote public-s3 ok
    (recording state in git...)
 

--- a/docs/basics/101-139-s3.rst
+++ b/docs/basics/101-139-s3.rst
@@ -261,7 +261,7 @@ Alternatively, this URL can also be copied from your AWS console.
 .. code-block:: console
 
    $ git annex enableremote public-s3 \
-   publicurl="https://$BUCKET.s3.eu-west-1.amazonaws.com"
+   publicurl="https://$BUCKET.s3.dualstack.eu-west-1.amazonaws.com"
    enableremote public-s3 ok
    (recording state in git...)
 


### PR DESCRIPTION
Amazon has streamlined their s3 endpoint naming:
* it is not `s3-region` in some regions and `s3.region` in others anymore, it is `s3.region` everywhere
* if you want IPv6 support (it's about time), you need to use `s3.dualstack.region` instead.

Updating the example in the chapter on using S3, hopefully most people setting this up will not need to look this info up anymore.