### PR TITLE
replace word 'crop' with 'resize'

### DIFF
--- a/docs/basics/101-110-run2.rst
+++ b/docs/basics/101-110-run2.rst
@@ -324,7 +324,7 @@ the ``-o``/``--output`` option.
    pair: declare command output; with DataLad run
 
 In order to execute :dlcmd:`run` with both the ``-i``/``--input`` and ``-o``/``--output``
-flag and see their magic, let's crop the second logo, ``logo_interval.jpg``:
+flag and see their magic, let's resize the second logo, ``logo_interval.jpg``:
 
 .. index::
    pair: files are unlocked by default; on Windows


### PR DESCRIPTION
Hi, I think the word "crop" in this sentence may be slightly misleading and should be replaced with "resize".
To me the image operations of cropping and resizing are very different.
Since the text and examples beyond that sentence all talk about resizing, it should also be called resizing here as well.  